### PR TITLE
Remove BoundaryValues as friend from MeshBlock

### DIFF
--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -76,7 +76,6 @@ inline MeshBlockApplicationData::~MeshBlockApplicationData() {}
 //  \brief data/functions associated with a single block
 class MeshBlock {
   friend class RestartOutput;
-  friend class BoundaryValues;
   friend class Mesh;
   friend class TaskList;
 #ifdef HDF5OUTPUT


### PR DESCRIPTION
I don't know why this was made a friend in the first place, BoundaryValues never calls on any of the mesh block private attributes. 