### PR TITLE
make block_list a std::vector instead of a std::list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added (new features/APIs/variables/...)
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 303]](https://github.com/lanl/parthenon/pull/303) Changed `Mesh::BlockList` from a `std::list<MeshBlock>` to a `std::vector<std::shared_ptr<MeshBlock>>`, making `FindMeshBlock` run in constant, rather than linear, time. Loops over `block_list` in application drivers must be cahnged accordingly.
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/docs/mesh/mesh.md
+++ b/docs/mesh/mesh.md
@@ -1,0 +1,20 @@
+# Mesh
+
+The mesh object represents the mesh on a given processor/MPI
+rank. There is one mesh per processor. The `Mesh` object owns all
+`MeshBlock`s on a given processor.
+
+## Looping over MeshBlocks
+
+`MeshBlock`s are stored in a variable `Mesh::block_list`, which is an object of type
+```C++
+using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;
+```
+and so to get the predicted time step for each mesh block, you can call:
+```C++
+for (auto &pmb : pmesh->block_list) {
+    std::cout << pmb->NewDt() << std::endl;
+}
+```
+where `pmesh` is a pointer to a `Mesh` object. This paradigm may appear, 
+for example, in an application driver.

--- a/example/advection/parthenon_app_inputs.cpp
+++ b/example/advection/parthenon_app_inputs.cpp
@@ -92,7 +92,7 @@ void UserWorkAfterLoop(Mesh *mesh, ParameterInput *pin, SimTime &tm) {
   Real l1_err = 0.0;
   Real max_err = 0.0;
 
-  for (auto pmb = mesh->block_list.begin(); pmb != mesh->block_list.end(); pmb++) {
+  for (auto &pmb : mesh->block_list) {
     auto pkg = pmb->packages["advection_package"];
 
     auto rc = pmb->real_containers.Get(); // get base container

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -130,7 +130,8 @@ TaskCollection PiDriver::MakeTasks(T &blocks) {
   int pack_size = pinput->GetOrAddInteger("Pi", "pack_size", 1);
   if (pack_size < 1) pack_size = blocks.size();
 
-  partition::Partition_t<MeshBlock> partitions;
+  // partition::Partition_t<MeshBlock> partitions;
+  std::vector<BlockList_t> partitions;
   partition::ToSizeN(blocks, pack_size, partitions);
   ParArrayHost<Real> areas("areas", partitions.size());
 

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -130,7 +130,6 @@ TaskCollection PiDriver::MakeTasks(T &blocks) {
   int pack_size = pinput->GetOrAddInteger("Pi", "pack_size", 1);
   if (pack_size < 1) pack_size = blocks.size();
 
-  // partition::Partition_t<MeshBlock> partitions;
   std::vector<BlockList_t> partitions;
   partition::ToSizeN(blocks, pack_size, partitions);
   ParArrayHost<Real> areas("areas", partitions.size());

--- a/example/face_fields/face_fields_example.cpp
+++ b/example/face_fields/face_fields_example.cpp
@@ -74,12 +74,12 @@ DriverStatus FaceFieldExample::Execute() {
 
   // post-evolution analysis
   Real rank_sum = 0.0;
-  for (auto &block : pmesh->block_list) {
+  for (auto &pmb : pmesh->block_list) {
     parthenon::IndexDomain const interior = parthenon::IndexDomain::interior;
-    parthenon::IndexRange const ib = block.cellbounds.GetBoundsI(interior);
-    parthenon::IndexRange const jb = block.cellbounds.GetBoundsJ(interior);
-    parthenon::IndexRange const kb = block.cellbounds.GetBoundsK(interior);
-    auto &rc = block.real_containers.Get();
+    parthenon::IndexRange const ib = pmb->cellbounds.GetBoundsI(interior);
+    parthenon::IndexRange const jb = pmb->cellbounds.GetBoundsJ(interior);
+    parthenon::IndexRange const kb = pmb->cellbounds.GetBoundsK(interior);
+    auto &rc = pmb->real_containers.Get();
     auto &summed = rc->Get("c.c.interpolated_sum").data;
     for (int k = kb.s; k <= kb.e; k++) {
       for (int j = jb.s; j <= jb.e; j++) {

--- a/example/kokkos_pi/kokkos_pi.cpp
+++ b/example/kokkos_pi/kokkos_pi.cpp
@@ -160,7 +160,7 @@ static std::list<MeshBlock> setupMesh(const int &n_block, const int &n_mesh,
   // Set up our mesh.
   Metadata myMetadata({Metadata::Independent, Metadata::Cell});
   BlockList_t block_list;
-  block_list.reserve(n_mesh*n_mesh*n_mesh);
+  block_list.reserve(n_mesh * n_mesh * n_mesh);
 
   // compute an offset due to ghost cells
   double delta = dxyzCell * static_cast<Real>(NG);

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -1,4 +1,3 @@
-
 //========================================================================================
 // (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
 //
@@ -39,8 +38,7 @@ void Driver::PostExecute() {
     SignalHandler::CancelWallTimeAlarm();
     // Calculate and print the zone-cycles/cpu-second and wall-second
     std::uint64_t zonecycles =
-        pmesh->mbcnt *
-        static_cast<std::uint64_t>(pmesh->block_list.front().GetNumberOfMeshBlockCells());
+        pmesh->mbcnt * static_cast<std::uint64_t>(pmesh->GetNumberOfMeshBlockCells());
 
     auto wtime = timer_main.seconds();
     std::cout << std::endl << "walltime used = " << wtime << std::endl;
@@ -124,8 +122,8 @@ void EvolutionDriver::PostExecute(DriverStatus status) {
 
 void EvolutionDriver::InitializeBlockTimeSteps() {
   // calculate the first time step
-  for (auto &mb : pmesh->block_list) {
-    mb.SetBlockTimestep(Update::EstimateTimestep(mb.real_containers.Get()));
+  for (auto &pmb : pmesh->block_list) {
+    pmb->SetBlockTimestep(Update::EstimateTimestep(mb.real_containers.Get()));
   }
 }
 
@@ -136,8 +134,8 @@ void EvolutionDriver::InitializeBlockTimeSteps() {
 void EvolutionDriver::SetGlobalTimeStep() {
   Real dt_max = 2.0 * tm.dt;
   tm.dt = std::numeric_limits<Real>::max();
-  for (auto const &mb : pmesh->block_list) {
-    tm.dt = std::min(tm.dt, mb.NewDt());
+  for (auto const &pmb : pmesh->block_list) {
+    tm.dt = std::min(tm.dt, pmb->NewDt());
   }
   tm.dt = std::min(dt_max, tm.dt);
 
@@ -159,8 +157,7 @@ void EvolutionDriver::OutputCycleDiagnostics() {
       if (Globals::my_rank == 0) {
         std::uint64_t zonecycles =
             (pmesh->mbcnt - mbcnt_prev) *
-            static_cast<std::uint64_t>(
-                pmesh->block_list.front().GetNumberOfMeshBlockCells());
+            static_cast<std::uint64_t>(pmesh->GetNumberOfMeshBlockCells());
         std::cout << "cycle=" << tm.ncycle << std::scientific
                   << std::setprecision(dt_precision) << " time=" << tm.time
                   << " dt=" << tm.dt << std::setprecision(2) << " zone-cycles/wsec = "

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -123,7 +123,7 @@ void EvolutionDriver::PostExecute(DriverStatus status) {
 void EvolutionDriver::InitializeBlockTimeSteps() {
   // calculate the first time step
   for (auto &pmb : pmesh->block_list) {
-    pmb->SetBlockTimestep(Update::EstimateTimestep(mb.real_containers.Get()));
+    pmb->SetBlockTimestep(Update::EstimateTimestep(pmb->real_containers.Get()));
   }
 }
 

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -94,8 +94,8 @@ TaskListStatus ConstructAndExecuteBlockTasks(T *driver, Args... args) {
   TaskRegion &tr = tc.AddRegion(nmb);
 
   int i = 0;
-  for (auto &mb : driver->pmesh->block_list) {
-    tr[i++] = driver->MakeTaskList(&mb, std::forward<Args>(args)...);
+  for (auto &pmb : driver->pmesh->block_list) {
+    tr[i++] = driver->MakeTaskList(pmb.get(), std::forward<Args>(args)...);
   }
   TaskListStatus status = tc.Execute();
   return status;

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -188,8 +188,8 @@ void Mesh::CalculateLoadBalance(std::vector<double> const &costlist,
 void Mesh::ResetLoadBalanceVariables() {
   if (lb_automatic_) {
     for (auto &pmb : block_list) {
-      costlist[mb->gid] = TINY_NUMBER;
-      mb->ResetTimeMeasurement();
+      costlist[pmb->gid] = TINY_NUMBER;
+      pmb->ResetTimeMeasurement();
     }
   }
   lb_flag_ = false;

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -599,10 +599,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       int on = newtoold[n];
       if ((ranklist[on] == Globals::my_rank) && (loclist[on].level == newloc[n].level)) {
         // on the same MPI rank and same level -> just move it
-        auto pob = FindMeshBlock(on);
-
-        // Move the block from `block_list` to `new_block_list`
-        new_block_list[n - nbs] = pob;
+        new_block_list[n - nbs] = FindMeshBlock(on);
       } else {
         // on a different refinement level or MPI rank - create a new block
         BoundaryFlag block_bcs[6];

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -592,9 +592,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   {
     RegionSize block_size = GetBlockSize();
 
-    BlockList_t new_block_list;
-    new_block_list.clear();
-    new_block_list.resize(nbe - nbs + 1);
+    BlockList_t new_block_list(nbe - nbs + 1);
     for (int n = nbs; n <= nbe; n++) {
       int on = newtoold[n];
       if ((ranklist[on] == Globals::my_rank) && (loclist[on].level == newloc[n].level)) {

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -187,9 +187,9 @@ void Mesh::CalculateLoadBalance(std::vector<double> const &costlist,
 
 void Mesh::ResetLoadBalanceVariables() {
   if (lb_automatic_) {
-    for (auto &mb : block_list) {
-      costlist[mb.gid] = TINY_NUMBER;
-      mb.ResetTimeMeasurement();
+    for (auto &pmb : block_list) {
+      costlist[mb->gid] = TINY_NUMBER;
+      mb->ResetTimeMeasurement();
     }
   }
   lb_flag_ = false;
@@ -203,12 +203,12 @@ void Mesh::ResetLoadBalanceVariables() {
 void Mesh::UpdateCostList() {
   if (lb_automatic_) {
     double w = static_cast<double>(lb_interval_ - 1) / static_cast<double>(lb_interval_);
-    for (auto &mb : block_list) {
-      costlist[mb.gid] = costlist[mb.gid] * w + mb.cost_;
+    for (auto &pmb : block_list) {
+      costlist[pmb->gid] = costlist[pmb->gid] * w + pmb->cost_;
     }
   } else if (lb_flag_) {
-    for (auto &mb : block_list) {
-      costlist[mb.gid] = mb.cost_;
+    for (auto &pmb : block_list) {
+      costlist[pmb->gid] = pmb->cost_;
     }
   }
 }
@@ -227,9 +227,9 @@ void Mesh::UpdateMeshBlockTree(int &nnew, int &ndel) {
   // count the number of the blocks to be (de)refined
   nref[Globals::my_rank] = 0;
   nderef[Globals::my_rank] = 0;
-  for (auto const &mb : block_list) {
-    if (mb.pmr->refine_flag_ == 1) nref[Globals::my_rank]++;
-    if (mb.pmr->refine_flag_ == -1) nderef[Globals::my_rank]++;
+  for (auto const &pmb : block_list) {
+    if (pmb->pmr->refine_flag_ == 1) nref[Globals::my_rank]++;
+    if (pmb->pmr->refine_flag_ == -1) nderef[Globals::my_rank]++;
   }
 #ifdef MPI_PARALLEL
   MPI_Allgather(MPI_IN_PLACE, 1, MPI_INT, nref.data(), 1, MPI_INT, MPI_COMM_WORLD);
@@ -271,9 +271,9 @@ void Mesh::UpdateMeshBlockTree(int &nnew, int &ndel) {
 
   // collect the locations and costs
   int iref = rdisp[Globals::my_rank], ideref = ddisp[Globals::my_rank];
-  for (auto const &mb : block_list) {
-    if (mb.pmr->refine_flag_ == 1) lref[iref++] = mb.loc;
-    if (mb.pmr->refine_flag_ == -1 && tnderef >= nleaf) lderef[ideref++] = mb.loc;
+  for (auto const &pmb : block_list) {
+    if (pmb->pmr->refine_flag_ == 1) lref[iref++] = pmb->loc;
+    if (pmb->pmr->refine_flag_ == -1 && tnderef >= nleaf) lderef[ideref++] = pmb->loc;
   }
 #ifdef MPI_PARALLEL
   if (tnref > 0) {
@@ -439,9 +439,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   int nbe = nbs + nblist[Globals::my_rank] - 1;
 
 #ifdef MPI_PARALLEL
-  int bnx1 = block_list.front().block_size.nx1;
-  int bnx2 = block_list.front().block_size.nx2;
-  int bnx3 = block_list.front().block_size.nx3;
+  int bnx1 = GetBlockSize().nx1;
+  int bnx2 = GetBlockSize().nx2;
+  int bnx3 = GetBlockSize().nx3;
   // Step 3. count the number of the blocks to be sent / received
   int nsend = 0, nrecv = 0;
   for (int n = nbs; n <= nbe; n++) {
@@ -475,9 +475,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   // pb->pmr->pvars_cc/fc_ v point to the same objects, if adaptive
 
   // int num_cc = block_list.front().pmr->pvars_cc_.size();
-  int num_fc = block_list.front().vars_fc_.size();
+  int num_fc = block_list.front()->vars_fc_.size();
   int nx4_tot = 0;
-  for (auto &pvar_cc : block_list.front().vars_cc_) {
+  for (auto &pvar_cc : block_list.front()->vars_cc_) {
     nx4_tot += pvar_cc->GetDim(4);
   }
 
@@ -590,9 +590,10 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
   // Step 7. construct a new MeshBlock list (moving the data within the MPI rank)
   {
-    RegionSize block_size = block_list.front().block_size;
+    RegionSize block_size = GetBlockSize();
 
-    std::list<MeshBlock> new_block_list;
+    BlockList_t new_block_list;
+    new_block_list.reserve(nbe - nbs + 1);
     for (int n = nbs; n <= nbe; n++) {
       int on = newtoold[n];
       if ((ranklist[on] == Globals::my_rank) && (loclist[on].level == newloc[n].level)) {
@@ -600,7 +601,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         auto const pob = FindMeshBlock(on);
 
         // Move the block from `block_list` to `new_block_list`
-        new_block_list.splice(new_block_list.end(), block_list, pob);
+        new_block_list.push_back(pob);
 
         // pob is now the current block
         pob->gid = n;
@@ -610,24 +611,25 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         BoundaryFlag block_bcs[6];
         SetBlockSizeAndBoundaries(newloc[n], block_size, block_bcs);
         // append new block to list of MeshBlocks
-        new_block_list.emplace_back(n, n - nbs, newloc[n], block_size, block_bcs, this,
-                                    pin, app_in, properties, packages, gflag, true);
+        new_block_list.push_back(std::make_shared<MeshBlock>(
+            n, n - nbs, newloc[n], block_size, block_bcs, this, pin, app_in, properties,
+            packages, gflag, true));
         // fill the conservative variables
         if ((loclist[on].level > newloc[n].level)) { // fine to coarse (f2c)
           for (int ll = 0; ll < nleaf; ll++) {
             if (ranklist[on + ll] != Globals::my_rank) continue;
             // fine to coarse on the same MPI rank (different AMR level) - restriction
             auto pob = FindMeshBlock(on + ll);
-            FillSameRankFineToCoarseAMR(&*pob, &new_block_list.back(), loclist[on + ll]);
+            FillSameRankFineToCoarseAMR(pob.get(), new_block_list.back().get(), loclist[on + ll]);
           }
         } else if ((loclist[on].level < newloc[n].level) && // coarse to fine (c2f)
                    (ranklist[on] == Globals::my_rank)) {
           // coarse to fine on the same MPI rank (different AMR level) - prolongation
           auto pob = FindMeshBlock(on);
-          FillSameRankCoarseToFineAMR(&*pob, &new_block_list.back(), newloc[n]);
+          FillSameRankCoarseToFineAMR(pob.get(), new_block_list.back().get(), newloc[n]);
         }
-        ApplyBoundaryConditions(new_block_list.back().real_containers.Get());
-        FillDerivedVariables::FillDerived(new_block_list.back().real_containers.Get());
+        ApplyBoundaryConditions(new_block_list.back()->real_containers.Get());
+        FillDerivedVariables::FillDerived(new_block_list.back()->real_containers.Get());
       }
     }
 
@@ -689,8 +691,8 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   costlist = std::move(newcost);
 
   // re-initialize the MeshBlocks
-  for (auto &mb : block_list) {
-    mb.pbval->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
+  for (auto &pmb : block_list) {
+    pmb->pbval->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
   }
   Initialize(2, pin, app_in);
 

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -620,7 +620,8 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
             if (ranklist[on + ll] != Globals::my_rank) continue;
             // fine to coarse on the same MPI rank (different AMR level) - restriction
             auto pob = FindMeshBlock(on + ll);
-            FillSameRankFineToCoarseAMR(pob.get(), new_block_list.back().get(), loclist[on + ll]);
+            FillSameRankFineToCoarseAMR(pob.get(), new_block_list.back().get(),
+                                        loclist[on + ll]);
           }
         } else if ((loclist[on].level < newloc[n].level) && // coarse to fine (c2f)
                    (ranklist[on] == Globals::my_rank)) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1122,8 +1122,8 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
 /// the search at.
 std::shared_ptr<MeshBlock> Mesh::FindMeshBlock(int tgid) {
   // Attempt to simply index into the block list.
-  int nbs = block_list[0]->gid;
-  int i = tgid - nbs;
+  const int nbs = block_list[0]->gid;
+  const int i = tgid - nbs;
   PARTHENON_DEBUG_REQUIRE(0 <= i && i < block_list.size(),
                           "MeshBlock local index out of bounds.");
   PARTHENON_DEBUG_REQUIRE(block_list[i]->gid == tgid, "MeshBlock not found!");

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1008,7 +1008,7 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
 #pragma omp parallel for num_threads(nthreads)
       for (int i = 0; i < nmb; ++i) {
         auto &pmb = block_list[i];
-        pmb->ProblemGenerator(pmb, pin);
+        pmb->ProblemGenerator(pmb.get(), pin);
       }
     }
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1117,15 +1117,21 @@ std::shared_ptr<MeshBlock> Mesh::FindMeshBlock(int tgid) {
   // Attempt to simply index into the block list.
   int nbs = nslist[Globals::my_rank];
   int i = tgid - nbs;
-  if (block_list[i]->gid == tgid) {
+  if (0 <= i && i < block_list.size() && block_list[i]->gid == tgid) {
     return block_list[i];
   } else {
     // Fall back to brute force search.
     // TODO(JMM): If I forget to remove the fallback method, yell at me.
-    PARTHENON_WARN("Block not found by simple index! Attempting to search...");
+    // PARTHENON_WARN("Block not found via indexing. Searching...");
     auto it = std::find_if(
         block_list.begin(), block_list.end(),
         [tgid](std::shared_ptr<MeshBlock> const &pmb) { return pmb->gid == tgid; });
+    if (it == block_list.end()) {
+      PARTHENON_THROW("Block not found. tgid,nbs,list_size="
+                      + std::to_string(tgid) + ", " + std::to_string(nbs)
+                      + ", " + std::to_string(block_list.size())
+                      );
+    }
     return *it;
   }
 }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -474,9 +474,10 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Properties_t &properti
   for (int i = nbs; i <= nbe; i++) {
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
     // create a block and add into the link list
-    block_list.emplace_back(i, i - nbs, loclist[i], block_size, block_bcs, this, pin,
-                            app_in, properties, packages, gflag);
-    block_list.back().pbval->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
+    block_list.push_back(std::make_shared<MeshBlock>(i, i - nbs, loclist[i], block_size,
+                                                     block_bcs, this, pin, app_in,
+                                                     properties, packages, gflag));
+    block_list.back()->pbval->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
   }
 
   ResetLoadBalanceVariables();
@@ -733,9 +734,10 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
 
     // create a block and add into the link list
-    block_list.emplace_back(i, i - nbs, this, pin, app_in, properties, packages,
-                            loclist[i], block_size, block_bcs, costlist[i], gflag);
-    block_list.back().pbval->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
+    block_list.push_back(std::make_shared<MeshBlock>(
+        i, i - nbs, this, pin, app_in, properties, packages, loclist[i], block_size,
+        block_bcs, costlist[i], gflag));
+    block_list.back()->pbval->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
   }
 
   ResetLoadBalanceVariables();
@@ -985,8 +987,8 @@ void Mesh::EnrollUserMetric(MetricFunc my_func) {
 // \brief Apply MeshBlock::UserWorkBeforeOutput
 
 void Mesh::ApplyUserWorkBeforeOutput(ParameterInput *pin) {
-  for (auto &mb : block_list) {
-    mb.UserWorkBeforeOutput(pin);
+  for (auto &pmb : block_list) {
+    pmb->UserWorkBeforeOutput(pin);
   }
 }
 
@@ -1001,22 +1003,11 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
   int nthreads = GetNumMeshThreads();
 #endif
   int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
-  std::vector<MeshBlock *> pmb_array;
   do {
-    // initialize a vector of MeshBlock pointers
-    nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
-
-    pmb_array.clear();
-    pmb_array.reserve(nmb);
-
-    for (auto &mb : block_list) {
-      pmb_array.push_back(&mb);
-    }
-
     if (res_flag == 0) {
 #pragma omp parallel for num_threads(nthreads)
       for (int i = 0; i < nmb; ++i) {
-        MeshBlock *pmb = pmb_array[i];
+        auto &pmb = block_list[i];
         pmb->ProblemGenerator(pmb, pin);
       }
     }
@@ -1025,7 +1016,7 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
     // Create send/recv MPI_Requests for all BoundaryData objects
 #pragma omp parallel for num_threads(nthreads)
     for (int i = 0; i < nmb; ++i) {
-      MeshBlock *pmb = pmb_array[i];
+      auto &pmb = block_list[i];
       // BoundaryVariable objects evolved in main TimeIntegratorTaskList:
       pmb->pbval->SetupPersistentMPI();
       pmb->real_containers.Get()->SetupPersistentMPI();
@@ -1037,32 +1028,33 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
       // prepare to receive conserved variables
 #pragma omp for
       for (int i = 0; i < nmb; ++i) {
-        pmb_array[i]->real_containers.Get()->StartReceiving(
+        block_list[i]->real_containers.Get()->StartReceiving(
             BoundaryCommSubset::mesh_init);
       }
       call++; // 2
               // send conserved variables
 #pragma omp for
       for (int i = 0; i < nmb; ++i) {
-        pmb_array[i]->real_containers.Get()->SendBoundaryBuffers();
+        block_list[i]->real_containers.Get()->SendBoundaryBuffers();
       }
       call++; // 3
 
       // wait to receive conserved variables
 #pragma omp for
       for (int i = 0; i < nmb; ++i) {
-        pmb_array[i]->real_containers.Get()->ReceiveAndSetBoundariesWithWait();
+        block_list[i]->real_containers.Get()->ReceiveAndSetBoundariesWithWait();
       }
       call++; // 4
 #pragma omp for
       for (int i = 0; i < nmb; ++i) {
-        pmb_array[i]->real_containers.Get()->ClearBoundary(BoundaryCommSubset::mesh_init);
+        block_list[i]->real_containers.Get()->ClearBoundary(
+            BoundaryCommSubset::mesh_init);
       }
       call++;
       // Now do prolongation, compute primitives, apply BCs
 #pragma omp for
       for (int i = 0; i < nmb; ++i) {
-        auto &pmb = pmb_array[i];
+        auto &pmb = block_list[i];
         auto &pbval = pmb->pbval;
         if (multilevel) pbval->ProlongateBoundaries(0.0, 0.0);
         // TODO(JoshuaSBrown): Dead code left in for possible future extraction of
@@ -1088,7 +1080,7 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
       if (!res_flag && adaptive) {
 #pragma omp for
         for (int i = 0; i < nmb; ++i) {
-          pmb_array[i]->pmr->CheckRefinementCondition();
+          block_list[i]->pmr->CheckRefinementCondition();
         }
       }
     } // omp parallel
@@ -1121,10 +1113,21 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
 
 /// Finds location of a block with ID `tgid`. Can provide an optional "hint" to start
 /// the search at.
-std::list<MeshBlock>::iterator Mesh::FindMeshBlock(int tgid) {
-  // search the rest of the list
-  return std::find_if(block_list.begin(), block_list.end(),
-                      [tgid](MeshBlock const &bl) { return bl.gid == tgid; });
+std::shared_ptr<MeshBlock> Mesh::FindMeshBlock(int tgid) {
+  // Attempt to simply index into the block list.
+  int nbs = nslist[Globals::my_rank];
+  int i = tgid - nbs;
+  if (block_list[i]->gid == tgid) {
+    return block_list[i];
+  } else {
+    // Fall back to brute force search.
+    // TODO(JMM): If I forget to remove the fallback method, yell at me.
+    PARTHENON_WARN("Block not found by simple index! Attempting to search...");
+    auto it = std::find_if(
+        block_list.begin(), block_list.end(),
+        [tgid](std::shared_ptr<MeshBlock> const &pmb) { return pmb->gid == tgid; });
+    return *it;
+  }
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -350,9 +350,7 @@ class Mesh {
   int GetNumberOfMeshBlockCells() const {
     return block_list.front()->GetNumberOfMeshBlockCells();
   }
-  const RegionSize& GetBlockSize() const {
-    return block_list.front()->block_size;
-  }
+  const RegionSize &GetBlockSize() const { return block_list.front()->block_size; }
 
   // data
   bool modified;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -23,7 +23,6 @@
 
 #include <cstdint>
 #include <functional>
-// #include <list>
 #include <map>
 #include <memory>
 #include <string>

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -312,7 +312,7 @@ class MeshBlock {
   void StartTimeMeasurement();
   void StopTimeMeasurement();
 };
-using BlockList_t = std::vector<std::shared_ptd<MeshBlock>>;
+using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;
 
 //----------------------------------------------------------------------------------------
 //! \class Mesh

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -79,7 +79,6 @@ using MeshBlockVarFluxPack = MeshBlockPack<VariableFluxPack<T>>;
 
 // TODO(JMM): Should this be cached?
 namespace mesh_pack_impl {
-using meshpack::BlockList_t;
 
 // TODO(JMM): blocks data type might change
 template <typename T, typename F>

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -29,15 +29,15 @@ static std::string stringXdmfArrayRef(const std::string &prefix,
                                       const std::string &label, const hsize_t *dims,
                                       const int &ndims, const std::string &theType,
                                       const int &precision) {
-  std::string mystr =
-      prefix + R"(<DataItem Format="HDF" Dimensions=")" + std::to_string(dims[0]);
-  for (int i = 1; i < ndims; i++)
-    mystr += " " + std::to_string(dims[i]);
-  mystr += "\" Name=\"" + label + "\"";
-  mystr += " NumberType=\"" + theType + "\"";
-  mystr += R"( Precision=")" + std::to_string(precision) + R"(">)" + '\n';
-  mystr += prefix + "  " + hdfPath + label + "</DataItem>" + '\n';
-  return mystr;
+  //   std::string mystr =
+  //       prefix + R"(<DataItem Format="HDF" Dimensions=")" + std::to_string(dims[0]);
+  //   for (int i = 1; i < ndims; i++)
+  //     mystr += " " + std::to_string(dims[i]);
+  //   mystr += "\" Name=\"" + label + "\"";
+  //   mystr += " NumberType=\"" + theType + "\"";
+  //   mystr += R"( Precision=")" + std::to_string(precision) + R"(">)" + '\n';
+  //   mystr += prefix + "  " + hdfPath + label + "</DataItem>" + '\n';
+  //   return mystr;
 }
 
 static void writeXdmfArrayRef(std::ofstream &fid, const std::string &prefix,
@@ -364,19 +364,20 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
   local_count[0] = num_blocks_local;
   global_count[0] = max_blocks_global;
 
-  LOADVARIABLEALL(tmpData, pm, mb.coords.x1f, out_ib.s, out_ib.e + 1, 0, 0, 0, 0);
+  // These macros are defined in parthenon_hdf5.hpp, which establishes relevant scope
+  LOADVARIABLEALL(tmpData, pm, pmb->coords.x1f, out_ib.s, out_ib.e + 1, 0, 0, 0, 0);
   local_count[1] = global_count[1] = nx1 + 1;
   WRITEH5SLAB("x", tmpData, gLocations, local_start, local_count, global_count,
               property_list);
 
   // write Y coordinates
-  LOADVARIABLEALL(tmpData, pm, mb.coords.x2f, 0, 0, out_jb.s, out_jb.e + 1, 0, 0);
+  LOADVARIABLEALL(tmpData, pm, pmb->coords.x2f, 0, 0, out_jb.s, out_jb.e + 1, 0, 0);
   local_count[1] = global_count[1] = nx2 + 1;
   WRITEH5SLAB("y", tmpData, gLocations, local_start, local_count, global_count,
               property_list);
 
   // write Z coordinates
-  LOADVARIABLEALL(tmpData, pm, mb.coords.x3f, 0, 0, 0, 0, out_kb.s, out_kb.e + 1);
+  LOADVARIABLEALL(tmpData, pm, pmb->coords.x3f, 0, 0, 0, 0, out_kb.s, out_kb.e + 1);
 
   local_count[1] = global_count[1] = nx3 + 1;
   WRITEH5SLAB("z", tmpData, gLocations, local_start, local_count, global_count,

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -134,7 +134,7 @@ void PHDF5Output::genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm) {
   int ndims = 5;
 
   // same set of variables for all grids so use only one container
-  auto ciX = ContainerIterator<Real>(pm->block_list.front().real_containers.Get(),
+  auto ciX = ContainerIterator<Real>(pm->block_list.front()->real_containers.Get(),
                                      output_params.variables);
   for (int ib = 0; ib < pm->nbtotal; ib++) {
     xdmf << "    <Grid GridType=\"Uniform\" Name=\"" << ib << "\">" << std::endl;
@@ -201,7 +201,7 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
   const IndexDomain interior = IndexDomain::interior;
   const IndexDomain entire = IndexDomain::entire;
 
-  auto const &first_block = pm->block_list.front();
+  auto const &first_block = *(pm->block_list.front());
 
   // shooting a blank just for getting the variable names
   IndexRange out_ib = first_block.cellbounds.GetBoundsI(interior);
@@ -323,7 +323,7 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
   status = H5Dclose(myDSet);
 
   // allocate space for largest size variable
-  auto ciX = ContainerIterator<Real>(pm->block_list.front().real_containers.Get(),
+  auto ciX = ContainerIterator<Real>(pm->block_list.front()->real_containers.Get(),
                                      output_params.variables);
   size_t maxV = 1;
   hsize_t sumDim4AllVars = 0;
@@ -429,7 +429,7 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     hsize_t index = 0;
     for (auto &pmb : pm->block_list) { // for every block1
       auto ci =
-          ContainerIterator<Real>(pmb.real_containers.Get(), output_params.variables);
+          ContainerIterator<Real>(pmb->real_containers.Get(), output_params.variables);
       for (auto &v : ci.vars) {
         std::string name = v->label();
         if (name.compare(vWriteName) == 0) {

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -29,15 +29,15 @@ static std::string stringXdmfArrayRef(const std::string &prefix,
                                       const std::string &label, const hsize_t *dims,
                                       const int &ndims, const std::string &theType,
                                       const int &precision) {
-  //   std::string mystr =
-  //       prefix + R"(<DataItem Format="HDF" Dimensions=")" + std::to_string(dims[0]);
-  //   for (int i = 1; i < ndims; i++)
-  //     mystr += " " + std::to_string(dims[i]);
-  //   mystr += "\" Name=\"" + label + "\"";
-  //   mystr += " NumberType=\"" + theType + "\"";
-  //   mystr += R"( Precision=")" + std::to_string(precision) + R"(">)" + '\n';
-  //   mystr += prefix + "  " + hdfPath + label + "</DataItem>" + '\n';
-  //   return mystr;
+  std::string mystr =
+      prefix + R"(<DataItem Format="HDF" Dimensions=")" + std::to_string(dims[0]);
+  for (int i = 1; i < ndims; i++)
+    mystr += " " + std::to_string(dims[i]);
+  mystr += "\" Name=\"" + label + "\"";
+  mystr += " NumberType=\"" + theType + "\"";
+  mystr += R"( Precision=")" + std::to_string(precision) + R"(">)" + '\n';
+  mystr += prefix + "  " + hdfPath + label + "</DataItem>" + '\n';
+  return mystr;
 }
 
 static void writeXdmfArrayRef(std::ofstream &fid, const std::string &prefix,

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -68,7 +68,7 @@ using parthenon::Real;
 #define LOADVARIABLEALL(dst, pm, var, is, ie, js, je, ks, ke)                            \
   {                                                                                      \
     int index = 0;                                                                       \
-    for (auto &mb : pm->block_list) {                                                    \
+    for (auto &pmb : pm->block_list) {                                                   \
       for (int k = ks; k <= ke; k++) {                                                   \
         for (int j = js; j <= je; j++) {                                                 \
           for (int i = is; i <= ie; i++) {                                               \

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -120,7 +120,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) 
 
   const IndexDomain interior = IndexDomain::interior;
 
-  auto &mb = pm->block_list.front();
+  auto &mb = *(pm->block_list.front());
 
   // shooting a blank just for getting the variable names
   const IndexRange out_ib = mb.cellbounds.GetBoundsI(interior);
@@ -323,7 +323,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) 
     global_count[0] = max_blocks_global;
     int i = 0;
     for (auto &pmb : pm->block_list) {
-      auto xmin = pmb.coords.GetXmin();
+      auto xmin = pmb->coords.GetXmin();
       tmpData[i] = xmin[0];
       i++;
       if (pm->ndim > 1) {
@@ -353,9 +353,9 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) 
     global_count[0] = max_blocks_global;
     i = 0;
     for (auto &pmb : pm->block_list) {
-      tmpLoc[i++] = pmb.loc.lx1;
-      tmpLoc[i++] = pmb.loc.lx2;
-      tmpLoc[i++] = pmb.loc.lx3;
+      tmpLoc[i++] = pmb->loc.lx1;
+      tmpLoc[i++] = pmb->loc.lx2;
+      tmpLoc[i++] = pmb->loc.lx3;
     }
     WRITEH5SLABI64("loc.lx123", tmpLoc.data(), gBlocks, local_start, local_count,
                    global_count, property_list);
@@ -368,11 +368,11 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) 
     global_count[0] = max_blocks_global;
     i = 0;
     for (auto &pmb : pm->block_list) {
-      tmpID[i++] = pmb.loc.level;
-      tmpID[i++] = pmb.gid;
-      tmpID[i++] = pmb.lid;
-      tmpID[i++] = pmb.cnghost;
-      tmpID[i++] = pmb.gflag;
+      tmpID[i++] = pmb->loc.level;
+      tmpID[i++] = pmb->gid;
+      tmpID[i++] = pmb->lid;
+      tmpID[i++] = pmb->cnghost;
+      tmpID[i++] = pmb->gflag;
     }
     WRITEH5SLABI32("loc.level-gid-lid-cnghost-gflag", tmpID.data(), gBlocks, local_start,
                    local_count, global_count, property_list);
@@ -414,7 +414,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) 
   for (auto &vwrite : ciX.vars) { // for each variable we write
     const std::string vWriteName = vwrite->label();
     hid_t vLocalSpace, vGlobalSpace;
-    auto &mb = pm->block_list.front();
+    auto &mb = *(pm->block_list.front());
     const hsize_t vlen = vwrite->GetDim(4);
     local_count[4] = global_count[4] = vlen;
     std::vector<Real> tmpData(varSize * vlen * num_blocks_local);
@@ -433,7 +433,7 @@ void RestartOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) 
     for (auto &pmb : pm->block_list) {
       bool found = false;
       auto ci = ContainerIterator<Real>(
-          pmb.real_containers.Get(),
+          pmb->real_containers.Get(),
           {parthenon::Metadata::Independent, parthenon::Metadata::Restart}, true);
       for (auto &v : ci.vars) {
         // Note index 4 transposed to interior

--- a/src/outputs/vtk.cpp
+++ b/src/outputs/vtk.cpp
@@ -71,8 +71,7 @@ void VTKOutput::WriteContainer(SimTime &tm, Mesh *pm, ParameterInput *pin, bool 
   int big_end = IsBigEndian(); // =1 on big endian machine
 
   // Loop over MeshBlocks
-  for (std::list<MeshBlock>::iterator pmb = pm->block_list.begin();
-       pmb != pm->block_list.end(); pmb++) {
+  for (auto &pmb : pm->block_list) {
     // set start/end array indices depending on whether ghost zones are included
     IndexDomain domain = IndexDomain::interior;
     if (output_params.include_ghost_zones) {

--- a/src/parthenon/driver.hpp
+++ b/src/parthenon/driver.hpp
@@ -39,6 +39,7 @@ using namespace ::parthenon::prelude;
 
 using ::parthenon::ApplicationInput;
 using ::parthenon::ApplyBoundaryConditions;
+using ::parthenon::BlockList_t;
 using ::parthenon::Driver;
 using ::parthenon::DriverStatus;
 using ::parthenon::Integrator;

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -195,7 +195,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
   const IndexDomain interior = IndexDomain::interior;
   auto &packages = rm.packages;
   // Get block list and temp array size
-  auto &mb = rm.block_list.front();
+  auto &mb = *(rm.block_list.front());
   int nb = rm.GetNumMeshBlocksThisRank(Globals::my_rank);
   int nbs = mb.gid;
   int nbe = nbs + nb - 1;
@@ -240,7 +240,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     for (auto &pmb : rm.block_list) {
       bool found = false;
       auto cX = ContainerIterator<Real>(
-          pmb.real_containers.Get(),
+          pmb->real_containers.Get(),
           {parthenon::Metadata::Independent, parthenon::Metadata::Restart}, true);
       for (auto &v : cX.vars) {
         if (vName.compare(v->label()) == 0) {

--- a/src/utils/partition_stl_containers.hpp
+++ b/src/utils/partition_stl_containers.hpp
@@ -20,10 +20,11 @@
 
 namespace parthenon {
 namespace partition {
-// TODO(JMM): The templated type safety with T* and T may need to be
-// changed if we move to sufficiently general container objects.
+// Note the interface here has objects in partition are now
+// COPIED, not pointed at.
+// Change is due to using std::shared_ptr<MeshBlock>
 template <typename T>
-using Partition_t = std::vector<std::vector<T *>>;
+using Partition_t = std::vector<std::vector<T>>;
 
 namespace partition_impl {
 // x/y rounded up
@@ -60,7 +61,7 @@ void ToSizeN(Container_t &container, const int N, Partition_t<T> &partitions) {
   int p = 0;
   int b = 0;
   for (auto &element : container) {
-    partitions[p].push_back(&element);
+    partitions[p].push_back(element);
     if (++b >= N) {
       ++p;
       b = 0;

--- a/tst/unit/test_partitioning.cpp
+++ b/tst/unit/test_partitioning.cpp
@@ -36,7 +36,7 @@ inline void check_partitions_even(Partition_t<int> partitions, int nelements, in
   int n_incorrect = 0;
   for (int p = 0; p < partitions.size(); p++) {
     for (int i = 0; i < elements_per_part; i++) {
-      if (*partitions[p][i] != p * elements_per_part + i) {
+      if (partitions[p][i] != p * elements_per_part + i) {
         n_incorrect++;
       }
     }
@@ -156,7 +156,7 @@ TEST_CASE("Check that partitioning a container works", "[Partition]") {
         int n_incorrect = 0;
         for (int p = 0; p < partitions.size() - 1; p++) {
           for (int i = 0; i < elements_per_part; i++) {
-            if (*partitions[p][i] != p * elements_per_part + i) {
+            if (partitions[p][i] != p * elements_per_part + i) {
               n_incorrect++;
             }
           }
@@ -165,7 +165,7 @@ TEST_CASE("Check that partitioning a container works", "[Partition]") {
         AND_THEN("The elements are correct for the final partition") {
           const int p = partitions.size() - 1;
           for (int i = 0; i < leftover; i++) {
-            REQUIRE(*partitions[p][i] == p * elements_per_part + i);
+            REQUIRE(partitions[p][i] == p * elements_per_part + i);
           }
         }
       }
@@ -179,7 +179,7 @@ TEST_CASE("Check that partitioning a container works", "[Partition]") {
         int n_incorrect = 0;
         for (int p = 0; p < partitions.size(); p++) {
           for (int i = 0; i < partitions[p].size(); i++) {
-            if (*partitions[p][i] != *partitions_v2[p][i]) {
+            if (partitions[p][i] != partitions_v2[p][i]) {
               n_incorrect++;
             }
           }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

As we have known for some time (see issue #211), `FindMeshBlock` is slow when there are a large number of meshblocks per core. As @pgrete discovered today, it appears this may be a significant blocking factor when meshblocks are small (i.e., around 16^3 or less). This is an attempt to fix the issue. 

I replace the
```C++
std::list<MeshBlock> block_list;
```
in `Mesh` with
```C++
using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;
BlockList_t block_list;
```
I choose to use a `std::vector` of shared pointers, rather than a `vector` of `MeshBlock`s, for a couple reasons:
1. This avoids the issue @jmstone raised about pointers of objects within a vector not being reliable, because when the vector is appended to, it is re-allocated and the data copied.
2. This avoids the gotcha of attempting to copy meshblocks. The naive thing to do is to copy the shared pointer, which will work fine.
3. This simplifies the logic and typing in `partition_stl_containers.hpp` and `meshblock_pack.hpp`, and saves some ampersands floating around.

I'm not married to this choice of course. If people feel differently, please speak up.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
