### PR TITLE
change required python version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR 262]](https://github.com/lanl/parthenon/pull/262) Fix setting of "coverage" label in testing. Automatically applies coverage tag to all tests not containing "performance" label.
 
+### Changed (changing behavior/API/variables/...)
+- [[PR 276]](https://github.com/lanl/parthenon/pull/276) Decrease required Python version from 3.6 to 3.5.
+
 ### Removed
 
 ## Release 0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,6 @@
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR 271]](https://github.com/lanl/parthenon/issues/256): Fix setting default CXX standard.
 - [[PR 262]](https://github.com/lanl/parthenon/pull/262) Fix setting of "coverage" label in testing. Automatically applies coverage tag to all tests not containing "performance" label.
-
-### Changed (changing behavior/API/variables/...)
 - [[PR 276]](https://github.com/lanl/parthenon/pull/276) Decrease required Python version from 3.6 to 3.5.
 
 ### Removed

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -18,7 +18,7 @@
 # will be grabbed. Including the version number would prioritise the version provided over more 
 #
 find_package(Python3 REQUIRED COMPONENTS Interpreter)
-if( ${Python3_VERSION} VERSION_LESS "3.6")
+if( ${Python3_VERSION} VERSION_LESS "3.5")
   message(FATAL_ERROR "Python version requirements not satisfied")
 endif()
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Reduce required version to python 3.5 instead of python 3.6. Runs on my laptop and Darwin. Resolves issue #274 where I found that Darwin used Python 3.5 by default. The differences between Python 3.5 and 3.6 are extremely minor. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
