### PR TITLE
Officially Create Version 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@
 - dolor (#911)
 
 ## Release 0.1.0
+Date: 8/4/2020
 
 Initial release of Parthenon AMR infrastructure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,12 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- Introduced CHANGELOG.md
-
-### Changed (changing behavior/API/variables/...)
-
-### Fixed (not changing behavior/API/variables/...)
-
-### Removed
-
-
-## Release 0.MAJOR.MINOR
-Note:
-- will only contain the subsections of develop that were filled
-- will (ideally) include the PR that introduced the change
-
-### Added (new features/APIs/variables/...)
 - lorem (#11)
 - ipsum (#14)
 
 ### Fixed (not changing behavior/API/variables/...)
-
 - dolor (#911)
 
+## Release 0.1.0
+
+Initial release of Parthenon AMR infrastructure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,12 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- lorem (#11)
-- ipsum (#14)
+
+### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
-- dolor (#911)
+
+### Removed
 
 ## Release 0.1.0
 Date: 8/4/2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,6 @@
 Date: 8/4/2020
 
 Initial release of Parthenon AMR infrastructure.
+
+### Changed
+[[PR 214]](https://github.com/lanl/parthenon/pull/214): The weak linked routines for user-specified parthenon behavior have been removed in favor of a more portable approach. See [the documentation](docs/README.md#user-specified-internal-functions).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@
 #=========================================================================================
 
 cmake_minimum_required(VERSION 3.10)
-project(parthenon LANGUAGES C CXX)
+project(parthenon VERSION 0.1.0 LANGUAGES C CXX)
 
 include(CTest)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,6 @@ The decision on creating a new release is made during the bi-weekly calls.
 A release consists of of merging `develop` into `stable` and create a new tag for that version
 using a modified [semantic versioning](https://semver.org/) scheme.
 Releases will be tagged `v0.MAJOR.MINOR` given the current rapid development.
-Release branches named `v0.MAJOR` will track the latest minor release.
 
 - MAJOR is incremented for API incompatible changes
 - MINOR is incremented for backwards compatible changes and bug fixes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,8 @@ We aim at creating a new release everyone 4 to 6 weeks.
 The decision on creating a new release is made during the bi-weekly calls.
 A release consists of of merging `develop` into `stable` and create a new tag for that version
 using a modified [semantic versioning](https://semver.org/) scheme.
-Releases will be tagged `0.MAJOR.MINOR` given the current rapid development.
+Releases will be tagged `v0.MAJOR.MINOR` given the current rapid development.
+Release branches named `v0.MAJOR` will track the latest minor release.
 
 - MAJOR is incremented for API incompatible changes
 - MINOR is incremented for backwards compatible changes and bug fixes


### PR DESCRIPTION
## PR Summary

This change primarily sets the version number in CMakeList.txt and puts some boiler plate about the initial release in CHANGELOG.md.

Also changes the rules a little about tagged releases - prefixes the releases with "v", and also calls for branches that track the latest minor release for each major version.

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
