### PR TITLE
Remove performance and regression from commit-wise tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,6 +73,8 @@ parthenon-cpu-unit:
       - build-debug/CMakeFiles/CMakeOutput.log
 
 parthenon-cuda-performance_and_regression:
+  only:
+    - schedules
   tags:
     - cuda
   stage: performance_and_regression
@@ -96,6 +98,8 @@ parthenon-cuda-performance_and_regression:
       - build-cuda-perf/tst/regression/outputs/advection_convergence/advection-errors.png
 
 parthenon-cuda-performance_and_regression-mpi:
+  only:
+    - schedules
   tags:
     - cuda
   stage: performance_and_regression
@@ -122,6 +126,8 @@ parthenon-cuda-performance_and_regression-mpi:
 
 # run performance and regression on CPUs without MPI
 parthenon-cpu-performance_and_regression:
+  only:
+    - schedules
   tags:
     - cpu
   stage: performance_and_regression
@@ -144,6 +150,8 @@ parthenon-cpu-performance_and_regression:
 
 # run performance and regression on CPUs with MPI
 parthenon-cpu-performance_and_regression-mpi:
+  only:
+    - schedules
   tags:
     - cpu
   stage: performance_and_regression

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
 
 stages:
-  - unit
+  - short
   - performance_and_regression
   - coverage
   - style
@@ -34,7 +34,7 @@ style-check:
 parthenon-cuda-unit:
   tags:
     - cuda
-  stage: unit
+  stage: short
   script:
     - mkdir build-cuda-debug
     - cd build-cuda-debug
@@ -45,7 +45,7 @@ parthenon-cuda-unit:
       -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
       ../
     - make -j${J}
-    - ctest -j${J} -LE 'performance|regression'
+    - ctest -LE 'performance|regression'
   artifacts:
     when: always
     expire_in: 3 days
@@ -56,7 +56,7 @@ parthenon-cuda-unit:
 parthenon-cpu-unit:
   tags:
     - cpu
-  stage: unit
+  stage: short
   script:
     - mkdir build-debug
     - cd build-debug
@@ -65,12 +65,53 @@ parthenon-cpu-unit:
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       ../
     - make -j${J}
-    - ctest -j${J} -LE "performance|regression"
+    - ctest -LE "performance|regression"
   artifacts:
     when: always
     expire_in: 3 days
     paths:
       - build-debug/CMakeFiles/CMakeOutput.log
+
+parthenon-cuda-short:
+  tags:
+    - cuda
+  stage: short
+  script:
+    - mkdir build-cuda-perf-mpi
+    - cd build-cuda-perf-mpi
+    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
+      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+      -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
+      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
+      -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
+      ../
+    - make -j${J}
+    - export OMPI_MCA_mpi_common_cuda_event_max=1000
+    - ctest -R regression_mpi_test:output_hdf5
+  artifacts:
+    when: always
+    expire_in: 3 days
+    paths:
+      - build-cuda-perf-mpi/CMakeFiles/CMakeOutput.log
+
+parthenon-cpu-short:
+  tags:
+    - cpu
+  stage: short
+  script:
+    - mkdir build-perf-mpi
+    - cd build-perf-mpi
+    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
+      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
+      ../
+    - make -j${J}
+    - ctest -R regression_mpi_test:output_hdf5
+  artifacts:
+    when: always
+    expire_in: 3 days
+    paths:
+      - build-perf-mpi/CMakeFiles/CMakeOutput.log
 
 parthenon-cuda-performance_and_regression:
   only:
@@ -108,7 +149,7 @@ parthenon-cuda-performance_and_regression-mpi:
     - cuda
   stage: performance_and_regression
   script:
-    - mkdir build-cuda-perf-mpi
+    - mkdir -p build-cuda-perf-mpi
     - cd build-cuda-perf-mpi
     - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
@@ -116,7 +157,7 @@ parthenon-cuda-performance_and_regression-mpi:
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
       ../
-    - make -j${J} 
+    - make -j${J}
     - export OMPI_MCA_mpi_common_cuda_event_max=1000
 #    - ctest -L "performance" # no need for performance test as currently none use MPI
     - ctest -L regression -LE "mpi-no|perf-reg" --timeout 3600
@@ -164,7 +205,7 @@ parthenon-cpu-performance_and_regression-mpi:
     - cpu
   stage: performance_and_regression
   script:
-    - mkdir build-perf-mpi
+    - mkdir -p build-perf-mpi
     - cd build-perf-mpi
     - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -175,6 +175,8 @@ parthenon-cpu-performance_and_regression-mpi:
 
 # run unit suite on CPUs with code coverage
 parthenon-cpu-coverage:
+  only:
+    - schedules
   tags:
     - cpu
   stage: coverage

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,7 @@ parthenon-cpu-unit:
 parthenon-cuda-performance_and_regression:
   only:
     - schedules
+    - develop
     - web
   tags:
     - cuda
@@ -101,6 +102,7 @@ parthenon-cuda-performance_and_regression:
 parthenon-cuda-performance_and_regression-mpi:
   only:
     - schedules
+    - develop
     - web
   tags:
     - cuda
@@ -130,6 +132,7 @@ parthenon-cuda-performance_and_regression-mpi:
 parthenon-cpu-performance_and_regression:
   only:
     - schedules
+    - develop
     - web
   tags:
     - cpu
@@ -155,6 +158,7 @@ parthenon-cpu-performance_and_regression:
 parthenon-cpu-performance_and_regression-mpi:
   only:
     - schedules
+    - develop
     - web
   tags:
     - cpu
@@ -181,6 +185,7 @@ parthenon-cpu-performance_and_regression-mpi:
 parthenon-cpu-coverage:
   only:
     - schedules
+    - develop
     - web
   tags:
     - cpu

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -75,6 +75,7 @@ parthenon-cpu-unit:
 parthenon-cuda-performance_and_regression:
   only:
     - schedules
+    - web
   tags:
     - cuda
   stage: performance_and_regression
@@ -100,6 +101,7 @@ parthenon-cuda-performance_and_regression:
 parthenon-cuda-performance_and_regression-mpi:
   only:
     - schedules
+    - web
   tags:
     - cuda
   stage: performance_and_regression
@@ -128,6 +130,7 @@ parthenon-cuda-performance_and_regression-mpi:
 parthenon-cpu-performance_and_regression:
   only:
     - schedules
+    - web
   tags:
     - cpu
   stage: performance_and_regression
@@ -152,6 +155,7 @@ parthenon-cpu-performance_and_regression:
 parthenon-cpu-performance_and_regression-mpi:
   only:
     - schedules
+    - web
   tags:
     - cpu
   stage: performance_and_regression
@@ -177,6 +181,7 @@ parthenon-cpu-performance_and_regression-mpi:
 parthenon-cpu-coverage:
   only:
     - schedules
+    - web
   tags:
     - cpu
   stage: coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [[PR 271]](https://github.com/lanl/parthenon/issues/256): Fix setting default CXX standard.
 - [[PR 262]](https://github.com/lanl/parthenon/pull/262) Fix setting of "coverage" label in testing. Automatically applies coverage tag to all tests not containing "performance" label.
 - [[PR 276]](https://github.com/lanl/parthenon/pull/276) Decrease required Python version from 3.6 to 3.5.
+- [[PR 283]](https://github.com/lanl/parthenon/pull/283) Change CI to extended nightly develop tests and short push tests.
 
 ### Removed
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Test MR for changing performance and regression tests to only run on nightly builds. Hopefully this will significantly speed up CI, at not too much cost to stability, since the full test suite is run nightly. Partially addresses #278 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
