### PR TITLE
Variable packs over the entire mesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added (new features/APIs/variables/...)
 [[PR250]] Feature::Restart. If output file format 'rst' is specified restart files are written using independent variables and those marked with Restart metadata flag.  Simulations can be restarted with a '-r \<restartFile\>' argument to the code.
+[[PR 263]](https://github.com/lanl/parthenon/pull/263) Added MeshPack, a mechanism for looping over the whole mesh at once within a `Kokkos` kernel. See [documentation](docs/mesh/packing.md)
 
 ### Changed (changing behavior/API/variables/...)
 - [\#68](https://github.com/lanl/parthenon/issues/68) Moved default `par_for` wrappers to `MeshBlock` 

--- a/docs/mesh/packing.md
+++ b/docs/mesh/packing.md
@@ -39,9 +39,9 @@ For example:
 // pack all variables on the base container accross the whole mesh
 auto meshpack = PackVariablesAndFluxes(pmesh, "base");
 auto variablepack = meshpack(m); // Indexes into the m'th meshblock
-auto auto var = mesh(m,l); // Indexes into the k'th variable on the m'th MB
+auto var = meshpack(m,l); // Indexes into the k'th variable on the m'th MB
 // The l'th variable in the i,j,k'th cell of the m'th meshblock
-Real r = mesh(m,l,k,j,i); 
+Real r = meshpack(m,l,k,j,i); 
 ```
 
 For convenience, `MeshPack` also includes the following methods and fields:

--- a/docs/mesh/packing.md
+++ b/docs/mesh/packing.md
@@ -1,0 +1,65 @@
+# Packing Variables Accross the Entire Mesh
+
+`Kokkos` kernel launches have a 6 microsecond overhead. For small
+kernels that perform little work, this can be a perforamnce bottleneck
+when each kernel is launched per meshblock. Parthenon therefore
+provides the capability to combine variables into a single data
+structure that spans all meshblocks, the `MeshPack`. 
+
+## Creating a Mesh Pack
+
+There are two methods for creating mesh packs, which are analogous to the `VariablePack` and `VariableFluxPack` available in [containers](../interface/containers.md).
+```C++
+template <typename... Args>
+auto PackVariablesOnMesh(Mesh *pmesh, const std::string &container_name,
+                         Args &&... args)
+```
+and
+```C++
+auto PackVariablesAndFluxesOnMesh(Mesh *pmesh, const std::string &container_name,
+                                  Args &&... args)
+```
+The former packs only the variables, the latter packs in the variables and associated flux vectors.
+
+The variatic arguments take exactly the same arguments as
+`container.PackVariables` and `container.PackVariablesAndFluxes`. You
+can pass in a metadata vector, a vector of names, and optionally IDs
+and a map from names to indices. See
+[here](../interface/containers.md) for more details.
+
+## Data Layout
+
+The Mesh Pack is indexable as a five-dimensional `Kokkos` view. The
+slowest moving index indexes into a 4-dimensional `VariablePack`. The
+next slowest indexes into a variable. The fastest three index into the
+cells on a meshblock.
+
+For example:
+```C++
+// pack all variables on the base container accross the whole mesh
+auto meshpack = PackVariablesAndFluxes(pmesh, "base");
+auto variablepack = meshpack(m); // Indexes into the m'th meshblock
+auto auto var = mesh(m,l); // Indexes into the k'th variable on the m'th MB
+// The l'th variable in the i,j,k'th cell of the m'th meshblock
+Real r = mesh(m,l,k,j,i); 
+```
+
+For convenience, `MeshPack` also includes the following methods and fields:
+```C++
+// the IndexShape object describing the bounds of all blocks in the pack
+IndexShape bounds = meshpack.cellbounds; 
+
+// a 1D array of coords objects
+auto coords = meshpack.coords(m); // gets the Coordinates_t object on the m'th MB
+
+// The dimensionality of the simulation. Will be 1, 2, or 3.
+// This is needed because components of the flux vector
+// are only allocated for dimensions in use.
+int ndim = meshpack.GetNdim();
+
+// Get the sparse index of the n'th sparse variable in the pack.
+int sparse = meshpack.GetSparse(n);
+
+// The size of the n'th dimension of the pack
+int dim = meshpack.GetDim(n);
+```

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -149,8 +149,7 @@ Real ComputeAreaOnMesh(parthenon::Mesh *pmesh) {
   using policy = Kokkos::MDRangePolicy<Kokkos::Rank<5>>;
   Kokkos::parallel_reduce(
       "calculate_pi compute area",
-      policy(parthenon::DevExecSpace(),
-             {0, 0, kb.s, jb.s, ib.s},
+      policy(parthenon::DevExecSpace(), {0, 0, kb.s, jb.s, ib.s},
              {pack.GetDim(5), pack.GetDim(4), kb.e + 1, jb.e + 1, ib.e + 1},
              {1, 1, 1, 1, ib.e + 1 - ib.s}),
       KOKKOS_LAMBDA(int b, int v, int k, int j, int i, Real &larea) {

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -124,7 +124,8 @@ Real ComputeAreaOnMesh(parthenon::Mesh *pmesh) {
       },
       area);
   // These params are mesh wide. Doesn't matter which meshblock I pull it from.
-  const auto &radius = pmesh->pblock->packages["calculate_pi"]->Param<Real>("radius");
+  const auto &radius =
+    pmesh->block_list.front().packages["calculate_pi"]->Param<Real>("radius");
   return area / (radius * radius);
 }
 

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -125,7 +125,7 @@ Real ComputeAreaOnMesh(parthenon::Mesh *pmesh) {
       area);
   // These params are mesh wide. Doesn't matter which meshblock I pull it from.
   const auto &radius =
-    pmesh->block_list.front().packages["calculate_pi"]->Param<Real>("radius");
+      pmesh->block_list.front().packages["calculate_pi"]->Param<Real>("radius");
   return area / (radius * radius);
 }
 

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <string>
 #include <utility>
+#include <vector>
 
 // Parthenon Includes
 #include <coordinates/coordinates.hpp>

--- a/example/calculate_pi/calculate_pi.hpp
+++ b/example/calculate_pi/calculate_pi.hpp
@@ -28,6 +28,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 
 // Task Implementations
 parthenon::TaskStatus ComputeArea(parthenon::MeshBlock *pmb);
+
+// Run task on the entire mesh at once
+Real ComputeAreaOnMesh(Mesh* mesh);
 } // namespace calculate_pi
 
 #endif // EXAMPLE_CALCULATE_PI_CALCULATE_PI_HPP_

--- a/example/calculate_pi/calculate_pi.hpp
+++ b/example/calculate_pi/calculate_pi.hpp
@@ -30,7 +30,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 parthenon::TaskStatus ComputeArea(parthenon::MeshBlock *pmb);
 
 // Run task on the entire mesh at once
-Real ComputeAreaOnMesh(Mesh* mesh);
+Real ComputeAreaOnMesh(Mesh *mesh);
 } // namespace calculate_pi
 
 #endif // EXAMPLE_CALCULATE_PI_CALCULATE_PI_HPP_

--- a/example/calculate_pi/calculate_pi.hpp
+++ b/example/calculate_pi/calculate_pi.hpp
@@ -30,7 +30,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 parthenon::TaskStatus ComputeArea(parthenon::MeshBlock *pmb);
 
 // Run task on the entire mesh at once
-Real ComputeAreaOnMesh(Mesh *mesh);
+Real ComputeAreaOnMesh(parthenon::Mesh *pmesh);
 } // namespace calculate_pi
 
 #endif // EXAMPLE_CALCULATE_PI_CALCULATE_PI_HPP_

--- a/example/calculate_pi/parthinput.example
+++ b/example/calculate_pi/parthinput.example
@@ -52,6 +52,10 @@ max_level = 2                   # if set, limits refinement level from this crit
 
 <Pi>
 radius = 1.5
+# Whether or not to use mesh-wide kernel calls
+# A value of 0 is default task-based mechanism, where kernels are per meshblock
+# A value of 1 makes a single global kernel call over all meshblocks on a rank
+use_mesh_pack = 0
 
 <parthenon/output0>
 file_type = hdf5

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -110,7 +110,7 @@ parthenon::DriverStatus PiDriver::Execute() {
       // extract area from device memory
       Real block_area;
       Kokkos::deep_copy(mb.exec_space, block_area, v.Get(0, 0, 0, 0, 0, 0));
-      pmb->exec_space.fence(); // as the deep copy may be async
+      mb.exec_space.fence(); // as the deep copy may be async
 
       const auto &radius = mb.packages["calculate_pi"]->Param<Real>("radius");
       // area must be reduced by r^2 to get the block's contribution to PI

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -59,7 +59,7 @@ parthenon::DriverStatus PiDriver::Execute() {
 
   pouts->MakeOutputs(pmesh, pinput);
   double area = 0.0;
-  if (pin->GetOrAddBoolean("Pi", "use_mesh_pack", false)) {
+  if (pinput->GetOrAddBoolean("Pi", "use_mesh_pack", false)) {
     // Use the mesh pack and do it all in one step
     area = calculate_pi::ComputeAreaOnMesh(pmesh);
   } else {

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -59,7 +59,7 @@ parthenon::DriverStatus PiDriver::Execute() {
 
   pouts->MakeOutputs(pmesh, pinput);
   double area = 0.0;
-  if ( pin->GetOrAddBoolean("Pi", "use_mesh_pack", false) ) {
+  if (pin->GetOrAddBoolean("Pi", "use_mesh_pack", false)) {
     // Use the mesh pack and do it all in one step
     area = calculate_pi::ComputeAreaOnMesh(pmesh);
   } else {
@@ -71,16 +71,16 @@ parthenon::DriverStatus PiDriver::Execute() {
     while (pmb != nullptr) {
       auto &rc = pmb->real_containers.Get();
       ParArrayND<Real> v = rc->Get("in_or_out").data;
-      
+
       // extract area from device memory
       Real block_area;
       Kokkos::deep_copy(pmb->exec_space, block_area, v.Get(0, 0, 0, 0, 0, 0));
       pmb->exec_space.fence(); // as the deep copy may be async
-      
+
       const auto &radius = pmb->packages["calculate_pi"]->Param<Real>("radius");
       // area must be reduced by r^2 to get the block's contribution to PI
       block_area /= (radius * radius);
-      
+
       area += block_area;
       pmb = pmb->next;
     }

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -13,6 +13,8 @@
 
 // Standard Includes
 #include <fstream>
+#include <string>
+#include <vector>
 
 // Parthenon Includes
 #include <parthenon/package.hpp>
@@ -56,28 +58,32 @@ parthenon::DriverStatus PiDriver::Execute() {
   PreExecute();
 
   pouts->MakeOutputs(pmesh, pinput);
-
-  ConstructAndExecuteBlockTasks<>(this);
-
-  // All the blocks are done, now do a global reduce and spit out the answer
-  // first sum over blocks on this rank
-  Real area = 0.0;
-  MeshBlock *pmb = pmesh->pblock;
-  while (pmb != nullptr) {
-    auto &rc = pmb->real_containers.Get();
-    ParArrayND<Real> v = rc->Get("in_or_out").data;
-
-    // extract area from device memory
-    Real block_area;
-    Kokkos::deep_copy(pmb->exec_space, block_area, v.Get(0, 0, 0, 0, 0, 0));
-    pmb->exec_space.fence(); // as the deep copy may be async
-
-    const auto &radius = pmb->packages["calculate_pi"]->Param<Real>("radius");
-    // area must be reduced by r^2 to get the block's contribution to PI
-    block_area /= (radius * radius);
-
-    area += block_area;
-    pmb = pmb->next;
+  double area = 0.0;
+  if ( pin->GetOrAddBoolean("Pi", "use_mesh_pack", false) ) {
+    // Use the mesh pack and do it all in one step
+    area = calculate_pi::ComputeAreaOnMesh(pmesh);
+  } else {
+    // Task based method
+    ConstructAndExecuteBlockTasks<>(this);
+    // All the blocks are done, now do a global reduce and spit out the answer
+    // first sum over blocks on this rank
+    MeshBlock *pmb = pmesh->pblock;
+    while (pmb != nullptr) {
+      auto &rc = pmb->real_containers.Get();
+      ParArrayND<Real> v = rc->Get("in_or_out").data;
+      
+      // extract area from device memory
+      Real block_area;
+      Kokkos::deep_copy(pmb->exec_space, block_area, v.Get(0, 0, 0, 0, 0, 0));
+      pmb->exec_space.fence(); // as the deep copy may be async
+      
+      const auto &radius = pmb->packages["calculate_pi"]->Param<Real>("radius");
+      // area must be reduced by r^2 to get the block's contribution to PI
+      block_area /= (radius * radius);
+      
+      area += block_area;
+      pmb = pmb->next;
+    }
   }
 #ifdef MPI_PARALLEL
   Real pi_val;

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -105,13 +105,13 @@ class VariableFluxPack : public VariablePack<T> {
 
   KOKKOS_FORCEINLINE_FUNCTION
   ViewOfParArrays<T> &flux(const int dir) const {
-    assert(dir > 0 && dir <= ndim_);
+    assert(dir > 0 && dir <= this->ndim_);
     return f_[dir - 1];
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
   T &flux(const int dir, const int n, const int k, const int j, const int i) const {
-    assert(dir > 0 && dir <= ndim_);
+    assert(dir > 0 && dir <= this->ndim_);
     return f_[dir - 1](n)(k, j, i);
   }
 
@@ -286,7 +286,7 @@ VariableFluxPack<T> MakeFluxPack(const vpack_types::VarList<T> &vars,
   // add fluxes to host view
   FillFluxViews(flux_vars, vmap, ndim, f1, f2, f3);
 
-  return VariableFluxPack<T>(cv, f1, f2, f3, sparse_assoc, cv_size, fsize);
+  return VariableFluxPack<T>(cv, f1, f2, f3, sparse_assoc, cv_size);
 }
 
 template <typename T>

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -66,8 +66,8 @@ class VariablePack {
   VariablePack() = default;
   VariablePack(const ViewOfParArrays<T> view, const ParArrayND<int> sparse_ids,
                const std::array<int, 4> dims)
-    : v_(view), sparse_ids_(sparse_ids), dims_(dims),
-      ndim_((dims[2] > 1 ? 3 : (dims[1] > 1 ? 2 : 1))){}
+      : v_(view), sparse_ids_(sparse_ids), dims_(dims),
+        ndim_((dims[2] > 1 ? 3 : (dims[1] > 1 ? 2 : 1))) {}
   KOKKOS_FORCEINLINE_FUNCTION
   ParArray3D<T> &operator()(const int n) const { return v_(n); }
   KOKKOS_FORCEINLINE_FUNCTION

--- a/src/mesh/domain.hpp
+++ b/src/mesh/domain.hpp
@@ -55,8 +55,8 @@ enum class IndexDomain { entire, interior };
 //  index also contains a label for defining which region the index shape is assigned too
 class IndexShape {
  private:
-  std::array<IndexRange,NDIM> x_;
-  std::array<int,NDIM> entire_ncells_;
+  std::array<IndexRange, NDIM> x_;
+  std::array<int, NDIM> entire_ncells_;
 
   KOKKOS_INLINE_FUNCTION bool DimensionProvided_(const std::vector<int> &interior_dims,
                                                  int dim) {

--- a/src/mesh/domain.hpp
+++ b/src/mesh/domain.hpp
@@ -55,8 +55,8 @@ enum class IndexDomain { entire, interior };
 //  index also contains a label for defining which region the index shape is assigned too
 class IndexShape {
  private:
-  IndexRange x_[NDIM];
-  int entire_ncells_[NDIM];
+  std::array<IndexRange,NDIM> x_;
+  std::array<int,NDIM> entire_ncells_;
 
   KOKKOS_INLINE_FUNCTION bool DimensionProvided_(const std::vector<int> &interior_dims,
                                                  int dim) {
@@ -164,6 +164,7 @@ class IndexShape {
   }
 
   // Kept basic for kokkos
+  KOKKOS_INLINE_FUNCTION
   int GetTotal(const IndexDomain &domain) const noexcept {
     if (NDIM == 0) return 0;
     int total = 1;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -310,7 +310,9 @@ class Mesh {
   ~Mesh();
 
   // accessors
-  int GetNumMeshBlocksThisRank(int my_rank = Globals::my_rank) { return nblist[my_rank]; }
+  int GetNumMeshBlocksThisRank(int my_rank = Globals::my_rank) const {
+    return nblist[my_rank];
+  }
   int GetNumMeshThreads() const { return num_mesh_threads_; }
   std::int64_t GetTotalCells() {
     return static_cast<std::int64_t>(nbtotal) * pblock->block_size.nx1 *

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -310,9 +310,7 @@ class Mesh {
   ~Mesh();
 
   // accessors
-  int GetNumMeshBlocksThisRank(int my_rank=Globals::my_rank) {
-    return nblist[my_rank];
-  }
+  int GetNumMeshBlocksThisRank(int my_rank = Globals::my_rank) { return nblist[my_rank]; }
   int GetNumMeshThreads() const { return num_mesh_threads_; }
   std::int64_t GetTotalCells() {
     return static_cast<std::int64_t>(nbtotal) * pblock->block_size.nx1 *

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -310,7 +310,9 @@ class Mesh {
   ~Mesh();
 
   // accessors
-  int GetNumMeshBlocksThisRank(int my_rank) { return nblist[my_rank]; }
+  int GetNumMeshBlocksThisRank(int my_rank=Globals::my_rank) {
+    return nblist[my_rank];
+  }
   int GetNumMeshThreads() const { return num_mesh_threads_; }
   std::int64_t GetTotalCells() {
     return static_cast<std::int64_t>(nbtotal) * pblock->block_size.nx1 *

--- a/src/mesh/mesh_pack.hpp
+++ b/src/mesh/mesh_pack.hpp
@@ -83,7 +83,7 @@ auto PackMesh(Mesh *pmesh, F &packing_function) {
   auto coords_host = Kokkos::create_mirror_view(coords);
 
   int b = 0;
-  for (auto & mb : pmesh->block_list) {
+  for (auto &mb : pmesh->block_list) {
     coords_host(b) = mb.coords;
     packs_host(b) = packing_function(&mb);
     b++;

--- a/src/mesh/mesh_pack.hpp
+++ b/src/mesh/mesh_pack.hpp
@@ -32,11 +32,9 @@ template <typename T>
 class MeshPack {
  public:
   MeshPack() = default;
-  MeshPack(const ParArray1D<T> view,
-           const IndexShape shape,
-           const ParArray1D<Coordinates_t> coordinates,
-           const std::array<int, 5> dims)
-    : v_(view), cellbounds(shape), coords(coordinates), dims_(dims) {}
+  MeshPack(const ParArray1D<T> view, const IndexShape shape,
+           const ParArray1D<Coordinates_t> coordinates, const std::array<int, 5> dims)
+      : v_(view), cellbounds(shape), coords(coordinates), dims_(dims) {}
   KOKKOS_FORCEINLINE_FUNCTION
   auto &operator()(const int block) const { return v_(block); }
   KOKKOS_FORCEINLINE_FUNCTION
@@ -100,8 +98,8 @@ auto PackMesh(Mesh *pmesh, const std::string &container_name, F &packing_functio
   }
   dims[4] = nblock;
 
-  Kokkos::deep_copy(packs,packs_host);
-  Kokkos::deep_copy(coords,coords_host);
+  Kokkos::deep_copy(packs, packs_host);
+  Kokkos::deep_copy(coords, coords_host);
 
   return MeshPack(packs, pmesh->pblock->cellbounds, coords, dims);
 }

--- a/src/mesh/mesh_pack.hpp
+++ b/src/mesh/mesh_pack.hpp
@@ -1,0 +1,107 @@
+//========================================================================================
+// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//=======================================================================================
+#ifndef MESH_MESH_PACK_HPP_
+#define MESH_MESH_PACK_HPP_
+
+#include <array>
+#include <utility>
+
+#include "interface/container.hpp"
+#include "interface/variable_pack.hpp"
+#include "mesh/mesh.hpp" // TODO(JMM): Replace with forward declaration?
+
+namespace parthenon {
+
+// a separate dims array removes a branch case in `GetDim`
+template <typename T>
+class MeshPack {
+ public:
+  MeshPack() = default;
+  MeshPack(const ParArray1D<T> view,
+           const std::array<int, 5> dims)
+    : v_(view), dims_(dims) {}
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto &operator()(const int block) const {
+    return v_(block);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto &operator()(const int block, const int n) const {
+    return v_(block)(n);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto &operator()(const int block, const int n,
+                   const int k, const int j, const int i) const {
+    reutrn v_(block)(n)(k,j,i);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  int GetDim(const int i) const {
+    assert(i > 0 && i < 6);
+    return dims_[i - 1];
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  int GetNdim() const { return v_(0).GetNdim(); }
+  KOKKOS_FORCEINLINE_FUNCTION
+  int GetSparse(const int n) const {
+    return v_(0).GetSparse(n);
+  }
+
+ private:
+  ParArray1D<T> v_;
+  std::array<int, 5> dims_;
+};
+
+template <typename T>
+using ViewOfPacks = ParArray1D<VariablePack<T>>;
+template <typename T>
+using ViewOfFluxPacks = ParArray1D<VariableFluxPack<T>>;
+template <typename T>
+using MeshVariablePack = MeshPack<VariablePack<T>>;
+template <typename T>
+using MeshVariableFluxPack = MeshPack<VariableFluxPack<T>>;
+
+// Uses Real only because meshblock only owns real containers
+template <typename... Args>
+auto MakeMeshVariablePack(Mesh* pmesh,
+                          const std::string& container_name,
+                          Args... args,
+                          PackIndexMap &vmap) {
+  int nblocks = pmesh->GetNumMeshBlocksThisRank();
+  ViewOfPacks<T> packs("MakeMeshVariablePack::cv", nblocks);
+  auto packs_host = packs.GetHostMirror();
+  
+  // TODO(JMM): Update to Andrew's C++ std::list when available
+  MeshBlock *pmb = pmesh->pblock;
+  int b = 0;
+  while (pmb != nullptr) { 
+    auto &container = pmb->real_containers.Get(container_name);
+    packs_host(b) = container->PackVariables(std::forward<Args>(args)...,vmap);
+    pmb = pmb->next;
+    b++;
+  }
+  auto pack = packs_host(0);
+  packs.DeepCopy(packs_host);
+
+  std::array<int, 5> dims;
+  for (int i = 0; i < 4; i++) {
+    dims[i] = pack.GetDim(i+1);
+  }
+  dims[4] = nblock;
+
+  return MeshVariablePack(packs,pack.GetSparseIDs(),dims);
+}
+
+
+
+} // namespace parthenon
+
+#endif // MESH_MESH_PACK_HPP_

--- a/src/mesh/mesh_pack.hpp
+++ b/src/mesh/mesh_pack.hpp
@@ -16,19 +16,27 @@
 #include <array>
 #include <utility>
 
+#include "coordinates/coordinates.hpp"
 #include "interface/container.hpp"
 #include "interface/variable_pack.hpp"
+#include "kokkos_abstraction.hpp"
+#include "mesh/domain.hpp"
 #include "mesh/mesh.hpp" // TODO(JMM): Replace with forward declaration?
 
 namespace parthenon {
 
 // a separate dims array removes a branch case in `GetDim`
+// TODO(JMM): Using one IndexShape because its the same for all
+// meshblocks. This needs careful thought before sticking with it.
 template <typename T>
 class MeshPack {
  public:
   MeshPack() = default;
-  MeshPack(const ParArray1D<T> view, const std::array<int, 5> dims)
-      : v_(view), dims_(dims) {}
+  MeshPack(const ParArray1D<T> view,
+           const IndexShape shape,
+           const ParArray1D<Coordinates_t> coordinates,
+           const std::array<int, 5> dims)
+    : v_(view), cellbounds(shape), coords(coordinates), dims_(dims) {}
   KOKKOS_FORCEINLINE_FUNCTION
   auto &operator()(const int block) const { return v_(block); }
   KOKKOS_FORCEINLINE_FUNCTION
@@ -47,6 +55,10 @@ class MeshPack {
   int GetNdim() const { return v_(0).GetNdim(); }
   KOKKOS_FORCEINLINE_FUNCTION
   int GetSparse(const int n) const { return v_(0).GetSparse(n); }
+
+  // TODO(JMM): Also include mesh domain object?
+  IndexShape cellbounds;
+  ParArray1D<Coordinates_t> coords;
 
  private:
   ParArray1D<T> v_;
@@ -68,12 +80,15 @@ template <typename T, typename F>
 auto PackMesh(Mesh *pmesh, const std::string &container_name, F &packing_function) {
   int nblocks = pmesh->GetNumMeshBlocksThisRank();
   ParArray1D<T> packs("MakeMeshVariablePack::view", nblocks);
-  auto packs_host = packs.GetHostMirror();
+  auto packs_host = Kokkos::create_mirror_view(packs);
+  ParArray1D<Coordinates_t> coords("MakeMeshPackVariable::coords", nblocks);
+  auto coords_host = Kokkos::create_mirror_view(coords);
 
   // TODO(JMM): Update to Andrew's C++ std::list when available
   MeshBlock *pmb = pmesh->pblock;
   int b = 0;
   while (pmb != nullptr) {
+    coords_host(b) = pmb->coords;
     packs_host(b) = packing_function(pmb);
     pmb = pmb->next;
     b++;
@@ -85,9 +100,10 @@ auto PackMesh(Mesh *pmesh, const std::string &container_name, F &packing_functio
   }
   dims[4] = nblock;
 
-  packs.DeepCopy(packs_host);
+  Kokkos::deep_copy(packs,packs_host);
+  Kokkos::deep_copy(coords,coords_host);
 
-  return MeshPack(packs, dims);
+  return MeshPack(packs, pmesh->pblock->cellbounds, coords, dims);
 }
 } // namespace mesh_pack_impl
 
@@ -95,7 +111,7 @@ auto PackMesh(Mesh *pmesh, const std::string &container_name, F &packing_functio
 template <typename... Args>
 auto PackVariablesOnMesh(Mesh *pmesh, const std::string &container_name,
                          Args &&... args) {
-  return PackMesh<VariablePack<Real>>(pmesh, [=](MeshBlock *pmb) {
+  return PackMesh<VariablePack<Real>>(pmesh, [&](MeshBlock *pmb) {
     auto container = pmb->real_containers.Get(container_name);
     return container->PackVariables(std::forward<Args>(args)...);
   });
@@ -103,7 +119,7 @@ auto PackVariablesOnMesh(Mesh *pmesh, const std::string &container_name,
 template <typename... Args>
 auto PackVariablesAndFluxesOnMesh(Mesh *pmesh, const std::string &container_name,
                                   Args &&... args) {
-  return PackMesh<VariableFluxPack<Real>>(pmesh, [=](MeshBlock *pmb) {
+  return PackMesh<VariableFluxPack<Real>>(pmesh, [&](MeshBlock *pmb) {
     auto container = pmb->real_containers.Get(container_name);
     return container->PackVariablesAndFluxes(std::forward<Args>(args)...);
   });

--- a/src/mesh/mesh_pack.hpp
+++ b/src/mesh/mesh_pack.hpp
@@ -14,6 +14,7 @@
 #define MESH_MESH_PACK_HPP_
 
 #include <array>
+#include <string>
 #include <utility>
 
 #include "coordinates/coordinates.hpp"


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This pull request is motivated by the performance discussion on Monday. Since we are now looking at coalescing kernels over meshblocks, I decided to see if I could throw together a prototype for a piece of what we need: a data structure we can capture and pass into a Kokkos kernel.

The path I decided to go down was to generalize the `VariablePack` mechanism @jdolence implemented. I implement here a `MeshPack` object and `PackMesh` method, which takes essentially the same arguments as `PackVariables` or `PackVariablesAndFluxes`. But it also takes a container and a mesh pointer. The resulting object is a view of VariablePacks. The way to interact with it is as a 5D view, where the indices are: `MeshBlock`, `Variable`, `k`, `j`, `i`.

I decided to go down this path mainly because it seemed straightforward. We don't have to rewrite the underlying data layout or make high-level objects like `MeshBlock` CUDA-friendly. 

To test it out, I implemented an alternate version of the `pi_example` that computes the area step with a global Kokkos kernel rather than a task.

### A few caveats

- I have done **zero** performance testing. If this is a path we want to go down, we need to test this thing out more rigorously.
- It needs to be a little more general to support buffer packs (which aren't needed in the pi example). The boundary buffers need to be addable to this pack object. I don't think this is an impediment though. It should be straightforward.
-  I implemented but didn't test this packing for `FluxPack`s. That's for the future, I think.
- At the moment, I restricted this packing to pack all blocks on an MPI rank. I just wanted to see if I could do it. It should be straightforward to select a set of block IDs or partition into N block objects, each owning some (roughly) equal number of blocks.
- A major missing piece of this machinery is a way of integrating tasks with these superblocks or bulk-synchronous operations. Ideally, we could seamleslsy weave together tasks on individual blocks and on these superblocks. 

### Concluding thoughts

To be clear, I'm not proposing this as the final implementation we should merge in. Rather, I wanted to just share it with you all to start a discussion and see what you think and whether we should pursue something like this. I was pleasantly surprised how easy it was to implement this thing. The infrastructure we've written so far is flexible enough to support it with very little suffering.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
