### PR TITLE
add metadata documentation for fillghosts

### DIFF
--- a/docs/interface/Metadata.md
+++ b/docs/interface/Metadata.md
@@ -5,6 +5,7 @@
 Variables can be tagged with a variety of `MetadataFlag` values. These flags
 primarily allow an application to tell Parthenon to apply certain behaviors to
 each field.
+
 ### Variable Topology
 
 Topology essentially specifies on which place on the finite volume
@@ -89,6 +90,22 @@ variables are copied or not in multiple stages.
   this.
 
 - `Metadata::SharedComms` TODO(JMM): not sure this variable is used
+
+### Ghost Zones, Communication, and Fluxes
+
+Depending on a combination of flags, extra communication buffers and
+classes may be allocated. The behaviours are the following:
+
+- If `Metadata::FillGhosts` is set, boundary conditions data is set,
+  MPI communication buffers are allocated, and buffers for a coarse
+  grid are allocated. These buffers are *one-copy*, meaning they are
+  shared between all instances of a variable in all `Containers` in a
+  `ContainerCollection`.
+
+- If, in addition to `Metadata::FillGhosts`, `Metadata::Independent`
+  is set, the flux vector for the variable is allocated. In the
+  current design, the flux is fundamental to communication, since flux
+  corrections accross meshblocks utilize the flux buffer.
 
 ### Application Metadata Flags
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Recently @pgrete discovered an interesting, undocumented bit of behaviour. The fluxes for an independent variable are only allocated if `Metadata::FillGhosts` is set. While this isn't necessarily obvious from the documentation, it does make some sense, since independent variables probably need their ghost zones filled and since the flux is used for flux correction between mesh blocks.

While this may merit a redesign in the future, I think that for now the solution is document it and move on. For the reasons outlined above, the design at the moment makes sense for our needs, and we can revisit if that changes.

As such, this PR can be considered to resolve issue #272 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
