### PR TITLE
Change AddTask signature slightly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed (changing behavior/API/variables/...)
 - [[PR 303]](https://github.com/lanl/parthenon/pull/303) Changed `Mesh::BlockList` from a `std::list<MeshBlock>` to a `std::vector<std::shared_ptr<MeshBlock>>`, making `FindMeshBlock` run in constant, rather than linear, time. Loops over `block_list` in application drivers must be cahnged accordingly.
+- [[PR 300]](https://github.com/lanl/parthenon/pull/300): Slight changes to `AddTask` function signature. Should not impact typical usages.
 
 ### Fixed (not changing behavior/API/variables/...)
 
@@ -27,7 +28,6 @@ Date: 9/12/2020
 - [\#68](https://github.com/lanl/parthenon/issues/68) Moved default `par_for` wrappers to `MeshBlock` 
 - [[PR 243]](https://github.com/lanl/parthenon/pull/243) Automatically find/check Python version used in regression tests. Bumps CMake minimum version to 3.12
 - [[PR 266]](https://github.com/lanl/parthenon/pull/266): It is no longer necessary to specify Kokkos_ENABLE_OPENMP this is by default enabled, to turn off one can specify PARTHENON_DISABLE_OPENMP.
-- [[PR 300]](https://github.com/lanl/parthenon/pull/300): Slight changes to `AddTask` function signature. Should not impact typical usages.
 
 ### Fixed
 - [[PR 271]](https://github.com/lanl/parthenon/issues/256): Fix setting default CXX standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [\#68](https://github.com/lanl/parthenon/issues/68) Moved default `par_for` wrappers to `MeshBlock` 
 - [[PR 243]](https://github.com/lanl/parthenon/pull/243) Automatically find/check Python version used in regression tests. Bumps CMake minimum version to 3.12
 - [[PR 266]](https://github.com/lanl/parthenon/pull/266): It is no longer necessary to specify Kokkos_ENABLE_OPENMP this is by default enabled, to turn off one can specify PARTHENON_DISABLE_OPENMP.
+- [[PR 300]](https://github.com/lanl/parthenon/pull/300): Slight changes to `AddTask` function signature. Should not impact typical usages.
 
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR 271]](https://github.com/lanl/parthenon/issues/256): Fix setting default CXX standard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Changed (changing behavior/API/variables/...)
 - [[PR 303]](https://github.com/lanl/parthenon/pull/303) Changed `Mesh::BlockList` from a `std::list<MeshBlock>` to a `std::vector<std::shared_ptr<MeshBlock>>`, making `FindMeshBlock` run in constant, rather than linear, time. Loops over `block_list` in application drivers must be cahnged accordingly.
-- [[PR 300]](https://github.com/lanl/parthenon/pull/300): Slight changes to `AddTask` function signature. Should not impact typical usages.
+- [[PR 300]](https://github.com/lanl/parthenon/pull/300): Changes to `AddTask` function signature. Requires re-ordering task dependency argument to front.
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -25,17 +25,17 @@ The `TaskID` class implements methods that allow Parthenon to keep track of task
  TaskCollection tc;
  TaskRegion &tr1 = tc.AddRegion(nmb);
  for (int i = 0; i < nmb; i++) {
-   auto task_id = tr1[i].AddTask(foo, dep, args, blocks[i]);
+   auto task_id = tr1[i].AddTask(dep, foo, args, blocks[i]);
  }
 
  {
    TaskRegion &tr2 = tc.AddRegion(1);
-   auto sync_task = tr2[0].AddTask(bar, dep, args, blocks);
+   auto sync_task = tr2[0].AddTask(dep, bar, args, blocks);
  }
 
  TaskRegion &tr3 = tc.AddRegion(nmb);
  for (int i = 0; i < nmb; i++) {
-     auto task_id = tr3[i].AddTask(foo, dep, args, blocks[i]);
+     auto task_id = tr3[i].AddTask(dep, foo, args, blocks[i]);
  }
  ```
 

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -141,14 +141,14 @@ TaskCollection PiDriver::MakeTasks(T &blocks) {
       TaskID none(0);
       auto pack = PackVariablesOnMesh(partitions[i], "base",
                                       std::vector<std::string>{"in_or_out"});
-      auto get_area = async_region[i].AddTask(ComputeArea, none, pack, areas, i);
+      auto get_area = async_region[i].AddTask(none, ComputeArea, pack, areas, i);
     }
   }
   TaskRegion &sync_region = tc.AddRegion(1);
   {
     TaskID none(0);
     auto accumulate_areas =
-        sync_region[0].AddTask(AccumulateAreas, none, areas, pmesh->packages);
+        sync_region[0].AddTask(none, AccumulateAreas, areas, pmesh->packages);
   }
 
   return tc;

--- a/example/face_fields/face_fields_example.cpp
+++ b/example/face_fields/face_fields_example.cpp
@@ -112,9 +112,10 @@ TaskList FaceFieldExample::MakeTaskList(MeshBlock *pmb) {
   TaskList tl;
   TaskID none(0);
 
-  auto fill_faces = tl.AddTask(FaceFields::fill_faces, none, pmb);
+  auto fill_faces = tl.AddTask(none, FaceFields::fill_faces, pmb);
 
   auto interpolate = tl.AddTask(
+      fill_faces,
       [](MeshBlock *pmb) -> TaskStatus {
         auto &rc = pmb->real_containers.Get();
         parthenon::IndexDomain interior = parthenon::IndexDomain::interior;
@@ -139,9 +140,10 @@ TaskList FaceFieldExample::MakeTaskList(MeshBlock *pmb) {
         }
         return TaskStatus::complete;
       },
-      fill_faces, pmb);
+      pmb);
 
   auto sum = tl.AddTask(
+      interpolate,
       [](MeshBlock *pmb) -> TaskStatus {
         auto &rc = pmb->real_containers.Get();
         parthenon::IndexDomain interior = parthenon::IndexDomain::interior;
@@ -159,7 +161,7 @@ TaskList FaceFieldExample::MakeTaskList(MeshBlock *pmb) {
         }
         return TaskStatus::complete;
       },
-      interpolate, pmb);
+      pmb);
 
   return tl;
 }

--- a/src/tasks/task_list.hpp
+++ b/src/tasks/task_list.hpp
@@ -73,7 +73,7 @@ class TaskList {
   TaskID AddTask(F &&func, TaskID const &dep, Args &&... args) {
     TaskID id(tasks_added_ + 1);
     task_list_.push_back(
-        Task(id, dep, [=, func{std::forward<F>(func)}]() mutable -> TaskStatus {
+        Task(id, dep, [=, func = std::forward<F>(func)]() mutable -> TaskStatus {
           return func(args...);
         }));
     tasks_added_++;

--- a/src/tasks/task_list.hpp
+++ b/src/tasks/task_list.hpp
@@ -70,7 +70,7 @@ class TaskList {
   }
 
   template <class F, class... Args>
-  TaskID AddTask(F &&func, TaskID const &dep, Args &&... args) {
+  TaskID AddTask(TaskID const &dep, F &&func, Args &&... args) {
     TaskID id(tasks_added_ + 1);
     task_list_.push_back(
         Task(id, dep, [=, func = std::forward<F>(func)]() mutable -> TaskStatus {
@@ -83,10 +83,10 @@ class TaskList {
   // overload to add member functions of class T to task list
   // NOTE: we must capture the object pointer
   template <class T, class... Args>
-  TaskID AddTask(TaskStatus (T::*func)(Args...), T *obj, TaskID const &dep,
+  TaskID AddTask(TaskID const &dep, TaskStatus (T::*func)(Args...), T *obj,
                  Args &&... args) {
-    return this->AddTask([=]() mutable -> TaskStatus { return (obj->*func)(args...); },
-                         dep);
+    return this->AddTask(dep,
+                         [=]() mutable -> TaskStatus { return (obj->*func)(args...); });
   }
 
   void Print() {

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -18,6 +18,7 @@
 
 list(APPEND unit_tests_SOURCES
     test_taskid.cpp
+    test_tasklist.cpp
     test_unit_face_variables.cpp
     test_unit_params.cpp
     test_unit_constants.cpp

--- a/tst/unit/test_tasklist.cpp
+++ b/tst/unit/test_tasklist.cpp
@@ -38,7 +38,7 @@ TEST_CASE("Task Object Lifecycle", "[TaskList][AddTask]") {
       track_destruction = obj;
 
       TaskList task_list;
-      task_list.AddTask([obj] { return TaskStatus::complete; }, TaskID{});
+      task_list.AddTask(TaskID{}, [obj] { return TaskStatus::complete; });
 
       // Task objects should still be alive here.
       REQUIRE(!track_destruction.expired());


### PR DESCRIPTION
## PR Summary

- Takes dependency task by const ref
- Makes the member function pointer signature more explicit
- Adds a test for task_list
- Implements member function AddTask using the generic AddTask
- Tries to forward arguments better to reduce copies

The original purpose of this PR was to make it possible to use move-only objects in a Task function, but the `std::function` at the root of the `Task` object throws a wrench into that. Nonetheless, did some clean-up of some things I found along the way.

The reason this came up is that I needed to implement clean-up of the xRage-side task objects.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
