### PR TITLE
Fix broken nightly CI test

### DIFF
--- a/.gitlab-ci-ias.yml
+++ b/.gitlab-ci-ias.yml
@@ -9,9 +9,10 @@ before_script:
     - git submodule init
     - git submodule update
     - export OMP_NUM_THREADS=1
+    - export OMP_PROC_BIND=1
     - export OMP_NESTED=True
     - export CTEST_OUTPUT_ON_FAILURE=1
-    - export J=$(( $(nproc --all) / 4  + 1 )) && echo Using ${J} cores during build
+    - export J=4 && echo Using ${J} cores during build
     - export PATH=${PWD}/opt/cmake-${CMAKE_VER}-Linux-x86_64/bin:$PATH
     - export PATH=${PWD}/opt/openmpi-${OMPI_VER}/bin:$PATH
     - export LD_LIBRARY_PATH=${PWD}/opt/openmpi-${OMPI_VER}/lib:$LD_LIBRARY_PATH

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -194,8 +194,8 @@ parthenon-cpu-performance_and_regression-mpi:
   script:
     - mkdir -p build-perf-mpi
     - cd build-perf-mpi
-    - cmake -DCMAKE_BUILD_TYPE=Release -DHDF5_ROOT=/usr/local/hdf5/parallel
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_WSM=True
+    - cmake -DCMAKE_BUILD_TYPE=Release
+      -DMACHINE_VARIANT=mpi
       ../
     - make -j${J}
 #    - ctest -L "performance" # no need for performance test as currently none use MPI

--- a/cmake/machinecfg/CI.cmake
+++ b/cmake/machinecfg/CI.cmake
@@ -20,7 +20,6 @@ message(STATUS "Loading machine configuration for default CI machine. "
 
 # common options
 set(Kokkos_ARCH_WSM ON CACHE BOOL "CPU architecture")
-set(HDF5_ROOT /usr/local/hdf5/parallel CACHE STRING "HDF5 path")
 
 # variants
 if (${MACHINE_VARIANT} MATCHES "cuda")
@@ -33,4 +32,7 @@ if (${MACHINE_VARIANT} MATCHES "mpi")
   # not using the following as the default is determined correctly
   #set(TEST_MPIEXEC mpiexec CACHE STRING "Command to launch MPI applications")
   list(APPEND TEST_MPIOPTS "--allow-run-as-root")
+  set(HDF5_ROOT /usr/local/hdf5/parallel CACHE STRING "HDF5 path")
+else()
+  set(HDF5_ROOT /usr/local/hdf5/serial CACHE STRING "HDF5 path")
 endif()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I missed the MPI setting and serial HDF5 dir in the machine config causing the nightly tests to fail.
This should be fixed now.

Also the CI performance tests at IAS failed because the build ran out of memory. Reducing the number of parallel build processes fixed the problem in another repo.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented. (does not apply)
- [x] Adds a test for any bugs fixed. Adds tests for new features. (does not apply)
- [x] Code is formatted 
- [X] Changes are summarized in CHANGELOG.md (I don't think it worth mentioning given this is a post-PR fix)
