### PR TITLE
Fix casing in "CATCH2_FOUND" to "Catch2_FOUND"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,7 +93,7 @@ if (${ENABLE_UNIT_TESTS} OR ${ENABLE_INTEGRATION_TESTS} OR ${ENABLE_REGRESSION_T
   # Try finding an installed Catch2 first
   find_package(Catch2 2.11.1 QUIET)
 
-  if (NOT CATCH2_FOUND)
+  if (NOT Catch2_FOUND)
     # If Catch2 is not found, instead use the git submodule
     if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/Catch2/single_include)
       # Unable to find the header files for Catch2 or they don't exist


### PR DESCRIPTION
## PR Summary

Catch2 wasn't being found because the case of `CATCH2_FOUND` was incorrect. Must be `Catch2_FOUND`.

## PR Checklist

- [x] Code passes cpplint (No C++ changes)
- [x] New features are documented. (no new features)
- [x] Adds a test for any bugs fixed. Adds tests for new features. (just a build system fix)
