### PR TITLE
Introduce explicit type for metadata flags in ContainerIterator ctor

### DIFF
--- a/src/better_boundaries/boundary_conditions.cpp
+++ b/src/better_boundaries/boundary_conditions.cpp
@@ -26,7 +26,7 @@ void ApplyBoundaryConditions(Container<Real>& rc) {
     const int imax = pmb->ncells1; const int jmax = pmb->ncells2; const int kmax = pmb->ncells3;
 
     Metadata m;
-    ContainerIterator<Real> citer(rc, {m.independent});
+    ContainerIterator<Real> citer(rc, std::vector<parthenon::Metadata::flags> {m.independent});
     const int nvars = citer.vars.size();
 
     switch (pmb->boundary_flag[BoundaryFace::inner_x1]) {

--- a/src/interface/Update.cpp
+++ b/src/interface/Update.cpp
@@ -29,8 +29,8 @@ void FluxDivergence(Container<Real> &in, Container<Real> &dudt_cont) {
   int ke = pmb->ke;
 
   Metadata m;
-  ContainerIterator<Real> cin_iter(in, {m.independent});
-  ContainerIterator<Real> cout_iter(dudt_cont, {m.independent});
+  ContainerIterator<Real> cin_iter(in, std::vector<parthenon::Metadata::flags> {m.independent});
+  ContainerIterator<Real> cout_iter(dudt_cont, std::vector<parthenon::Metadata::flags> {m.independent});
   int nvars = cout_iter.vars.size();
 
   AthenaArray<Real> x1area(pmb->ncells1);
@@ -107,9 +107,9 @@ void UpdateContainer(Container<Real> &in, Container<Real> &dudt_cont,
   int ke = pmb->ke;
 
   Metadata m;
-  ContainerIterator<Real> cin_iter(in, {m.independent});
-  ContainerIterator<Real> cout_iter(out, {m.independent});
-  ContainerIterator<Real> du_iter(dudt_cont, {m.independent});
+  ContainerIterator<Real> cin_iter(in, std::vector<parthenon::Metadata::flags> {m.independent});
+  ContainerIterator<Real> cout_iter(out, std::vector<parthenon::Metadata::flags> {m.independent});
+  ContainerIterator<Real> du_iter(dudt_cont, std::vector<parthenon::Metadata::flags> {m.independent});
   int nvars = cout_iter.vars.size();
 
   for (int n = 0; n < nvars; n++) {
@@ -140,8 +140,8 @@ void AverageContainers(Container<Real> &c1, Container<Real> &c2,
   int ke = pmb->ke;
 
   Metadata m;
-  ContainerIterator<Real> c1_iter(c1, {m.independent});
-  ContainerIterator<Real> c2_iter(c2, {m.independent});
+  ContainerIterator<Real> c1_iter(c1, std::vector<parthenon::Metadata::flags> {m.independent});
+  ContainerIterator<Real> c2_iter(c2, std::vector<parthenon::Metadata::flags> {m.independent});
   int nvars = c2_iter.vars.size();
 
   for (int n = 0; n < nvars; n++) {


### PR DESCRIPTION
Fixes #46 

The implicit type conversion failed with nvcc (that's why the Kokkos integration test failed.
```
 32%] Building CXX object src/CMakeFiles/parthenon.dir/better_boundaries/boundary_conditions.cpp.o
/home/pgrete/src/parthenon/src/better_boundaries/boundary_conditions.cpp: In function ‘void parthenon::ApplyBoundaryConditions(parthenon::Container<double>&)’:
/home/pgrete/src/parthenon/src/better_boundaries/boundary_conditions.cpp:29:60: error: expected ‘;’ before ‘}’ token
     ContainerIterator<Real> citer(rc, {m.independent});
                                                            ^
                                                            ;
/home/pgrete/src/parthenon/src/better_boundaries/boundary_conditions.cpp:29:62: error: no matching function for call to ‘parthenon::ContainerIterator<double>::ContainerIterator(parthenon::Container<double>&, parthenon::Metadata::flags)’
     ContainerIterator<Real> citer(rc, {m.independent});
                                                              ^
/home/pgrete/src/parthenon/src/interface/ContainerIterator.hpp:41:1: note: candidate: ‘parthenon::ContainerIterator<T>::ContainerIterator(parthenon::Container<T>&, const std::vector<parthenon::Metadata::flags>&) [with T = double]’
   ContainerIterator<T>(Container<T>& c, const std::vector<Metadata::flags> &flagVector) {
 ^ ~~~~~~~~~~~~~~~
/home/pgrete/src/parthenon/src/interface/ContainerIterator.hpp:41:1: note:   no known conversion for argument 2 from ‘parthenon::Metadata::flags’ to ‘const std::vector<parthenon::Metadata::flags>&’
/home/pgrete/src/parthenon/src/interface/ContainerIterator.hpp:31:7: note: candidate: ‘parthenon::ContainerIterator<double>::ContainerIterator(const parthenon::ContainerIterator<double>&)’
 class ContainerIterator {
       ^~~~~~~~~~~~~~~~~
/home/pgrete/src/parthenon/src/interface/ContainerIterator.hpp:31:7: note:   candidate expects 1 argument, 2 provided
/home/pgrete/src/parthenon/src/interface/ContainerIterator.hpp:31:7: note: candidate: ‘parthenon::ContainerIterator<double>::ContainerIterator(parthenon::ContainerIterator<double>&&)’
/home/pgrete/src/parthenon/src/interface/ContainerIterator.hpp:31:7: note:   candidate expects 1 argument, 2 provided
make[2]: *** [src/CMakeFiles/parthenon.dir/build.make:63: src/CMakeFiles/parthenon.dir/better_boundaries/boundary_conditions.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1419: src/CMakeFiles/parthenon.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

The change adds the explicit type and results in a successful compilation.