### PR TITLE
Machine configuration files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,7 @@ before_script:
     - export OMP_NUM_THREADS=1
     - export CMAKE_VERSION=3.12.4
     - export CTEST_OUTPUT_ON_FAILURE=1
+    - export MACHINE_CFG=${PWD}/cmake/machinecfg/CI.cmake
     - export J=$(( $(nproc --all) / 4  + 1 )) && echo Using ${J} cores during build
     - wget -qO- http://www.cmake.org/files/v${CMAKE_VERSION:0:4}/cmake-${CMAKE_VERSION}-Linux-x86_64.tar.gz | tar -xz
     - export PATH=${PWD}/cmake-${CMAKE_VERSION}-Linux-x86_64/bin:$PATH
@@ -38,11 +39,9 @@ parthenon-cuda-unit:
   script:
     - mkdir build-cuda-debug
     - cd build-cuda-debug
-    - cmake -DCMAKE_BUILD_TYPE=Debug -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
-      -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
+    - cmake -DCMAKE_BUILD_TYPE=Debug
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
-      -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
+      -DMACHINE_VARIANT=cuda-mpi
       ../
     - make -j${J}
     - ctest -LE 'performance|regression'
@@ -60,9 +59,9 @@ parthenon-cpu-unit:
   script:
     - mkdir build-debug
     - cd build-debug
-    - cmake -DCMAKE_BUILD_TYPE=Debug -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+    - cmake -DCMAKE_BUILD_TYPE=Debug
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
+      -DMACHINE_VARIANT=mpi
       ../
     - make -j${J}
     - ctest -LE "performance|regression"
@@ -79,11 +78,9 @@ parthenon-cuda-short:
   script:
     - mkdir build-cuda-perf-mpi
     - cd build-cuda-perf-mpi
-    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
-      -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
+    - cmake -DCMAKE_BUILD_TYPE=Release
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
-      -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
+      -DMACHINE_VARIANT=cuda-mpi
       ../
     - make -j${J}
     - export OMPI_MCA_mpi_common_cuda_event_max=1000
@@ -101,9 +98,9 @@ parthenon-cpu-short:
   script:
     - mkdir build-perf-mpi
     - cd build-perf-mpi
-    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+    - cmake -DCMAKE_BUILD_TYPE=Release
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
+      -DMACHINE_VARIANT=mpi
       ../
     - make -j${J}
     - ctest -R regression_mpi_test:output_hdf5
@@ -124,11 +121,9 @@ parthenon-cuda-performance_and_regression:
   script:
     - mkdir build-cuda-perf
     - cd build-cuda-perf
-    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/serial
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
-      -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
-      -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
+    - cmake -DCMAKE_BUILD_TYPE=Release
       -DPARTHENON_DISABLE_MPI=ON
+      -DMACHINE_VARIANT=cuda
       ../
     - make -j${J}
     - ctest -L "performance|regression" -LE "mpi-yes|perf-reg"
@@ -151,11 +146,9 @@ parthenon-cuda-performance_and_regression-mpi:
   script:
     - mkdir -p build-cuda-perf-mpi
     - cd build-cuda-perf-mpi
-    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
-      -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_PASCAL61=True
+    - cmake -DCMAKE_BUILD_TYPE=Release
       -DMPIEXEC_PREFLAGS="--allow-run-as-root"
-      -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
+      -DMACHINE_VARIANT=cuda-mpi
       ../
     - make -j${J}
     - export OMPI_MCA_mpi_common_cuda_event_max=1000
@@ -181,8 +174,7 @@ parthenon-cpu-performance_and_regression:
   script:
     - mkdir build-perf
     - cd build-perf
-    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/serial
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+    - cmake -DCMAKE_BUILD_TYPE=Release
       -DPARTHENON_DISABLE_MPI=ON
       ../
     - make -j${J}
@@ -234,9 +226,9 @@ parthenon-cpu-coverage:
   script:
     - mkdir build-debug-coverage
     - cd build-debug-coverage
-    - cmake -DCMAKE_BUILD_TYPE=Debug -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+    - cmake -DCMAKE_BUILD_TYPE=Debug
       -DMPIEXEC_PREFLAGS="--allow-run-as-root" -DCODE_COVERAGE=ON
+      -DMACHINE_VARIANT=mpi
       ../ && make -j${J} && make coverage && make coverage-upload
   artifacts:
     when: always

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,7 +40,6 @@ parthenon-cuda-unit:
     - mkdir build-cuda-debug
     - cd build-cuda-debug
     - cmake -DCMAKE_BUILD_TYPE=Debug
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       -DMACHINE_VARIANT=cuda-mpi
       ../
     - make -j${J}
@@ -60,7 +59,6 @@ parthenon-cpu-unit:
     - mkdir build-debug
     - cd build-debug
     - cmake -DCMAKE_BUILD_TYPE=Debug
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       -DMACHINE_VARIANT=mpi
       ../
     - make -j${J}
@@ -79,7 +77,6 @@ parthenon-cuda-short:
     - mkdir build-cuda-perf-mpi
     - cd build-cuda-perf-mpi
     - cmake -DCMAKE_BUILD_TYPE=Release
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       -DMACHINE_VARIANT=cuda-mpi
       ../
     - make -j${J}
@@ -99,7 +96,6 @@ parthenon-cpu-short:
     - mkdir build-perf-mpi
     - cd build-perf-mpi
     - cmake -DCMAKE_BUILD_TYPE=Release
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       -DMACHINE_VARIANT=mpi
       ../
     - make -j${J}
@@ -147,7 +143,6 @@ parthenon-cuda-performance_and_regression-mpi:
     - mkdir -p build-cuda-perf-mpi
     - cd build-cuda-perf-mpi
     - cmake -DCMAKE_BUILD_TYPE=Release
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       -DMACHINE_VARIANT=cuda-mpi
       ../
     - make -j${J}
@@ -201,7 +196,6 @@ parthenon-cpu-performance_and_regression-mpi:
     - cd build-perf-mpi
     - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
       -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root"
       ../
     - make -j${J}
 #    - ctest -L "performance" # no need for performance test as currently none use MPI
@@ -227,7 +221,7 @@ parthenon-cpu-coverage:
     - mkdir build-debug-coverage
     - cd build-debug-coverage
     - cmake -DCMAKE_BUILD_TYPE=Debug
-      -DMPIEXEC_PREFLAGS="--allow-run-as-root" -DCODE_COVERAGE=ON
+      -DCODE_COVERAGE=ON
       -DMACHINE_VARIANT=mpi
       ../ && make -j${J} && make coverage && make coverage-upload
   artifacts:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-[[PR250]] Feature::Restart. If output file format 'rst' is specified restart files are written using independent variables and those marked with Restart metadata flag.  Simulations can be restarted with a '-r \<restartFile\>' argument to the code.
+- [[PR250]](https://github.com/lanl/parthenon/pull/250) Feature::Restart. If output file format 'rst' is specified restart files are written using independent variables and those marked with Restart metadata flag.  Simulations can be restarted with a '-r \<restartFile\>' argument to the code.
+- [[PR 287]]((https://github.com/lanl/parthenon/pull/287) Added machine configuration file for compile options, see [documentation](https://github.com/lanl/parthenon/blob/develop/docs/building.md#default-machine-configurations)
 
 ### Changed (changing behavior/API/variables/...)
 - [\#68](https://github.com/lanl/parthenon/issues/68) Moved default `par_for` wrappers to `MeshBlock` 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,30 @@
 #=========================================================================================
 
 cmake_minimum_required(VERSION 3.12)
+
+# Load machine specific defaults such as architecture and mpi launch command.
+# Command line argument takes precedence over environment variable.
+# Loading this before project definition to allow setting the compiler.
+if (MACHINE_CFG)
+  if(EXISTS "${MACHINE_CFG}")
+    include(${MACHINE_CFG})
+  else()
+    message(FATAL_ERROR "Given machine configuration at "
+      "${MACHINE_CFG} not found.")
+  endif()
+elseif (DEFINED ENV{MACHINE_CFG})
+  if(EXISTS "$ENV{MACHINE_CFG}")
+    include($ENV{MACHINE_CFG})
+  else()
+    message(FATAL_ERROR "Given machine configuration from environment variable "
+      "MACHINE_CFG at $ENV{MACHINE_CFG} not found.")
+  endif()
+else()
+  message(WARNING "Not using any machine configuration. Consider creating a configuration "
+    "file following the examples in ${PROJECT_SOURCE_DIR}/cmake/machine_cfgs/ and then "
+    "point the MACHINE_CFG variable to your custom file.")
+endif()
+
 project(parthenon VERSION 0.1.0 LANGUAGES C CXX)
 
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ elseif (DEFINED ENV{MACHINE_CFG})
 else()
   message(WARNING "Not using any machine configuration. Consider creating a configuration "
     "file following the examples in ${PROJECT_SOURCE_DIR}/cmake/machine_cfgs/ and then "
-    "point the MACHINE_CFG variable to your custom file.")
+    "point the MACHINE_CFG variable to your custom file."
+    "Note, that the machine file can be placed in any directory (also outside the repo).")
 endif()
 
 project(parthenon VERSION 0.1.0 LANGUAGES C CXX)

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -69,16 +69,35 @@ function(setup_test_coverage dir arg)
   endif()
 endfunction()
 
+function(process_mpi_args nproc)
+  list(APPEND TMPARGS "--mpirun")
+  # use custom mpiexec
+  if (TEST_MPIEXEC)
+    list(APPEND TMPARGS "${TEST_MPIEXEC}")
+  # use CMake determined mpiexec
+  else()
+    list(APPEND TMPARGS "${MPIEXEC_EXECUTABLE}")
+  endif()
+  list(APPEND TMPARGS "--mpirun_opts=${MPIEXEC_NUMPROC_FLAG}")
+  list(APPEND TMPARGS "--mpirun_opts=${nproc}")
+  # set additional options from machine configuration
+  foreach(MPIARG ${TEST_MPIOPTS})
+    list(APPEND TMPARGS "--mpirun_opts=${MPIARG}")
+  endforeach()
+
+  # make the result accessible in the calling function
+  set(MPIARGS ${TMPARGS} PARENT_SCOPE)
+endfunction()
+
 # Adds test that will run in parallel with mpi
 # test output will be sent to /tst/regression/outputs/dir_mpi
 # test property labels: regression, mpi-yes
 function(setup_test_mpi nproc dir arg)
   if( MPI_FOUND )
     separate_arguments(arg) 
+    process_mpi_args(${nproc})
     add_test( NAME regression_mpi_test:${dir} COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_test.py
-      --mpirun ${MPIEXEC_EXECUTABLE} 
-      --mpirun_opts=${MPIEXEC_NUMPROC_FLAG} --mpirun_opts=${nproc}
-      --mpirun_opts=${MPIEXEC_PREFLAGS} ${arg}
+      ${MPIARGS} ${arg}
       --test_dir ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}
       --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}_mpi")
     set_tests_properties(regression_mpi_test:${dir} PROPERTIES LABELS "regression;mpi-yes" RUN_SERIAL ON )
@@ -95,11 +114,10 @@ function(setup_test_mpi_coverage nproc dir arg)
   if( MPI_FOUND )
     if( CODE_COVERAGE )
       separate_arguments(arg) 
+      process_mpi_args(${nproc})
       add_test( NAME regression_mpi_coverage_test:${dir} COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/run_test.py
         --coverage
-        --mpirun ${MPIEXEC_EXECUTABLE} 
-        --mpirun_opts=${MPIEXEC_NUMPROC_FLAG} --mpirun_opts=${nproc}
-        --mpirun_opts=${MPIEXEC_PREFLAGS} ${arg}
+        ${MPIARGS} ${arg}
         --test_dir ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/${dir}
         --output_dir "${PROJECT_BINARY_DIR}/tst/regression/outputs/${dir}_mpi_cov"
         )

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -78,7 +78,13 @@ function(process_mpi_args nproc)
   else()
     list(APPEND TMPARGS "${MPIEXEC_EXECUTABLE}")
   endif()
-  list(APPEND TMPARGS "--mpirun_opts=${MPIEXEC_NUMPROC_FLAG}")
+  # use custom numproc flag
+  if (TEST_NUMPROC_FLAG)
+    list(APPEND TMPARGS "--mpirun_opts=${TEST_NUMPROC_FLAG}")
+  # use CMake determined numproc flag
+  else()
+    list(APPEND TMPARGS "--mpirun_opts=${MPIEXEC_NUMPROC_FLAG}")
+  endif()
   list(APPEND TMPARGS "--mpirun_opts=${nproc}")
   # set additional options from machine configuration
   foreach(MPIARG ${TEST_MPIOPTS})

--- a/cmake/machinecfg/CI.cmake
+++ b/cmake/machinecfg/CI.cmake
@@ -15,7 +15,7 @@
 # the public, perform publicly and display publicly, and to permit others to do so.
 #========================================================================================
 
-message(STATUS "Loading machine configuration for default CI machine."
+message(STATUS "Loading machine configuration for default CI machine. "
   "Supported MACHINE_VARIANT includes 'cuda', 'mpi', and 'cuda-mpi'")
 
 # common options
@@ -29,4 +29,8 @@ if (${MACHINE_VARIANT} MATCHES "cuda")
   set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos/bin/nvcc_wrapper CACHE STRING "Use nvcc_wrapper")
 endif()
 
-#set(MACHINE_MPIEXEC srun CACHE STRING "Command to launch MPI applications")
+if (${MACHINE_VARIANT} MATCHES "mpi")
+  # not using the following as the default is determined correctly
+  #set(TEST_MPIEXEC mpiexec CACHE STRING "Command to launch MPI applications")
+  list(APPEND TEST_MPIOPTS "--allow-run-as-root")
+endif()

--- a/cmake/machinecfg/CI.cmake
+++ b/cmake/machinecfg/CI.cmake
@@ -1,0 +1,32 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2020 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+#========================================================================================
+# (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
+message(STATUS "Loading machine configuration for default CI machine."
+  "Supported MACHINE_VARIANT includes 'cuda', 'mpi', and 'cuda-mpi'")
+
+# common options
+set(Kokkos_ARCH_WSM ON CACHE BOOL "CPU architecture")
+set(HDF5_ROOT /usr/local/hdf5/parallel CACHE STRING "HDF5 path")
+
+# variants
+if (${MACHINE_VARIANT} MATCHES "cuda")
+  set(Kokkos_ARCH_PASCAL61 ON CACHE BOOL "GPU architecture")
+  set(Kokkos_ENABLE_CUDA ON CACHE BOOL "Enable Cuda")
+  set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos/bin/nvcc_wrapper CACHE STRING "Use nvcc_wrapper")
+endif()
+
+#set(MACHINE_MPIEXEC srun CACHE STRING "Command to launch MPI applications")

--- a/cmake/machinecfg/Summit.cmake
+++ b/cmake/machinecfg/Summit.cmake
@@ -1,0 +1,37 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2020 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+#========================================================================================
+# (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
+message(STATUS "Loading machine configuration for OLCF's Summit.\n"
+  "Supported MACHINE_VARIANT includes 'cuda', 'mpi', and 'cuda-mpi'\n"
+  "This configuration has been tested using the following modules: "
+  "module load cuda gcc cmake/3.14.2 python hdf5\n")
+
+# common options
+set(Kokkos_ARCH_POWER9 ON CACHE BOOL "CPU architecture")
+
+# variants
+if (${MACHINE_VARIANT} MATCHES "cuda")
+  set(Kokkos_ARCH_VOLTA70 ON CACHE BOOL "GPU architecture")
+  set(Kokkos_ENABLE_CUDA ON CACHE BOOL "Enable Cuda")
+  set(CMAKE_CXX_COMPILER ${CMAKE_CURRENT_SOURCE_DIR}/external/Kokkos/bin/nvcc_wrapper CACHE STRING "Use nvcc_wrapper")
+endif()
+
+if (${MACHINE_VARIANT} MATCHES "mpi")
+  set(TEST_MPIEXEC jsrun CACHE STRING "Command to launch MPI applications")
+  set(TEST_NUMPROC_FLAG "-a" CACHE STRING "Flag to set number of processes")
+  list(APPEND TEST_MPIOPTS "-n" "1" "-g" "6" "-c" "42" "-r" "1" "-d" "packed" "-b" "packed:7" "--smpiargs='-gpu'")
+endif()

--- a/docs/building.md
+++ b/docs/building.md
@@ -134,6 +134,26 @@ export PARTHENON_ROOT=$(pwd)/parthenon
 ```
 We set the latter variable for easier reference in out-of-source builds.
 
+### Default machine configurations
+
+To make the default configuration on widely used systems easier, Parthenon provides machine configuration files that contain default options.
+Defaults options include, but are not limited to setting
+- the compiler (e.g., `nvcc_wrapper` for Cuda builds), or
+- paths to non default package locations (e.g., for a custom HDF5 install), or 
+- custom MPI related commands used in the Parthenon test suite (e.g., the launch command).
+
+The machine configurations shipped with Parthenon are located in [`PARTHENON_ROOT/cmake/machinecfg`](../cmake/machinecfg) and are named by the machine name.
+In order to use them either
+- set the `MACHINE_CFG` environment variable to the appropriate file, or
+- set the `MACHINE_CFG` CMake variable to the appropriate file.
+In addition, you can set the `MACHINE_VARIANT` CMake variable to pick a specific configuration, e.g., one with Cuda and MPI enabled.
+
+We suggest to inspect the corresponding file for available options on a specific machine.
+
+In general, a typical workflow is expected to create your own machine file, e.g., on your develop system.
+We suggest to start with a copy of a machine file that matches closely with your target machine.
+Custom machine files should not be pushed to the main repository.
+
 ### Ubuntu 20.04 LTS
 
 The following procedure has been tested for an Ubuntu 20.04 LTS system:

--- a/docs/building.md
+++ b/docs/building.md
@@ -158,7 +158,7 @@ ctest -L performance
 
 ### OLCF Summit (Power9+Volta)
 
-Last verified 7 Aug 2020.
+Last verified 28 Aug 2020.
 
 #### Common environment
 
@@ -167,7 +167,7 @@ Last verified 7 Aug 2020.
 $ module restore system
 $ module load cuda gcc cmake/3.14.2 python hdf5
 
-# on 7 Aug 2020 that results the following version
+# on 28 Aug 2020 that results the following version
 $ module list
 
 Currently Loaded Modules:
@@ -182,11 +182,16 @@ Currently Loaded Modules:
 # configure and build. Make sure to build in an directory on the GPFS filesystem if you want to run the regression tests because the home directory is not writeable from the compute nodes (which will result in the regression tests failing)
 $ mkdir build-cuda-mpi && cd build-cuda-mpi
 # note that we do not specify the mpicxx wrapper in the following as cmake automatically extracts the required include and linker options
-$ cmake -DKokkos_ARCH_POWER9=ON -DKokkos_ARCH_VOLTA70=True -DKokkos_ENABLE_CUDA=True -DKokkos_ENABLE_OPENMP=True -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=${PARTHENON_ROOT}/external/Kokkos/bin/nvcc_wrapper ${PARTHENON_ROOT}
+$ cmake -DCMAKE_BUILD_TYPE=Release -DMACHINE_CFG=${PARTHENON_ROOT}/cmake/machinecfg/Summit.cmake -DMACHINE_VARIANT=cuda-mpi ${PARTHENON_ROOT}
 $ make -j10
 
-# run all tests (assumes running within a job)
-# NOT WORKING RIGHT NOW
+# The following commands are exepected to be run within job (interactive or scheduled)
+
+# Make sure that GPUs are assigned round robin to MPI processes
+$ export KOKKOS_NUM_DEVICES=6
+
+# run all MPI regression tests
+$ ctest -L regression -LE mpi-no
 
 # manually run a simulation (here using 2 nodes with each 6 GPUs and one MPI process per GPU)
 # note the `--smpiargs="-gpu"` which is required to enable Cuda aware MPI
@@ -200,7 +205,8 @@ $ jsrun -n 2 -a 6 -g 6 -c 42 -r 1 -d packed -b packed:7 --smpiargs="-gpu" exampl
 ```bash
 # configure and build
 $ mkdir build-cuda && cd build-cuda
-$ cmake -DKokkos_ARCH_POWER9=ON -DKokkos_ARCH_VOLTA70=True -DKokkos_ENABLE_CUDA=True -DKokkos_ENABLE_OPENMP=True -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=${PARTHENON_ROOT}/external/Kokkos/bin/nvcc_wrapper -DPARTHENON_DISABLE_MPI=On ${PARTHENON_ROOT}
+$ cmake -DCMAKE_BUILD_TYPE=Release -DMACHINE_CFG=${PARTHENON_ROOT}/cmake/machinecfg/Summit.cma
+ke -DMACHINE_VARIANT=cuda -DPARTHENON_DISABLE_MPI=On ${PARTHENON_ROOT}
 $ make -j10
 
 # run unit tests (assumes running within a job, e.g., via `bsub -W 1:30 -nnodes 1 -P PROJECTID -Is /bin/bash`)

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -21,16 +21,8 @@ from shutil import rmtree
 import subprocess
 from subprocess import PIPE
 import sys
+from shutil import which
 
-# TODO(pgrete) update CI image to Python 3
-def mkdir_p(path):
-    try:
-        os.makedirs(path)
-    except OSError as exc:  # Python >= 2.5
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise
 class Parameters():
     driver_path = ""
     driver_input_path = ""
@@ -156,34 +148,14 @@ class TestManager:
 
         mpi_exec = mpi_executable[0]
 
-        choices=['mpirun', 'mpiexec', 'srun', 'qsub', 'lsrun', 'aprun']
-        sys.stdout.flush()
-        for choice in choices:
-            sys.stdout.flush()
-            if mpi_exec.endswith(choice):
-                sys.stdout.flush()
-                if len(mpi_exec) != len(choice):
-                    sys.stdout.flush()
-                    if os.path.isfile(mpi_exec):
-                        return
-                    else:
-                        error_msg = "mpi executable path provided, but no file found "
-                        error_msg += mpi_exec 
-                        raise TestManagerError(error_msg)
-                else:
-                    return
-
-        error_msg = "Invalid mpi executable specified "
-        error_msg += mpi_exec 
-        error_msg += "\nExpected choices are:"
-        for choice in choices:
-            error_msg += choice
-            error_msg += "\n"
-        raise TestManagerError(error_msg)
+        if which(mpi_exec) is None:
+            error_msg = "mpi executable path provided, but no file found: "
+            error_msg += mpi_exec
+            raise TestManagerError(error_msg)
 
     def MakeOutputFolder(self):
         if not os.path.isdir(self.parameters.output_path):
-            mkdir_p(self.parameters.output_path)
+            os.makedirs(self.parameters.output_path)
 
         os.chdir(self.parameters.output_path)
 


### PR DESCRIPTION
## PR Summary

This implement the machine configuration files we discussed during the talk.
All variables are optional, so this could be seen as reducing the number of arguments when calling cmake from the terminal.
Moreover, I hope the current design is flexible enough to include different configuration by allowing user to simply create their own machine files (hopefully not too convoluted) "variant" handling.

I only added Summit and the CI machine to illustrate how this could be used as a starting point for discussion.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] Code passes cpplint
- [X] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
