### PR TITLE
add support for a visit database file

### DIFF
--- a/src/outputs/athena_hdf5_C.cpp
+++ b/src/outputs/athena_hdf5_C.cpp
@@ -143,7 +143,7 @@ static herr_t writeH5AF64(const char *name, const Real* pData,
   return status;
 }
 
-void ATHDF5Output::genXDMF(std::string hdfFile, Mesh *pm) {
+void ATHDF5Output::genXDMF(std::string hdfFile, std::string dbfile, Mesh *pm) {
   // using round robin generation.
   // must switch to MPIIO at some point
 
@@ -243,6 +243,13 @@ void ATHDF5Output::genXDMF(std::string hdfFile, Mesh *pm) {
   xdmf << "</Xdmf>" << std::endl;
   xdmf.close();
 
+  // little bit of a hack since we open the file and close it
+  // appends to the visit database file
+  auto visitdb = std::ofstream(dbfile.c_str(),
+			       std::ofstream::out | std::ofstream::app);
+  visitdb << filename_aux << std::endl;
+  visitdb.close();
+
   return;
 }
 
@@ -330,6 +337,7 @@ void ATHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   filename = std::string(output_params.file_basename);
   filename.append(".");
   filename.append(output_params.file_id);
+  std::string visit_db_filename = filename + ".visit";
   filename.append(".");
   std::stringstream file_number;
   file_number << std::setw(5) << std::setfill('0') << output_params.file_number;
@@ -580,7 +588,7 @@ void ATHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
   H5Fclose(file);
 
   // generate XDMF companion file
-  (void) genXDMF(filename, pm);
+  (void) genXDMF(filename, visit_db_filename, pm);
 
   // advance output parameters
   output_params.file_number++;
@@ -591,17 +599,3 @@ void ATHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) {
 }
 }
 #endif  // HDF5OUTPUT
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -173,7 +173,7 @@ class ATHDF5Output : public OutputType {
   // Function declarations
   explicit ATHDF5Output(OutputParameters oparams) : OutputType(oparams) {}
   void WriteOutputFile(Mesh *pm, ParameterInput *pin, bool flag) override;
-  void genXDMF(std::string hdfFile, Mesh *pm);
+  void genXDMF(std::string hdfFile, std::string dbfile, Mesh *pm);
 
  private:
   // Parameters


### PR DESCRIPTION
This merge request resolves issue #28 and automatically generates a `.visit` file which can be used to load in a time series into `visit`. The advantage of this is that visit can now automatically walk through your simulation as a time series.
