### PR TITLE
Allow fewer mesh blocks on a rank than there are OpenMP threads

### DIFF
--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -134,10 +134,21 @@ void Mesh::CalculateLoadBalance(double *clist, int *rlist, int *slist, int *nlis
               << "This will result in poor load balancing." << std::endl;
   }
 #endif
-  if ((Globals::nranks * num_mesh_threads_ > nb) && (Globals::my_rank == 0)) {
-    std::cout << "### WARNING in CalculateLoadBalance" << std::endl
+  if (Globals::nranks * num_mesh_threads_ > nb) {
+    if (!adaptive) {
+      // mesh is refined statically, treat this an as error (all ranks need to participate)
+      msg << "### FATAL ERROR in CalculateLoadBalance" << std::endl
         << "There are fewer MeshBlocks than OpenMP threads on each MPI rank" << std::endl
         << "Decrease the number of threads or use more MeshBlocks." << std::endl;
+      ATHENA_ERROR(msg);
+    } else if (Globals::my_rank == 0) {
+      // we have AMR, print warning only on Rank 0
+      std::cout << "### WARNING in CalculateLoadBalance" << std::endl
+        << "There are fewer MeshBlocks than OpenMP threads on each MPI rank" << std::endl
+        << "This is likely fine if the number of meshblocks is expected to grow during the "
+        "simulations. Otherwise, it might be worthwhile to decrease the number of threads or "
+        "use more meshblocks." << std::endl;
+    }
   }
 }
 


### PR DESCRIPTION
Several times, I have faced the situation where I wanted to run a simulation with a larger number of MPI ranks times OpenMP threads per rank than there are mesh blocks -- at least initially. These are usually cases where refinement will drastically increase the number of blocks later on, thus justifying the number of threads.

Unfortunately, Parthenon wouldn't launch if there were fewer blocks than the total number of threads across all ranks. I think that this requirement is too stringent, and all we really want is at least one block per MPI rank, but it's ok if there are fewer blocks on a rank than there are threads. So I'm making this check a warning instead (if the user didn't intend it, it could have negative performance implications).

@pgrete @forrestglines Do you think this could have negative consequences that I didn't consider?