### PR TITLE
Fix `IndexShape::GetTotal(IndexDomain)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [[PR 276]](https://github.com/lanl/parthenon/pull/276) Decrease required Python version from 3.6 to 3.5.
 - [[PR 283]](https://github.com/lanl/parthenon/pull/283) Change CI to extended nightly develop tests and short push tests.
 - [[PR 282]](https://github.com/lanl/parthenon/pull/282) Integrated meshpack and tasking in pi example
+- [[PR 294]](https://github.com/lanl/parthenon/pull/294) Fix `IndexShape::GetTotal(IndexDomain)` - previously was returning opposite of expected domain result.
 
 ### Removed
 

--- a/src/mesh/domain.hpp
+++ b/src/mesh/domain.hpp
@@ -170,10 +170,10 @@ class IndexShape {
     int total = 1;
     if (domain == IndexDomain::entire) {
       for (int i = 0; i < NDIM; ++i)
-        total *= x_[i].e - x_[i].s + 1;
+        total *= entire_ncells_[i];
     } else {
       for (int i = 0; i < NDIM; ++i)
-        total *= entire_ncells_[i];
+        total *= x_[i].e - x_[i].s + 1;
     }
     return total;
   }

--- a/tst/unit/test_unit_domain.cpp
+++ b/tst/unit/test_unit_domain.cpp
@@ -36,6 +36,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(interior) == 0);
     REQUIRE(shape.ks(interior) == 0);
     REQUIRE(shape.ke(interior) == 0);
+    REQUIRE(shape.GetTotal(interior) == 6);
 
     REQUIRE(shape.is(entire) == 0);
     REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
@@ -43,6 +44,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(entire) == 0);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 0);
+    REQUIRE(shape.GetTotal(entire) == 8);
   }
 
   GIVEN("A 2D Index Shape") {
@@ -57,6 +59,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
     REQUIRE(shape.ks(interior) == 0);
     REQUIRE(shape.ke(interior) == 0);
+    REQUIRE(shape.GetTotal(interior) == 6);
 
     REQUIRE(shape.is(entire) == 0);
     REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
@@ -64,6 +67,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 0);
+    REQUIRE(shape.GetTotal(entire) == 24);
   }
 
   GIVEN("A 3D Index Shape") {
@@ -79,6 +83,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
     REQUIRE(shape.ks(interior) == num_ghost);
     REQUIRE(shape.ke(interior) == num_ghost + nx3 - 1);
+    REQUIRE(shape.GetTotal(interior) == 24);
 
     REQUIRE(shape.is(entire) == 0);
     REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
@@ -86,6 +91,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 2 * num_ghost + nx3 - 1);
+    REQUIRE(shape.GetTotal(entire) == 144);
   }
 
   GIVEN("A 3D Index Shape initialize with vector") {
@@ -102,6 +108,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
     REQUIRE(shape.ks(interior) == num_ghost);
     REQUIRE(shape.ke(interior) == num_ghost + nx3 - 1);
+    REQUIRE(shape.GetTotal(interior) == 24);
 
     REQUIRE(shape.is(entire) == 0);
     REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
@@ -109,6 +116,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 2 * num_ghost + nx3 - 1);
+    REQUIRE(shape.GetTotal(entire) == 144);
   }
 
   GIVEN("A 3D Index Shape 0 dim in nx3") {
@@ -125,6 +133,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
     REQUIRE(shape.ks(interior) == 0);
     REQUIRE(shape.ke(interior) == 0);
+    REQUIRE(shape.GetTotal(interior) == 6);
 
     REQUIRE(shape.is(entire) == 0);
     REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
@@ -132,6 +141,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 0);
+    REQUIRE(shape.GetTotal(entire) == 24);
   }
 }
 

--- a/tst/unit/test_unit_domain.cpp
+++ b/tst/unit/test_unit_domain.cpp
@@ -30,8 +30,8 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nx1, num_ghost);
-    REQUIRE(shape.is(interior) == num_ghost);
-    REQUIRE(shape.ie(interior) == num_ghost + nx1 - 1);
+    REQUIRE(shape.is(interior) == 1);
+    REQUIRE(shape.ie(interior) == 6);
     REQUIRE(shape.js(interior) == 0);
     REQUIRE(shape.je(interior) == 0);
     REQUIRE(shape.ks(interior) == 0);
@@ -39,7 +39,7 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     REQUIRE(shape.GetTotal(interior) == 6);
 
     REQUIRE(shape.is(entire) == 0);
-    REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
+    REQUIRE(shape.ie(entire) == 7);
     REQUIRE(shape.js(entire) == 0);
     REQUIRE(shape.je(entire) == 0);
     REQUIRE(shape.ks(entire) == 0);
@@ -53,18 +53,18 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nx2, nx1, num_ghost);
-    REQUIRE(shape.is(interior) == num_ghost);
-    REQUIRE(shape.ie(interior) == num_ghost + nx1 - 1);
-    REQUIRE(shape.js(interior) == num_ghost);
-    REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
+    REQUIRE(shape.is(interior) == 1);
+    REQUIRE(shape.ie(interior) == 6);
+    REQUIRE(shape.js(interior) == 1);
+    REQUIRE(shape.je(interior) == 1);
     REQUIRE(shape.ks(interior) == 0);
     REQUIRE(shape.ke(interior) == 0);
     REQUIRE(shape.GetTotal(interior) == 6);
 
     REQUIRE(shape.is(entire) == 0);
-    REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
+    REQUIRE(shape.ie(entire) == 7);
     REQUIRE(shape.js(entire) == 0);
-    REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
+    REQUIRE(shape.je(entire) == 2);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 0);
     REQUIRE(shape.GetTotal(entire) == 24);
@@ -77,20 +77,20 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nx3, nx2, nx1, num_ghost);
-    REQUIRE(shape.is(interior) == num_ghost);
-    REQUIRE(shape.ie(interior) == num_ghost + nx1 - 1);
-    REQUIRE(shape.js(interior) == num_ghost);
-    REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
-    REQUIRE(shape.ks(interior) == num_ghost);
-    REQUIRE(shape.ke(interior) == num_ghost + nx3 - 1);
+    REQUIRE(shape.is(interior) == 1);
+    REQUIRE(shape.ie(interior) == 6);
+    REQUIRE(shape.js(interior) == 1);
+    REQUIRE(shape.je(interior) == 1);
+    REQUIRE(shape.ks(interior) == 1);
+    REQUIRE(shape.ke(interior) == 4);
     REQUIRE(shape.GetTotal(interior) == 24);
 
     REQUIRE(shape.is(entire) == 0);
-    REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
+    REQUIRE(shape.ie(entire) == 7);
     REQUIRE(shape.js(entire) == 0);
-    REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
+    REQUIRE(shape.je(entire) == 2);
     REQUIRE(shape.ks(entire) == 0);
-    REQUIRE(shape.ke(entire) == 2 * num_ghost + nx3 - 1);
+    REQUIRE(shape.ke(entire) == 5);
     REQUIRE(shape.GetTotal(entire) == 144);
   }
 
@@ -102,20 +102,20 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nxs, num_ghost);
-    REQUIRE(shape.is(interior) == num_ghost);
-    REQUIRE(shape.ie(interior) == num_ghost + nx1 - 1);
-    REQUIRE(shape.js(interior) == num_ghost);
-    REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
-    REQUIRE(shape.ks(interior) == num_ghost);
-    REQUIRE(shape.ke(interior) == num_ghost + nx3 - 1);
+    REQUIRE(shape.is(interior) == 1);
+    REQUIRE(shape.ie(interior) == 6);
+    REQUIRE(shape.js(interior) == 1);
+    REQUIRE(shape.je(interior) == 1);
+    REQUIRE(shape.ks(interior) == 1);
+    REQUIRE(shape.ke(interior) == 4);
     REQUIRE(shape.GetTotal(interior) == 24);
 
     REQUIRE(shape.is(entire) == 0);
-    REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
+    REQUIRE(shape.ie(entire) == 7);
     REQUIRE(shape.js(entire) == 0);
-    REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
+    REQUIRE(shape.je(entire) == 2);
     REQUIRE(shape.ks(entire) == 0);
-    REQUIRE(shape.ke(entire) == 2 * num_ghost + nx3 - 1);
+    REQUIRE(shape.ke(entire) == 5);
     REQUIRE(shape.GetTotal(entire) == 144);
   }
 
@@ -127,18 +127,18 @@ TEST_CASE("Checking IndexShape indices", "[is,ie,js,je,ks,ke]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nxs, num_ghost);
-    REQUIRE(shape.is(interior) == num_ghost);
-    REQUIRE(shape.ie(interior) == num_ghost + nx1 - 1);
-    REQUIRE(shape.js(interior) == num_ghost);
-    REQUIRE(shape.je(interior) == num_ghost + nx2 - 1);
+    REQUIRE(shape.is(interior) == 1);
+    REQUIRE(shape.ie(interior) == 6);
+    REQUIRE(shape.js(interior) == 1);
+    REQUIRE(shape.je(interior) == 1);
     REQUIRE(shape.ks(interior) == 0);
     REQUIRE(shape.ke(interior) == 0);
     REQUIRE(shape.GetTotal(interior) == 6);
 
     REQUIRE(shape.is(entire) == 0);
-    REQUIRE(shape.ie(entire) == 2 * num_ghost + nx1 - 1);
+    REQUIRE(shape.ie(entire) == 7);
     REQUIRE(shape.js(entire) == 0);
-    REQUIRE(shape.je(entire) == 2 * num_ghost + nx2 - 1);
+    REQUIRE(shape.je(entire) == 2);
     REQUIRE(shape.ks(entire) == 0);
     REQUIRE(shape.ke(entire) == 0);
     REQUIRE(shape.GetTotal(entire) == 24);
@@ -153,11 +153,11 @@ TEST_CASE("Checking IndexShape cell counts", "[ncellsi,ncellsj,ncellsk]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nx1, num_ghost);
-    REQUIRE(shape.ncellsi(interior) == nx1);
+    REQUIRE(shape.ncellsi(interior) == 6);
     REQUIRE(shape.ncellsj(interior) == 1);
     REQUIRE(shape.ncellsk(interior) == 1);
 
-    REQUIRE(shape.ncellsi(entire) == nx1 + 2 * num_ghost);
+    REQUIRE(shape.ncellsi(entire) == 8);
     REQUIRE(shape.ncellsj(entire) == 1);
     REQUIRE(shape.ncellsk(entire) == 1);
   }
@@ -168,12 +168,12 @@ TEST_CASE("Checking IndexShape cell counts", "[ncellsi,ncellsj,ncellsk]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nx2, nx1, num_ghost);
-    REQUIRE(shape.ncellsi(interior) == nx1);
-    REQUIRE(shape.ncellsj(interior) == nx2);
+    REQUIRE(shape.ncellsi(interior) == 6);
+    REQUIRE(shape.ncellsj(interior) == 1);
     REQUIRE(shape.ncellsk(interior) == 1);
 
-    REQUIRE(shape.ncellsi(entire) == nx1 + 2 * num_ghost);
-    REQUIRE(shape.ncellsj(entire) == nx2 + 2 * num_ghost);
+    REQUIRE(shape.ncellsi(entire) == 8);
+    REQUIRE(shape.ncellsj(entire) == 3);
     REQUIRE(shape.ncellsk(entire) == 1);
   }
 
@@ -184,13 +184,13 @@ TEST_CASE("Checking IndexShape cell counts", "[ncellsi,ncellsj,ncellsk]") {
     int num_ghost = 1;
 
     parthenon::IndexShape shape(nx3, nx2, nx1, num_ghost);
-    REQUIRE(shape.ncellsi(interior) == nx1);
-    REQUIRE(shape.ncellsj(interior) == nx2);
-    REQUIRE(shape.ncellsk(interior) == nx3);
+    REQUIRE(shape.ncellsi(interior) == 6);
+    REQUIRE(shape.ncellsj(interior) == 1);
+    REQUIRE(shape.ncellsk(interior) == 4);
 
-    REQUIRE(shape.ncellsi(entire) == nx1 + 2 * num_ghost);
-    REQUIRE(shape.ncellsj(entire) == nx2 + 2 * num_ghost);
-    REQUIRE(shape.ncellsk(entire) == nx3 + 2 * num_ghost);
+    REQUIRE(shape.ncellsi(entire) == 8);
+    REQUIRE(shape.ncellsj(entire) == 3);
+    REQUIRE(shape.ncellsk(entire) == 6);
   }
 
   GIVEN("A 3D Index Shape, check the numbers of cells after initializing with a vector") {
@@ -201,13 +201,13 @@ TEST_CASE("Checking IndexShape cell counts", "[ncellsi,ncellsj,ncellsk]") {
     std::vector<int> nxs = {nx3, nx2, nx1};
 
     parthenon::IndexShape shape(nxs, num_ghost);
-    REQUIRE(shape.ncellsi(interior) == nx1);
-    REQUIRE(shape.ncellsj(interior) == nx2);
-    REQUIRE(shape.ncellsk(interior) == nx3);
+    REQUIRE(shape.ncellsi(interior) == 6);
+    REQUIRE(shape.ncellsj(interior) == 1);
+    REQUIRE(shape.ncellsk(interior) == 4);
 
-    REQUIRE(shape.ncellsi(entire) == nx1 + 2 * num_ghost);
-    REQUIRE(shape.ncellsj(entire) == nx2 + 2 * num_ghost);
-    REQUIRE(shape.ncellsk(entire) == nx3 + 2 * num_ghost);
+    REQUIRE(shape.ncellsi(entire) == 8);
+    REQUIRE(shape.ncellsj(entire) == 3);
+    REQUIRE(shape.ncellsk(entire) == 6);
   }
 
   GIVEN("A 3D Index Shape, check the numbers of cells with 0 dim") {
@@ -218,12 +218,12 @@ TEST_CASE("Checking IndexShape cell counts", "[ncellsi,ncellsj,ncellsk]") {
     std::vector<int> nxs = {nx3, nx2, nx1};
 
     parthenon::IndexShape shape(nxs, num_ghost);
-    REQUIRE(shape.ncellsi(interior) == nx1);
-    REQUIRE(shape.ncellsj(interior) == nx2);
+    REQUIRE(shape.ncellsi(interior) == 6);
+    REQUIRE(shape.ncellsj(interior) == 1);
     REQUIRE(shape.ncellsk(interior) == 1);
 
-    REQUIRE(shape.ncellsi(entire) == nx1 + 2 * num_ghost);
-    REQUIRE(shape.ncellsj(entire) == nx2 + 2 * num_ghost);
+    REQUIRE(shape.ncellsi(entire) == 8);
+    REQUIRE(shape.ncellsj(entire) == 3);
     REQUIRE(shape.ncellsk(entire) == 1);
   }
 }


### PR DESCRIPTION

## PR Summary
The conditional in `IndexDomain::GetTotal` was backwards. This PR adds a test and fixes it.

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented. (N/A)
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
