### PR TITLE
Remove HtoD copies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [[PR 303]](https://github.com/lanl/parthenon/pull/303) Changed `Mesh::BlockList` from a `std::list<MeshBlock>` to a `std::vector<std::shared_ptr<MeshBlock>>`, making `FindMeshBlock` run in constant, rather than linear, time. Loops over `block_list` in application drivers must be cahnged accordingly.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 293]](https://github.com/lanl/parthenon/pull/293) Changed `VariablePack` and related objects to use `ParArray1D` objects instead of `ParArrayND` objects under the hood to reduce the size of the captured objects.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -436,8 +436,27 @@ template <typename T>
 vpack_types::VarList<T>
 Container<T>::MakeList_(const std::vector<MetadataFlag> &flags,
                         std::vector<std::string> &expanded_names) {
-  auto subcontainer = Container(*this, flags);
-  auto vars = subcontainer.MakeList_(expanded_names);
+  vpack_types::VarList<T> vars;
+  for (auto & vpair : varMap_) {
+    auto & var = vpair.second;
+    if (var->metadata().AllFlagsSet(flags)) {
+      vars.push_front(var);
+    }
+  }
+  for (auto &vpair : sparseMap_) {
+    auto & svar = vpair.second;
+    if (svar->metadata().AllFlagsSet(flags)) {
+      auto & varvec = svar->GetVector();
+      for (auto & var : varvec) {
+        vars.push_front(var);
+      }
+    }
+  }
+
+  for (auto &v : vars) {
+    expanded_names.push_back(v->label());
+  }
+
   return vars;
 }
 

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -437,17 +437,17 @@ vpack_types::VarList<T>
 Container<T>::MakeList_(const std::vector<MetadataFlag> &flags,
                         std::vector<std::string> &expanded_names) {
   vpack_types::VarList<T> vars;
-  for (auto & vpair : varMap_) {
-    auto & var = vpair.second;
+  for (auto &vpair : varMap_) {
+    auto &var = vpair.second;
     if (var->metadata().AllFlagsSet(flags)) {
       vars.push_front(var);
     }
   }
   for (auto &vpair : sparseMap_) {
-    auto & svar = vpair.second;
+    auto &svar = vpair.second;
     if (svar->metadata().AllFlagsSet(flags)) {
-      auto & varvec = svar->GetVector();
-      for (auto & var : varvec) {
+      auto &varvec = svar->GetVector();
+      for (auto &var : varvec) {
         vars.push_front(var);
       }
     }

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -21,8 +21,11 @@
 #include <utility>
 #include <vector>
 
+#include <Kokkos_Core.hpp>
+
 #include "interface/metadata.hpp"
 #include "interface/variable.hpp"
+#include "kokkos_abstraction.hpp"
 
 namespace parthenon {
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -145,7 +145,7 @@ void FillVarView(const vpack_types::VarList<T> &vars, PackIndexMap *vmap,
                  ViewOfParArrays<T> &cv, ParArray1D<int> &sparse_assoc) {
   using vpack_types::IndexPair;
 
-  auto host_view = Kokkos::create_mirror_view(Kokkos::HostSpace(),cv);
+  auto host_view = Kokkos::create_mirror_view(Kokkos::HostSpace(), cv);
   auto host_sp = Kokkos::create_mirror_view(Kokkos::HostSpace(), sparse_assoc);
 
   int vindex = 0;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Addresses the issue of explicit async HtoD MemCpy calls that came about because the size of the objects captured in the FluxDivergence kernel exceeded a critical size.  The fix was to move from `ParArrayND` objects to `ParArray1D` objects in VariablePack objects.  This change should be transparent to downstream codes.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
