### PR TITLE
Using uninitialized file stream fix

### DIFF
--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -878,12 +878,10 @@ void Mesh::OutputMeshStructure(int ndim) {
   FILE *fp = nullptr;
 
   // open 'mesh_structure.dat' file
-  if (f2) {
-    if ((fp = std::fopen("mesh_structure.dat","wb")) == nullptr) {
-      std::cout << "### ERROR in function Mesh::OutputMeshStructure" << std::endl
-                << "Cannot open mesh_structure.dat" << std::endl;
-      return;
-    }
+  if ((fp = std::fopen("mesh_structure.dat","wb")) == nullptr) {
+    std::cout << "### ERROR in function Mesh::OutputMeshStructure" << std::endl
+      << "Cannot open mesh_structure.dat" << std::endl;
+    return;
   }
 
   // Write overall Mesh structure to stdout and file
@@ -1000,7 +998,7 @@ void Mesh::OutputMeshStructure(int ndim) {
   }
 
   // close file, final outputs
-  if (f2) std::fclose(fp);
+  std::fclose(fp);
   std::cout << "Load Balancing:" << std::endl;
   std::cout << "  Minimum cost = " << mincost << ", Maximum cost = " << maxcost
             << ", Average cost = " << totalcost/nbtotal << std::endl << std::endl;


### PR DESCRIPTION
For some reason when using the mesh test flag the file stream was only being opened if the f2 flag was specified, but there was nothing preventing the file stream from being used. This means in cases where f2 was not true it was trying to use a null file stream causing seg fault. 