### PR TITLE
Fix setting default CXX standard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[#256]](https://github.com/lanl/parthenon/issues/256): Fix setting default CXX standard.
 
 ### Removed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,7 +186,7 @@ endif()
 
 # We want Kokkos to be built with C++14, since that's what we're using in
 # Parthenon.
-set(Kokkos_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 14)
 if(EXISTS ${Kokkos_ROOT}/CMakeLists.txt)
   add_subdirectory(${Kokkos_ROOT} Kokkos)
 elseif(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos/CMakeLists.txt)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The Kokkos prefixed variable seem to be overwritten/ignored when Kokkos is included.
If we use the CMake prefixed var instead then this is processed properly by the Kokkos CMakeLists.txt

Fix #256 

Before:

On first cmake call:
```
-- Using -std=c++11 for C++11 standard as feature
```
On second (identical) cmake call:
```
-- Using -std=c++14 for C++14 standard as feature
```

After:
On first cmake call:
```
-- Using -std=c++14 for C++14 standard as feature
```


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] Changes are summarized in CHANGELOG.md
