### PR TITLE
Add per cycle performance output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,11 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR250]] Feature::Restart. If output file format 'rst' is specified restart files are written using independent variables and those marked with Restart metadata flag.  Simulations can be restarted with a '-r \<restartFile\>' argument to the code.
+- [[PR 250]](https://github.com/lanl/parthenon/pull/250) Feature::Restart. If output file format 'rst' is specified restart files are written using independent variables and those marked with Restart metadata flag.  Simulations can be restarted with a '-r \<restartFile\>' argument to the code.
 - [[PR 263]](https://github.com/lanl/parthenon/pull/263) Added MeshPack, a mechanism for looping over the whole mesh at once within a `Kokkos` kernel. See [documentation](docs/mesh/packing.md)
 - [[PR 267]](https://github.com/lanl/parthenon/pull/267) Introduced TaskRegions and TaskCollections to allow for task launches on multiple blocks.
-- [[PR 287]]((https://github.com/lanl/parthenon/pull/287) Added machine configuration file for compile options, see [documentation](https://github.com/lanl/parthenon/blob/develop/docs/building.md#default-machine-configurations)
+- [[PR 287]](https://github.com/lanl/parthenon/pull/287) Added machine configuration file for compile options, see [documentation](https://github.com/lanl/parthenon/blob/develop/docs/building.md#default-machine-configurations)
+- [[PR 290]](https://github.com/lanl/parthenon/pull/290) Added per cycle performance output diagnostic.
 
 ### Changed (changing behavior/API/variables/...)
 - [\#68](https://github.com/lanl/parthenon/issues/68) Moved default `par_for` wrappers to `MeshBlock` 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,3 +134,7 @@ container iterators, and variable packs.
 ### Index Shape and Index Range
 
 A description of mesh indexing classes [here](mesh/domain.md).
+
+### Input file parameter
+
+An overview of input file parameters [here](input.md)

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -1,0 +1,5 @@
+### List of input file parameters (incomplete)
+
+   |             Option               | Default  | Type   | Description |
+   | -------------------------------: | :------- | :----- | :---------- |
+   | parthenon/time/perf_cycle_offset | 0        | int | Skip the first N cycles when calculating the final performance (e.g., zone-cycles/wall_second). Allows to hide the initialization overhead in Parthenon, which usually takes place in the first cycles when Containers are allocated, etc. | 

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -38,7 +38,7 @@ enum class DriverStatus { complete, timeout, failed };
 class Driver {
  public:
   Driver(ParameterInput *pin, ApplicationInput *app_in, Mesh *pm)
-      : pinput(pin), app_input(app_in), pmesh(pm) {}
+      : pinput(pin), app_input(app_in), pmesh(pm), mbcnt_prev() {}
   virtual DriverStatus Execute() = 0;
   void InitializeOutputs() { pouts = std::make_unique<Outputs>(pmesh, pinput); }
 
@@ -48,10 +48,8 @@ class Driver {
   std::unique_ptr<Outputs> pouts;
 
  protected:
-  clock_t tstart_;
-#ifdef OPENMP_PARALLEL
-  double omp_start_time_;
-#endif
+  Kokkos::Timer timer_cycle, timer_main;
+  std::uint64_t mbcnt_prev;
   virtual void PreExecute();
   virtual void PostExecute();
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -306,7 +306,8 @@ class MeshBlock {
       &InitUserMeshBlockDataDefault;
 
   // functions and variables for automatic load balancing based on timing
-  double cost_, lb_time_;
+  Kokkos::Timer lb_timer;
+  double cost_;
   void ResetTimeMeasurement();
   void StartTimeMeasurement();
   void StopTimeMeasurement();

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -370,11 +370,7 @@ void MeshBlock::ResetTimeMeasurement() {
 
 void MeshBlock::StartTimeMeasurement() {
   if (pmy_mesh->lb_automatic_) {
-#ifdef OPENMP_PARALLEL
-    lb_time_ = omp_get_wtime();
-#else
-    lb_time_ = static_cast<double>(clock());
-#endif
+    lb_timer.reset();
   }
 }
 
@@ -384,12 +380,7 @@ void MeshBlock::StartTimeMeasurement() {
 
 void MeshBlock::StopTimeMeasurement() {
   if (pmy_mesh->lb_automatic_) {
-#ifdef OPENMP_PARALLEL
-    lb_time_ = omp_get_wtime() - lb_time_;
-#else
-    lb_time_ = static_cast<double>(clock()) - lb_time_;
-#endif
-    cost_ += lb_time_;
+    cost_ += lb_timer.seconds();
   }
 }
 

--- a/tst/regression/test_suites/advection_performance/parthinput.advection_performance
+++ b/tst/regression/test_suites/advection_performance/parthinput.advection_performance
@@ -49,6 +49,7 @@ nx3 = 64
 tlim = 1.0
 nlim = 20
 integrator = rk2
+perf_cycle_offset = 2
 
 <Advection>
 cfl = 0.30


### PR DESCRIPTION

## PR Summary

Given allocation and general initialization overhead that in Parthenon often occurs within a Task during the first cycle, the aggregate performance number were often incorrect (when the overhead was significant and/or the runtime generally short).
This PR adds
- performance log/output per cycle
- the option to define how many initial cycles should be skipped in calculating the aggregate final performance number
- and generally gets grid of the #ifdef for picking a timer and now just uses Kokkos timers (closes #102)

Sample output:
```
$ ./example/advection/advection-example -i ../tst/regression/test_suites/advection_performance/parthinput.advection_performance parthenon/mesh/nx1=$MX parthenon/mesh/nx2=$MX parthenon/mesh/nx3=$MX parthenon/meshblock/nx1=$NX parthenon/meshblock/nx2=$NX parthenon/meshblock/nx3=$NX parthenon/time/nlim=10

Setup complete, executing driver...

cycle=0 time=0.0000000000000000e+00 dt=1.1718750000000000e-03 zone-cycles/wsec = 0.00e+00
cycle=1 time=1.1718750000000000e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 7.46e+05
cycle=2 time=2.3437499999999999e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.10e+18
cycle=3 time=3.5156249999999997e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 9.99e+05
cycle=4 time=4.6874999999999998e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06
cycle=5 time=5.8593750000000000e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06
cycle=6 time=7.0312500000000002e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06
cycle=7 time=8.2031250000000003e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06
cycle=8 time=9.3749999999999997e-03 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06
cycle=9 time=1.0546874999999999e-02 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06
cycle=10 time=1.1718749999999998e-02 dt=1.1718750000000000e-03 zone-cycles/wsec = 1.01e+06

Driver completed.
time=1.17e-02 cycle=10
tlim=1.00e+00 nlim=10

walltime used = 1.33e+02
zone-cycles/wallsecond = 1.01e+06
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
