### PR TITLE
Moved forward declaration of Integrator struct

### DIFF
--- a/src/task_list/tasks.hpp
+++ b/src/task_list/tasks.hpp
@@ -23,11 +23,12 @@
 #include "mesh/mesh.hpp"
 //#include "driver/multistage.hpp"
 
-class Integrator;
 
 #define MAX_TASKS 64
 
 namespace parthenon {
+
+class Integrator;
 
 enum class TaskStatus {fail, success, next};
 enum class TaskListStatus {running, stuck, complete, nothing_to_do};


### PR DESCRIPTION
Having this forward declaration in `tasks.hpp` was causing a name collision downstream when I tried to pull `parthenon::Integrator` out of the namespace with a `using` statement.