### PR TITLE
added weak scaling instructions

### DIFF
--- a/docs/weak_scaling.md
+++ b/docs/weak_scaling.md
@@ -30,7 +30,7 @@ make -j
 
 ### To Run
 
-- Note that if you disabled HDF5 in the previous step, you mest open
+- Note that if you disabled HDF5 in the previous step, you must open
   up the `parthinput.advection` file and comment out all blocks
   beginning with `<parthenon/output*>`.
 

--- a/docs/weak_scaling.md
+++ b/docs/weak_scaling.md
@@ -19,9 +19,10 @@ Running a Weak Scaling Test in Parthenon
 ```bash
 module purge
 module load cmake gcc/7.4.0 cuda/10.2 openmpi/p9/4.0.1-gcc_7.4.0 anaconda/Anaconda3.2019.10
-git clone git@github.com:lanl/parthenon.git
+git clone git@github.com:lanl/parthenon.git --recursive
 cd parthenon
 git checkout develop && git pull
+git submodule update --init --recursive
 mkdir -p bin && cd bin
 cmake -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_POWER9=True -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_VOLTA70=True -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper ..
 make -j

--- a/docs/weak_scaling.md
+++ b/docs/weak_scaling.md
@@ -1,0 +1,65 @@
+Running a Weak Scaling Test in Parthenon
+===
+
+- Here we present how to perform a weak scaling test on a Power9
+  architecture with two Volta GPUs per node.
+  
+- We use the advection test with slightly modified input parameters
+  for performance. AMR is turned on with 3 levels.
+
+- The following procedure was tested on power9 nodes on Darwin by
+  Jonah Miller. However, the same procedure should hold more
+  generically.
+
+### To Build
+
+```bash
+module purge
+module load cmake gcc/7.4.0 cuda/10.2 openmpi/p9/4.0.1-gcc_7.4.0 anaconda/Anaconda3.2019.10
+git clone git@github.com:lanl/parthenon.git
+cd parthenon
+git checkout develop && git pull
+mkdir -p bin && cd bin
+cmake -DPARTHENON_DISABLE_HDF5=ON -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_POWER9=True -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_VOLTA70=True -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper ..
+make -j
+```
+
+### To Run
+
+Place the following in your job script.
+```bash
+N=1
+mpirun -np ${N} ./example/advection/advection-example -i ../example/advection/parthinput.advection parthenon/time/nlim=10 parthenon/mesh/nx1=64 parthenon/mesh/nx2=64 parthenon/mesh/
+nx3=64 parthenon/meshblock/nx1=32 parthenon/meshblock/nx2=32 parthenon/meshblock/nx3=32 | tee ${N}.out
+
+N=2
+mpirun -np ${N} ./example/advection/advection-example -i ../example/advection/parthinput.advection parthenon/time/nlim=10 parthenon/mesh/nx1=128 parthenon/mesh/nx2=64 parthenon/mesh/
+nx3=64 parthenon/meshblock/nx1=32 parthenon/meshblock/nx2=32 parthenon/meshblock/nx3=32 | tee ${N}.out
+
+N=4
+mpirun -np ${N} ./example/advection/advection-example -i ../example/advection/parthinput.advection parthenon/time/nlim=10 parthenon/mesh/nx1=128 parthenon/mesh/nx2=128 parthenon/mesh/
+nx3=64 parthenon/meshblock/nx1=32 parthenon/meshblock/nx2=32 parthenon/meshblock/nx3=32 | tee ${N}.out
+
+N=8
+mpirun -np ${N} ./example/advection/advection-example -i ../example/advection/parthinput.advection parthenon/time/nlim=10 parthenon/mesh/nx1=128 parthenon/mesh/nx2=128 parthenon/mesh/
+nx3=128 parthenon/meshblock/nx1=32 parthenon/meshblock/nx2=32 parthenon/meshblock/nx3=32 | tee ${N}.out
+
+N=16
+mpirun -np ${N} ./example/advection/advection-example -i ../example/advection/parthinput.advection parthenon/time/nlim=10 parthenon/mesh/nx1=256 parthenon/mesh/nx2=128 parthenon/mesh/
+nx3=128 parthenon/meshblock/nx1=32 parthenon/meshblock/nx2=32 parthenon/meshblock/nx3=32 | tee ${N}.out
+
+# and so on
+```
+
+### To get the timing data
+
+- We use the built in instrumentation inside Parthenon, which is stored in the output.
+
+```bash
+filename=timings.dat
+printf "# nprocs\tzone-cycles/cpu-second\n" > ${filename}
+# make sure upper bound on this is log2(Nprocs max)
+for n in {0..4}; do echo $((2**n)) $(grep "zone-cycles/cpu_second = " $((2**n)).out | cut -d "=" -f 2) >> ${filename}; done
+```
+
+You can now load the timings in your favorite plotting program.

--- a/docs/weak_scaling.md
+++ b/docs/weak_scaling.md
@@ -13,6 +13,9 @@ Running a Weak Scaling Test in Parthenon
 
 ### To Build
 
+- Note that depending on your system you may need to disable HDF5 with
+  `-DPARTHENON_DISABLE_HDF5=On`.
+
 ```bash
 module purge
 module load cmake gcc/7.4.0 cuda/10.2 openmpi/p9/4.0.1-gcc_7.4.0 anaconda/Anaconda3.2019.10
@@ -20,13 +23,17 @@ git clone git@github.com:lanl/parthenon.git
 cd parthenon
 git checkout develop && git pull
 mkdir -p bin && cd bin
-cmake -DPARTHENON_DISABLE_HDF5=ON -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_POWER9=True -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_VOLTA70=True -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper ..
+cmake -DCMAKE_BUILD_TYPE=Release -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_POWER9=True -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_VOLTA70=True -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper ..
 make -j
 ```
 
 ### To Run
 
-Place the following in your job script.
+- Note that if you disabled HDF5 in the previous step, you mest open
+  up the `parthinput.advection` file and comment out all blocks
+  beginning with `<parthenon/output*>`.
+
+- Place the following in your job script.
 ```bash
 N=1
 mpirun -np ${N} ./example/advection/advection-example -i ../example/advection/parthinput.advection parthenon/time/nlim=10 parthenon/mesh/nx1=64 parthenon/mesh/nx2=64 parthenon/mesh/

--- a/example/advection/parthinput.advection
+++ b/example/advection/parthinput.advection
@@ -61,13 +61,13 @@ refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
 compute_error = false
 
-# <parthenon/output1>
-# file_type = rst
-# dt = 0.05
-# 
-# <parthenon/output0>
-# file_type = hdf5
-# dt = 0.05
-# variables = advected, one_minus_advected, & # comments are ok
-#             one_minus_advected_sq, & # on every (& characters are ok in comments)
-#             one_minus_sqrt_one_minus_advected_sq # line
+<parthenon/output1>
+file_type = rst
+dt = 0.05
+
+<parthenon/output0>
+file_type = hdf5
+dt = 0.05
+variables = advected, one_minus_advected, & # comments are ok
+            one_minus_advected_sq, & # on every (& characters are ok in comments)
+            one_minus_sqrt_one_minus_advected_sq # line

--- a/example/advection/parthinput.advection
+++ b/example/advection/parthinput.advection
@@ -46,6 +46,7 @@ nx2 = 16
 nx3 = 1
 
 <parthenon/time>
+nlim = -1
 tlim = 1.0
 integrator = rk2
 
@@ -60,13 +61,13 @@ refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
 compute_error = false
 
-<parthenon/output1>
-file_type = rst
-dt = 0.05
-
-<parthenon/output0>
-file_type = hdf5
-dt = 0.05
-variables = advected, one_minus_advected, & # comments are ok
-            one_minus_advected_sq, & # on every (& characters are ok in comments)
-            one_minus_sqrt_one_minus_advected_sq # line
+# <parthenon/output1>
+# file_type = rst
+# dt = 0.05
+# 
+# <parthenon/output0>
+# file_type = hdf5
+# dt = 0.05
+# variables = advected, one_minus_advected, & # comments are ok
+#             one_minus_advected_sq, & # on every (& characters are ok in comments)
+#             one_minus_sqrt_one_minus_advected_sq # line


### PR DESCRIPTION
As per @gshipman 's request, this PR adds documentation for weak scaling the advection test. This also necessitated a tiny change to `parthinput.advection`, where I add `nlim=-1` to the `parthenon/time` block. This doesn't change anything for the regression tests, but it allows `nlim` to be modified on the command line.

I think it's worth documenting this stuff, though maybe it should go into the wiki instead of the docs. Interested in people's thoughts.

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
