### PR TITLE
Add ability to find ParseAndAddCatchTests if using submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,11 +67,10 @@ if (${ENABLE_UNIT_TESTS} OR ${ENABLE_INTEGRATION_TESTS} OR ${ENABLE_REGRESSION_T
     endif()
 
     add_subdirectory(external/Catch2)
-    include(external/Catch2/contrib/ParseAndAddCatchTests.cmake)
-  else()
-    include(ParseAndAddCatchTests)
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2/contrib")
   endif()
 
+  include(ParseAndAddCatchTests)
   add_subdirectory(tst)
 endif()
 


### PR DESCRIPTION
Hope fully this fixes the issue in the correct way, if before I was getting the error:

8:43 AM

CMake Warning at CMakeLists.txt:57 (find_package):
  By not providing "FindCatch2.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Catch2", but
  CMake did not find one.

  Could not find a package configuration file provided by "Catch2" (requested
  version 2.11.1) with any of the following names:
Catch2Config.cmake
catch2-config.cmake

  Add the installation prefix of "Catch2" to CMAKE_PREFIX_PATH or set
  "Catch2_DIR" to a directory containing one of the above files.  If "Catch2"
  provides a separate development package or SDK, be sure it has been
  installed.

CMake Error at CMakeLists.txt:72 (include):
  include could not find load file:
ParseAndAddCatchTests

-- Building unit tests.
CMake Error at tst/unit/CMakeLists.txt:4 (ParseAndAddCatchTests):
  Unknown CMake command "ParseAndAddCatchTests".

This fixes the problem by including the ParseAndAddCatchTests module explicitly. 