### PR TITLE
MeshBlock Cleanup and Smart Backpointers. Resolves #306.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Changed (changing behavior/API/variables/...)
 - [[PR 303]](https://github.com/lanl/parthenon/pull/303) Changed `Mesh::BlockList` from a `std::list<MeshBlock>` to a `std::vector<std::shared_ptr<MeshBlock>>`, making `FindMeshBlock` run in constant, rather than linear, time. Loops over `block_list` in application drivers must be cahnged accordingly.
+- [[PR 307]](https://github.com/lanl/parthenon/pull/307) Changed back-pointers in mesh structure to weak pointers. Cleaned up `MeshBlock` constructor and implemented `MeshBlock` factory function.
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -124,7 +124,7 @@ TaskList AdvectionDriver::MakeTaskList(MeshBlock *pmb, int stage) {
   if (stage == integrator->nstages) {
     auto new_dt = tl.AddTask(
         [](std::shared_ptr<Container<Real>> &rc) {
-          MeshBlock *pmb = rc->pmy_block;
+          auto pmb = rc->pmy_block.lock();
           pmb->SetBlockTimestep(parthenon::Update::EstimateTimestep(rc));
           return TaskStatus::complete;
         },

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -124,7 +124,7 @@ TaskList AdvectionDriver::MakeTaskList(MeshBlock *pmb, int stage) {
   if (stage == integrator->nstages) {
     auto new_dt = tl.AddTask(
         [](std::shared_ptr<Container<Real>> &rc) {
-          auto pmb = rc->pmy_block.lock();
+          auto pmb = rc->GetBlockPointer();
           pmb->SetBlockTimestep(parthenon::Update::EstimateTimestep(rc));
           return TaskStatus::complete;
         },

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -164,7 +164,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 }
 
 AmrTag CheckRefinement(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
   // refine on advected, for example.  could also be a derived quantity
   auto v = rc->Get("advected").data;
 
@@ -196,7 +196,7 @@ AmrTag CheckRefinement(std::shared_ptr<Container<Real>> &rc) {
 
 // demonstrate usage of a "pre" fill derived routine
 void PreFill(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
@@ -216,7 +216,7 @@ void PreFill(std::shared_ptr<Container<Real>> &rc) {
 
 // this is the package registered function to fill derived
 void SquareIt(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
@@ -236,7 +236,7 @@ void SquareIt(std::shared_ptr<Container<Real>> &rc) {
 
 // demonstrate usage of a "post" fill derived routine
 void PostFill(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
@@ -259,7 +259,7 @@ void PostFill(std::shared_ptr<Container<Real>> &rc) {
 
 // provide the routine that estimates a stable timestep for this package
 Real EstimateTimestep(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
   auto pkg = pmb->packages["advection_package"];
   const auto &cfl = pkg->Param<Real>("cfl");
   const auto &vx = pkg->Param<Real>("vx");
@@ -294,7 +294,7 @@ Real EstimateTimestep(std::shared_ptr<Container<Real>> &rc) {
 // some field "advected" that we are pushing around.
 // This routine implements all the "physics" in this example
 TaskStatus CalculateFluxes(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -163,7 +164,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 }
 
 AmrTag CheckRefinement(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
   // refine on advected, for example.  could also be a derived quantity
   auto v = rc->Get("advected").data;
 
@@ -195,7 +196,7 @@ AmrTag CheckRefinement(std::shared_ptr<Container<Real>> &rc) {
 
 // demonstrate usage of a "pre" fill derived routine
 void PreFill(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
@@ -215,7 +216,7 @@ void PreFill(std::shared_ptr<Container<Real>> &rc) {
 
 // this is the package registered function to fill derived
 void SquareIt(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
@@ -235,7 +236,7 @@ void SquareIt(std::shared_ptr<Container<Real>> &rc) {
 
 // demonstrate usage of a "post" fill derived routine
 void PostFill(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
@@ -258,7 +259,7 @@ void PostFill(std::shared_ptr<Container<Real>> &rc) {
 
 // provide the routine that estimates a stable timestep for this package
 Real EstimateTimestep(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
   auto pkg = pmb->packages["advection_package"];
   const auto &cfl = pkg->Param<Real>("cfl");
   const auto &vx = pkg->Param<Real>("vx");
@@ -293,7 +294,7 @@ Real EstimateTimestep(std::shared_ptr<Container<Real>> &rc) {
 // some field "advected" that we are pushing around.
 // This routine implements all the "physics" in this example
 TaskStatus CalculateFluxes(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -36,7 +36,7 @@ using namespace parthenon::package::prelude;
 namespace calculate_pi {
 
 void SetInOrOut(std::shared_ptr<Container<Real>> &rc) {
-  auto pmb = rc->pmy_block.lock();
+  auto pmb = rc->GetBlockPointer();
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -36,7 +36,7 @@ using namespace parthenon::package::prelude;
 namespace calculate_pi {
 
 void SetInOrOut(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  auto pmb = rc->pmy_block.lock();
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
   IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior);

--- a/example/kokkos_pi/kokkos_pi.cpp
+++ b/example/kokkos_pi/kokkos_pi.cpp
@@ -179,7 +179,7 @@ static BlockList_t setupMesh(const int &n_block, const int &n_mesh, const double
         h_xyz(2, idx) = dxyzCell * (static_cast<Real>(k_mesh * n_block) + 0.5) - delta;
         // Add variable for in_or_out
         auto &base = pmb->real_containers.Get();
-        base->setBlock(pmb);
+        base->SetBlockPointer(pmb);
         base->Add("in_or_out", myMetadata);
       }
     }

--- a/example/kokkos_pi/kokkos_pi.cpp
+++ b/example/kokkos_pi/kokkos_pi.cpp
@@ -179,7 +179,7 @@ static BlockList_t setupMesh(const int &n_block, const int &n_mesh, const double
         h_xyz(2, idx) = dxyzCell * (static_cast<Real>(k_mesh * n_block) + 0.5) - delta;
         // Add variable for in_or_out
         auto &base = pmb->real_containers.Get();
-        base->setBlock(pmb.get());
+        base->setBlock(pmb);
         base->Add("in_or_out", myMetadata);
       }
     }

--- a/src/bvals/boundary_conditions.cpp
+++ b/src/bvals/boundary_conditions.cpp
@@ -23,7 +23,7 @@
 namespace parthenon {
 
 TaskStatus ApplyBoundaryConditions(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
   const IndexDomain interior = IndexDomain::interior;
   const IndexDomain entire = IndexDomain::entire;
   IndexRange ib = pmb->cellbounds.GetBoundsI(interior);

--- a/src/bvals/boundary_conditions.cpp
+++ b/src/bvals/boundary_conditions.cpp
@@ -23,7 +23,7 @@
 namespace parthenon {
 
 TaskStatus ApplyBoundaryConditions(std::shared_ptr<Container<Real>> &rc) {
-  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = rc->GetBlockPointer();
   const IndexDomain interior = IndexDomain::interior;
   const IndexDomain entire = IndexDomain::entire;
   IndexRange ib = pmb->cellbounds.GetBoundsI(interior);

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -46,9 +46,11 @@ namespace parthenon {
 // BoundaryValues constructor (the first object constructed inside the MeshBlock()
 // constructor): sets functions for the appropriate boundary conditions at each of the 6
 // dirs of a MeshBlock
-BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
+BoundaryValues::BoundaryValues(std::weak_ptr<MeshBlock> wpmb, BoundaryFlag *input_bcs,
                                ParameterInput *pin)
-    : BoundaryBase(pmb->pmy_mesh, pmb->loc, pmb->block_size, input_bcs), pmy_block_(pmb) {
+    : BoundaryBase(wpmb.lock()->pmy_mesh, wpmb.lock()->loc, wpmb.lock()->block_size,
+                   input_bcs),
+      pmy_block_(wpmb) {
   // Check BC functions for each of the 6 boundaries in turn ---------------------
   for (int i = 0; i < 6; i++) {
     switch (block_bcs[i]) {
@@ -66,6 +68,7 @@ BoundaryValues::BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs,
   CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x1], CoordinateDirection::X1DIR);
   CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x1], CoordinateDirection::X1DIR);
 
+  std::shared_ptr<MeshBlock> pmb;
   if (pmb->block_size.nx2 > 1) {
     nface_ = 4;
     nedge_ = 4;

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -68,7 +68,7 @@ BoundaryValues::BoundaryValues(std::weak_ptr<MeshBlock> wpmb, BoundaryFlag *inpu
   CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x1], CoordinateDirection::X1DIR);
   CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x1], CoordinateDirection::X1DIR);
 
-  std::shared_ptr<MeshBlock> pmb;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   if (pmb->block_size.nx2 > 1) {
     nface_ = 4;
     nedge_ = 4;

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -68,7 +68,7 @@ BoundaryValues::BoundaryValues(std::weak_ptr<MeshBlock> wpmb, BoundaryFlag *inpu
   CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x1], CoordinateDirection::X1DIR);
   CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x1], CoordinateDirection::X1DIR);
 
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   if (pmb->block_size.nx2 > 1) {
     nface_ = 4;
     nedge_ = 4;

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -98,7 +98,8 @@ class BoundaryBase {
 class BoundaryValues : public BoundaryBase, // public BoundaryPhysics,
                        public BoundaryCommunication {
  public:
-  BoundaryValues(MeshBlock *pmb, BoundaryFlag *input_bcs, ParameterInput *pin);
+  BoundaryValues(std::weak_ptr<MeshBlock> pmb, BoundaryFlag *input_bcs,
+                 ParameterInput *pin);
 
   // variable-length arrays of references to BoundaryVariable instances
   // containing all BoundaryVariable instances:
@@ -128,8 +129,9 @@ class BoundaryValues : public BoundaryBase, // public BoundaryPhysics,
   int AdvanceCounterPhysID(int num_phys);
 
  private:
-  MeshBlock *pmy_block_; // ptr to MeshBlock containing this BoundaryValues
-  int nface_, nedge_;    // used only in fc/flux_correction_fc.cpp calculations
+  // ptr to MeshBlock containing this BoundaryValues
+  std::weak_ptr<MeshBlock> pmy_block_;
+  int nface_, nedge_; // used only in fc/flux_correction_fc.cpp calculations
 
   // if a BoundaryPhysics or user fn should be applied at each MeshBlock boundary
   // false --> e.g. block, polar, periodic boundaries

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -28,6 +28,7 @@
 #include "bvals/bvals_interfaces.hpp"
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 
@@ -150,6 +151,14 @@ class BoundaryValues : public BoundaryBase, // public BoundaryPhysics,
                                             int sk, int ek);
   void ProlongateGhostCells(const NeighborBlock &nb, int si, int ei, int sj, int ej,
                             int sk, int ek);
+
+  /// Returns shared pointer to a block
+  std::shared_ptr<MeshBlock> GetBlockPointer() {
+    if (pmy_block_.expired()) {
+      PARTHENON_THROW("Invalid pointer to MeshBlock!");
+    }
+    return pmy_block_.lock();
+  }
 
   // temporary--- Added by @tomidakn on 2015-11-27 in f0f989f85f
   // TODO(KGF): consider removing this friendship designation

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -30,6 +30,7 @@
 
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 
@@ -274,6 +275,14 @@ class BoundaryVariable : public BoundaryCommunication, public BoundaryBuffer {
   // ptr to MeshBlock containing this BoundaryVariable
   std::weak_ptr<MeshBlock> pmy_block_;
   Mesh *pmy_mesh_;
+
+  /// Returns shared pointer to a block
+  std::shared_ptr<MeshBlock> GetBlockPointer() {
+    if (pmy_block_.expired()) {
+      PARTHENON_THROW("Invalid pointer to MeshBlock!");
+    }
+    return pmy_block_.lock();
+  }
 
   void CopyVariableBufferSameProcess(NeighborBlock &nb, int ssize);
   void CopyFluxCorrectionBufferSameProcess(NeighborBlock &nb, int ssize);

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -22,6 +22,7 @@
 // TODO(felker): deduplicate forward declarations
 // TODO(felker): consider moving enums and structs in a new file? bvals_structs.hpp?
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -250,7 +251,7 @@ class BoundaryBuffer {
 
 class BoundaryVariable : public BoundaryCommunication, public BoundaryBuffer {
  public:
-  explicit BoundaryVariable(MeshBlock *pmb);
+  explicit BoundaryVariable(std::weak_ptr<MeshBlock> pmb);
   virtual ~BoundaryVariable() = default;
 
   // (usuallly the std::size_t unsigned integer type)
@@ -270,7 +271,8 @@ class BoundaryVariable : public BoundaryCommunication, public BoundaryBuffer {
   BoundaryData<> bd_var_, bd_var_flcor_;
   // derived class dtors are also responsible for calling DestroyBoundaryData(bd_var_)
 
-  MeshBlock *pmy_block_; // ptr to MeshBlock containing this BoundaryVariable
+  // ptr to MeshBlock containing this BoundaryVariable
+  std::weak_ptr<MeshBlock> pmy_block_;
   Mesh *pmy_mesh_;
 
   void CopyVariableBufferSameProcess(NeighborBlock &nb, int ssize);

--- a/src/bvals/bvals_refine.cpp
+++ b/src/bvals/bvals_refine.cpp
@@ -75,7 +75,7 @@ namespace parthenon {
 // (automatically switches back to conserved variables at the end of fn)
 
 void BoundaryValues::ProlongateBoundaries(const Real time, const Real dt) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   int &mylevel = pmb->loc.level;
 
   // This hardcoded technique is also used to manually specify the coupling between
@@ -202,7 +202,7 @@ void BoundaryValues::ProlongateBoundaries(const Real time, const Real dt) {
 
 void BoundaryValues::RestrictGhostCellsOnSameLevel(const NeighborBlock &nb, int nk,
                                                    int nj, int ni) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   MeshRefinement *pmr = pmb->pmr.get();
 
   const IndexDomain interior = IndexDomain::interior;
@@ -294,7 +294,7 @@ void BoundaryValues::ApplyPhysicalBoundariesOnCoarseLevel(const NeighborBlock &n
 
 void BoundaryValues::ProlongateGhostCells(const NeighborBlock &nb, int si, int ei, int sj,
                                           int ej, int sk, int ek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &pmr = pmb->pmr;
 
   for (auto cc_pair : pmr->pvars_cc_) {

--- a/src/bvals/bvals_refine.cpp
+++ b/src/bvals/bvals_refine.cpp
@@ -75,7 +75,7 @@ namespace parthenon {
 // (automatically switches back to conserved variables at the end of fn)
 
 void BoundaryValues::ProlongateBoundaries(const Real time, const Real dt) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int &mylevel = pmb->loc.level;
 
   // This hardcoded technique is also used to manually specify the coupling between
@@ -202,7 +202,7 @@ void BoundaryValues::ProlongateBoundaries(const Real time, const Real dt) {
 
 void BoundaryValues::RestrictGhostCellsOnSameLevel(const NeighborBlock &nb, int nk,
                                                    int nj, int ni) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   MeshRefinement *pmr = pmb->pmr.get();
 
   const IndexDomain interior = IndexDomain::interior;
@@ -294,7 +294,7 @@ void BoundaryValues::ApplyPhysicalBoundariesOnCoarseLevel(const NeighborBlock &n
 
 void BoundaryValues::ProlongateGhostCells(const NeighborBlock &nb, int si, int ei, int sj,
                                           int ej, int sk, int ek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &pmr = pmb->pmr;
 
   for (auto cc_pair : pmr->pvars_cc_) {

--- a/src/bvals/bvals_var.cpp
+++ b/src/bvals/bvals_var.cpp
@@ -41,7 +41,7 @@ BoundaryVariable::BoundaryVariable(std::weak_ptr<MeshBlock> pmb)
 //  \brief Initialize BoundaryData structure
 
 void BoundaryVariable::InitBoundaryData(BoundaryData<> &bd, BoundaryQuantity type) {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   NeighborIndexes *ni = pmb->pbval->ni;
   int cng = pmb->cnghost;
   int size = 0;
@@ -138,7 +138,7 @@ void BoundaryVariable::CopyFluxCorrectionBufferSameProcess(NeighborBlock &nb, in
 //  \brief Send boundary buffers of variables
 
 void BoundaryVariable::SendBoundaryBuffers() {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   int mylevel = pmb->loc.level;
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
@@ -173,7 +173,7 @@ void BoundaryVariable::SendBoundaryBuffers() {
 bool BoundaryVariable::ReceiveBoundaryBuffers() {
   bool bflag = true;
 
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
     if (bd_var_.flag[nb.bufid] == BoundaryStatus::arrived) continue;
@@ -204,7 +204,7 @@ bool BoundaryVariable::ReceiveBoundaryBuffers() {
 //  \brief set the boundary data
 
 void BoundaryVariable::SetBoundaries() {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   int mylevel = pmb->loc.level;
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
@@ -226,7 +226,7 @@ void BoundaryVariable::SetBoundaries() {
 //  \brief receive and set the boundary data for initialization
 
 void BoundaryVariable::ReceiveAndSetBoundariesWithWait() {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   int mylevel = pmb->loc.level;
   pmb->exec_space.fence();
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {

--- a/src/bvals/cc/bvals_cc.cpp
+++ b/src/bvals/cc/bvals_cc.cpp
@@ -81,7 +81,7 @@ CellCenteredBoundaryVariable::~CellCenteredBoundaryVariable() {
 
 int CellCenteredBoundaryVariable::ComputeVariableBufferSize(const NeighborIndexes &ni,
                                                             int cng) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int cng1, cng2, cng3;
   cng1 = cng;
   cng2 = cng * (pmb->block_size.nx2 > 1 ? 1 : 0);
@@ -106,7 +106,7 @@ int CellCenteredBoundaryVariable::ComputeVariableBufferSize(const NeighborIndexe
 
 int CellCenteredBoundaryVariable::ComputeFluxCorrectionBufferSize(
     const NeighborIndexes &ni, int cng) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int size = 0;
   if (ni.ox1 != 0)
     size = (pmb->block_size.nx2 + 1) / 2 * (pmb->block_size.nx3 + 1) / 2 * (nu_ + 1);
@@ -125,7 +125,7 @@ int CellCenteredBoundaryVariable::ComputeFluxCorrectionBufferSize(
 
 int CellCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &buf,
                                                               const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
 
   IndexDomain interior = IndexDomain::interior;
@@ -152,7 +152,7 @@ int CellCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &
 
 int CellCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &buf,
                                                               const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
   int cn = NGHOST - 1;
 
@@ -180,7 +180,7 @@ int CellCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &
 
 int CellCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &buf,
                                                             const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
   int cn = pmb->cnghost - 1;
 
@@ -241,7 +241,7 @@ int CellCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &bu
 
 void CellCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
                                                         const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
 
   const IndexShape &cellbounds = pmb->cellbounds;
@@ -277,7 +277,7 @@ void CellCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
 
 void CellCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
                                                           const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
   int cng = pmb->cnghost;
 
@@ -324,7 +324,7 @@ void CellCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
 
 void CellCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
                                                         const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   // receive already restricted data
   int si, sj, sk, ei, ej, ek;
 
@@ -401,7 +401,7 @@ void CellCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
 
 void CellCenteredBoundaryVariable::SetupPersistentMPI() {
 #ifdef MPI_PARALLEL
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int &mylevel = pmb->loc.level;
 
   int cng, cng1, cng2, cng3;
@@ -482,7 +482,7 @@ void CellCenteredBoundaryVariable::SetupPersistentMPI() {
 
 void CellCenteredBoundaryVariable::StartReceiving(BoundaryCommSubset phase) {
 #ifdef MPI_PARALLEL
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int mylevel = pmb->loc.level;
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
@@ -499,7 +499,7 @@ void CellCenteredBoundaryVariable::StartReceiving(BoundaryCommSubset phase) {
 }
 
 void CellCenteredBoundaryVariable::ClearBoundary(BoundaryCommSubset phase) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
     bd_var_.flag[nb.bufid] = BoundaryStatus::waiting;

--- a/src/bvals/cc/bvals_cc.cpp
+++ b/src/bvals/cc/bvals_cc.cpp
@@ -139,7 +139,7 @@ int CellCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &
   int p = 0;
 
   ParArray4D<Real> var_cc_ = var_cc.Get<4>(); // automatic template deduction fails
-  BufferUtility::PackData(var_cc_, buf, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(var_cc_, buf, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   return p;
 }
@@ -169,7 +169,8 @@ int CellCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &
   pmb->pmr->RestrictCellCenteredValues(var_cc, coarse_buf, nl_, nu_, si, ei, sj, ej, sk,
                                        ek);
   ParArray4D<Real> coarse_buf_ = coarse_buf.Get<4>(); // auto template deduction fails
-  BufferUtility::PackData(coarse_buf_, buf, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(coarse_buf_, buf, nl_, nu_, si, ei, sj, ej, sk, ek, p,
+                          pmb.get());
   return p;
 }
 
@@ -230,7 +231,7 @@ int CellCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &bu
 
   int p = 0;
   ParArray4D<Real> var_cc_ = var_cc.Get<4>(); // auto template deduction fails
-  BufferUtility::PackData(var_cc_, buf, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(var_cc_, buf, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb.get());
   return p;
 }
 
@@ -267,7 +268,7 @@ void CellCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
   int p = 0;
 
   ParArray4D<Real> var_cc_ = var_cc.Get<4>(); // automatic template deduction fails
-  BufferUtility::UnpackData(buf, var_cc_, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, var_cc_, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb.get());
 }
 
 //----------------------------------------------------------------------------------------
@@ -314,7 +315,8 @@ void CellCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
 
   int p = 0;
   ParArray4D<Real> coarse_buf_ = coarse_buf.Get<4>(); // auto template deduction fails
-  BufferUtility::UnpackData(buf, coarse_buf_, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, coarse_buf_, nl_, nu_, si, ei, sj, ej, sk, ek, p,
+                            pmb.get());
 }
 
 //----------------------------------------------------------------------------------------
@@ -396,7 +398,7 @@ void CellCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
 
   int p = 0;
   ParArray4D<Real> var_cc_ = var_cc.Get<4>(); // automatic template deduction fails
-  BufferUtility::UnpackData(buf, var_cc_, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, var_cc_, nl_, nu_, si, ei, sj, ej, sk, ek, p, pmb.get());
 }
 
 void CellCenteredBoundaryVariable::SetupPersistentMPI() {

--- a/src/bvals/cc/bvals_cc.hpp
+++ b/src/bvals/cc/bvals_cc.hpp
@@ -20,6 +20,8 @@
 //  \brief handle boundaries for any ParArrayND type variable that represents a physical
 //         quantity indexed along / located around cell-centers
 
+#include <memory>
+
 #include "parthenon_mpi.hpp"
 
 #include "bvals/bvals.hpp"
@@ -33,7 +35,7 @@ namespace parthenon {
 
 class CellCenteredBoundaryVariable : public BoundaryVariable {
  public:
-  CellCenteredBoundaryVariable(MeshBlock *pmb, ParArrayND<Real> var,
+  CellCenteredBoundaryVariable(std::weak_ptr<MeshBlock> pmb, ParArrayND<Real> var,
                                ParArrayND<Real> coarse_var, ParArrayND<Real> *var_flux);
   ~CellCenteredBoundaryVariable();
 

--- a/src/bvals/cc/flux_correction_cc.cpp
+++ b/src/bvals/cc/flux_correction_cc.cpp
@@ -44,7 +44,7 @@ namespace parthenon {
 //  \brief Restrict, pack and send the surface flux to the coarse neighbor(s)
 
 void CellCenteredBoundaryVariable::SendFluxCorrection() {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
 
@@ -198,7 +198,7 @@ void CellCenteredBoundaryVariable::SendFluxCorrection() {
 //  \brief Receive and apply the surface flux from the finer neighbor(s)
 
 bool CellCenteredBoundaryVariable::ReceiveFluxCorrection() {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   bool bflag = true;
 
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {

--- a/src/bvals/cc/flux_correction_cc.cpp
+++ b/src/bvals/cc/flux_correction_cc.cpp
@@ -44,7 +44,7 @@ namespace parthenon {
 //  \brief Restrict, pack and send the surface flux to the coarse neighbor(s)
 
 void CellCenteredBoundaryVariable::SendFluxCorrection() {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
 
@@ -198,7 +198,7 @@ void CellCenteredBoundaryVariable::SendFluxCorrection() {
 //  \brief Receive and apply the surface flux from the finer neighbor(s)
 
 bool CellCenteredBoundaryVariable::ReceiveFluxCorrection() {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   bool bflag = true;
 
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {

--- a/src/bvals/fc/bvals_fc.cpp
+++ b/src/bvals/fc/bvals_fc.cpp
@@ -193,7 +193,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &
     else if (nb.ni.ox1 < 0) si--;
   }
   ParArray3D<Real> x1f = (*var_fc).x1f.Get<3>();
-  BufferUtility::PackData(x1f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x1f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx2
   if      (nb.ni.ox1 == 0)      si = ib.s,              ei = ib.e;
@@ -210,7 +210,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &
     else if (nb.ni.ox2 < 0) sj--;
   }
   ParArray3D<Real> x2f = (*var_fc).x2f.Get<3>();
-  BufferUtility::PackData(x2f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x2f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx3
   if      (nb.ni.ox2 == 0)      sj = jb.s,              ej = jb.e;
@@ -228,7 +228,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &
   }
   // clang-format on
   ParArray3D<Real> x3f = (*var_fc).x3f.Get<3>();
-  BufferUtility::PackData(x3f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x3f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   return p;
 }
@@ -275,7 +275,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &
   }
   pmr->RestrictFieldX1((*var_fc).x1f, coarse_buf.x1f, si, ei, sj, ej, sk, ek);
   ParArray3D<Real> x1f = coarse_buf.x1f.Get<3>();
-  BufferUtility::PackData(x1f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x1f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx2
   // clang-format off
@@ -299,7 +299,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &
       coarse_buf.x2f(sk, sj + 1, i) = coarse_buf.x2f(sk, sj, i);
   }
   ParArray3D<Real> x2f = coarse_buf.x2f.Get<3>();
-  BufferUtility::PackData(x2f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x2f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx3
   // clang-format off
@@ -325,7 +325,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &
     }
   }
   ParArray3D<Real> x3f = coarse_buf.x3f.Get<3>();
-  BufferUtility::PackData(x3f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x3f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   return p;
 }
@@ -407,7 +407,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &bu
   }
 
   ParArray3D<Real> x1f = (*var_fc).x1f.Get<3>();
-  BufferUtility::PackData(x1f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x1f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx2
   if (nb.ni.ox1 == 0) {
@@ -444,7 +444,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &bu
   }
 
   ParArray3D<Real> x2f = (*var_fc).x2f.Get<3>();
-  BufferUtility::PackData(x2f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x2f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx3
   if (nb.ni.ox2 == 0) {
@@ -491,7 +491,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &bu
   }
 
   ParArray3D<Real> x3f = (*var_fc).x3f.Get<3>();
-  BufferUtility::PackData(x3f, buf, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::PackData(x3f, buf, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   return p;
 }
@@ -538,7 +538,7 @@ void FaceCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x1f = (*var_fc).x1f.Get<3>();
-  BufferUtility::UnpackData(buf, x1f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x1f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx2
   if (nb.ni.ox1 == 0)
@@ -564,7 +564,7 @@ void FaceCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x2f = (*var_fc).x2f.Get<3>();
-  BufferUtility::UnpackData(buf, x2f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x2f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   if (pmb->block_size.nx2 == 1) { // 1D
 #pragma omp simd
@@ -596,7 +596,7 @@ void FaceCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x3f = (*var_fc).x3f.Get<3>();
-  BufferUtility::UnpackData(buf, x3f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x3f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   if (pmb->block_size.nx3 == 1) { // 1D or 2D
     for (int j = sj; j <= ej; ++j) {
@@ -668,7 +668,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x1f = coarse_buf.x1f.Get<3>();
-  BufferUtility::UnpackData(buf, x1f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x1f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx2
   if (nb.ni.ox1 == 0) {
@@ -699,7 +699,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x2f = coarse_buf.x2f.Get<3>();
-  BufferUtility::UnpackData(buf, x2f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x2f, si, ei, sj, ej, sk, ek, p, pmb.get());
   if (pmb->block_size.nx2 == 1) { // 1D
 #pragma omp simd
     for (int i = si; i <= ei; ++i)
@@ -737,7 +737,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x3f = coarse_buf.x3f.Get<3>();
-  BufferUtility::UnpackData(buf, x3f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x3f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   if (pmb->block_size.nx3 == 1) { // 2D
     for (int j = sj; j <= ej; ++j) {
@@ -826,7 +826,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
     sk = cellbounds.ks(interior) - NGHOST, ek = cellbounds.ks(interior) - 1;
   }
   ParArray3D<Real> x1f = (*var_fc).x1f.Get<3>();
-  BufferUtility::UnpackData(buf, x1f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x1f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   // bx2
   if (nb.ni.ox1 == 0) {
@@ -872,7 +872,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x2f = (*var_fc).x2f.Get<3>();
-  BufferUtility::UnpackData(buf, x2f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x2f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   if (pmb->block_size.nx2 == 1) { // 1D
 #pragma omp simd
@@ -933,7 +933,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
   }
 
   ParArray3D<Real> x3f = (*var_fc).x3f.Get<3>();
-  BufferUtility::UnpackData(buf, x3f, si, ei, sj, ej, sk, ek, p, pmb);
+  BufferUtility::UnpackData(buf, x3f, si, ei, sj, ej, sk, ek, p, pmb.get());
 
   if (pmb->block_size.nx3 == 1) { // 1D or 2D
     for (int j = sj; j <= ej; ++j) {

--- a/src/bvals/fc/bvals_fc.cpp
+++ b/src/bvals/fc/bvals_fc.cpp
@@ -67,7 +67,7 @@ FaceCenteredBoundaryVariable::~FaceCenteredBoundaryVariable() {
 
 int FaceCenteredBoundaryVariable::ComputeVariableBufferSize(const NeighborIndexes &ni,
                                                             int cng) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int nx1 = pmb->block_size.nx1;
   int nx2 = pmb->block_size.nx2;
   int nx3 = pmb->block_size.nx3;
@@ -124,7 +124,7 @@ int FaceCenteredBoundaryVariable::ComputeVariableBufferSize(const NeighborIndexe
 
 int FaceCenteredBoundaryVariable::ComputeFluxCorrectionBufferSize(
     const NeighborIndexes &ni, int cng) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int nx1 = pmb->block_size.nx1;
   int nx2 = pmb->block_size.nx2;
   int nx3 = pmb->block_size.nx3;
@@ -166,7 +166,7 @@ int FaceCenteredBoundaryVariable::ComputeFluxCorrectionBufferSize(
 
 int FaceCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &buf,
                                                               const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
   int p = 0;
 
@@ -241,7 +241,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferSameLevel(ParArray1D<Real> &
 
 int FaceCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &buf,
                                                               const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &pmr = pmb->pmr;
   int si, sj, sk, ei, ej, ek;
   int cng = NGHOST;
@@ -337,7 +337,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToCoarser(ParArray1D<Real> &
 
 int FaceCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &buf,
                                                             const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int nx1 = pmb->block_size.nx1;
   int nx2 = pmb->block_size.nx2;
   int nx3 = pmb->block_size.nx3;
@@ -503,7 +503,7 @@ int FaceCenteredBoundaryVariable::LoadBoundaryBufferToFiner(ParArray1D<Real> &bu
 
 void FaceCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
                                                         const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
 
   int p = 0;
@@ -616,7 +616,7 @@ void FaceCenteredBoundaryVariable::SetBoundarySameLevel(ParArray1D<Real> &buf,
 
 void FaceCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
                                                           const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int si, sj, sk, ei, ej, ek;
   int cng = pmb->cnghost;
   int p = 0;
@@ -756,7 +756,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromCoarser(ParArray1D<Real> &buf,
 
 void FaceCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
                                                         const NeighborBlock &nb) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   // receive already restricted data
   int si, sj, sk, ei, ej, ek;
   int p = 0;
@@ -946,7 +946,7 @@ void FaceCenteredBoundaryVariable::SetBoundaryFromFiner(ParArray1D<Real> &buf,
 }
 
 void FaceCenteredBoundaryVariable::CountFineEdges() {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int &mylevel = pmb->loc.level;
 
   // count the number of the fine meshblocks contacting on each edge
@@ -1011,7 +1011,7 @@ void FaceCenteredBoundaryVariable::SetupPersistentMPI() {
   CountFineEdges();
 
 #ifdef MPI_PARALLEL
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int nx1 = pmb->block_size.nx1;
   int nx2 = pmb->block_size.nx2;
   int nx3 = pmb->block_size.nx3;
@@ -1181,7 +1181,7 @@ void FaceCenteredBoundaryVariable::SetupPersistentMPI() {
 void FaceCenteredBoundaryVariable::StartReceiving(BoundaryCommSubset phase) {
   if (phase == BoundaryCommSubset::all) recv_flx_same_lvl_ = true;
 #ifdef MPI_PARALLEL
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int mylevel = pmb->loc.level;
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
@@ -1204,7 +1204,7 @@ void FaceCenteredBoundaryVariable::StartReceiving(BoundaryCommSubset phase) {
 
 void FaceCenteredBoundaryVariable::ClearBoundary(BoundaryCommSubset phase) {
   // Clear non-polar boundary communications
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   for (int n = 0; n < pmb->pbval->nneighbor; n++) {
     NeighborBlock &nb = pmb->pbval->neighbor[n];
     bd_var_.flag[nb.bufid] = BoundaryStatus::waiting;

--- a/src/bvals/fc/bvals_fc.hpp
+++ b/src/bvals/fc/bvals_fc.hpp
@@ -20,6 +20,8 @@
 //  \brief handle boundaries for any FaceField type variable that represents a physical
 //         quantity indexed along / located around face-centers of cells
 
+#include <memory>
+
 #include "parthenon_mpi.hpp"
 
 #include "bvals/bvals.hpp"
@@ -31,8 +33,8 @@ namespace parthenon {
 
 class FaceCenteredBoundaryVariable : public BoundaryVariable {
  public:
-  FaceCenteredBoundaryVariable(MeshBlock *pmb, FaceField *var, FaceField &coarse_buf,
-                               EdgeField &var_flux);
+  FaceCenteredBoundaryVariable(std::weak_ptr<MeshBlock> pmb, FaceField *var,
+                               FaceField &coarse_buf, EdgeField &var_flux);
   ~FaceCenteredBoundaryVariable();
 
   // may want to rebind var_fc to b, b1, b2, etc. Hence ptr member, not reference

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -708,7 +708,7 @@ void Container<T>::calcArrDims_(std::array<int, 6> &arrDims, const std::vector<i
     // direction, NOT the size of the arrays
     assert(N >= 0 && N <= 3);
     const IndexDomain entire = IndexDomain::entire;
-    std::shared_ptr<MeshBlock> pmb = pmy_block.lock();
+    std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
     arrDims[0] = pmb->cellbounds.ncellsi(entire);
     arrDims[1] = pmb->cellbounds.ncellsj(entire);
     arrDims[2] = pmb->cellbounds.ncellsk(entire);

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -708,9 +708,10 @@ void Container<T>::calcArrDims_(std::array<int, 6> &arrDims, const std::vector<i
     // direction, NOT the size of the arrays
     assert(N >= 0 && N <= 3);
     const IndexDomain entire = IndexDomain::entire;
-    arrDims[0] = pmy_block->cellbounds.ncellsi(entire);
-    arrDims[1] = pmy_block->cellbounds.ncellsj(entire);
-    arrDims[2] = pmy_block->cellbounds.ncellsk(entire);
+    std::shared_ptr<MeshBlock> pmb = pmy_block.lock();
+    arrDims[0] = pmb->cellbounds.ncellsi(entire);
+    arrDims[1] = pmb->cellbounds.ncellsj(entire);
+    arrDims[2] = pmb->cellbounds.ncellsk(entire);
     for (int i = 0; i < N; i++)
       arrDims[i + 3] = dims[i];
     for (int i = N; i < 3; i++)

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -45,7 +45,7 @@ class Container {
   //-----------------
   // Public Variables
   //-----------------
-  MeshBlock *pmy_block = nullptr; // ptr to MeshBlock
+  std::weak_ptr<MeshBlock> pmy_block;
 
   //-----------------
   // Public Methods
@@ -71,7 +71,7 @@ class Container {
 
   ///
   /// Set the pointer to the mesh block for this container
-  void setBlock(MeshBlock *pmb) { pmy_block = pmb; }
+  void setBlock(std::weak_ptr<MeshBlock> pmb) { pmy_block = pmb; }
 
   ///
   /// Allocate and add a variable<T> to the container

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -22,6 +22,7 @@
 #include "interface/sparse_variable.hpp"
 #include "interface/variable.hpp"
 #include "interface/variable_pack.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 
@@ -43,11 +44,6 @@ template <typename T>
 class Container {
  public:
   //-----------------
-  // Public Variables
-  //-----------------
-  std::weak_ptr<MeshBlock> pmy_block;
-
-  //-----------------
   // Public Methods
   //-----------------
   /// Constructor
@@ -59,6 +55,14 @@ class Container {
   Container<T>(const Container<T> &src, const std::vector<std::string> &names,
                const std::vector<int> sparse_ids = {});
   Container<T>(const Container<T> &src, const std::vector<MetadataFlag> &flags);
+
+  /// Returns shared pointer to a block
+  std::shared_ptr<MeshBlock> GetBlockPointer() {
+    if (pmy_block.expired()) {
+      PARTHENON_THROW("Invalid pointer to MeshBlock!");
+    }
+    return pmy_block.lock();
+  }
 
   /// We can initialize a container with slices from a different
   /// container.  For variables that have the sparse tag, this will
@@ -72,6 +76,9 @@ class Container {
   ///
   /// Set the pointer to the mesh block for this container
   void setBlock(std::weak_ptr<MeshBlock> pmb) { pmy_block = pmb; }
+  void setBlock(const std::shared_ptr<Container<T>> &other) {
+    pmy_block = other->GetBlockPointer();
+  }
 
   ///
   /// Allocate and add a variable<T> to the container
@@ -304,6 +311,7 @@ class Container {
 
  private:
   int debug = 0;
+  std::weak_ptr<MeshBlock> pmy_block;
 
   CellVariableVector<T> varVector_; ///< the saved variable array
   FaceVector<T> faceVector_;        ///< the saved face arrays

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -75,8 +75,8 @@ class Container {
 
   ///
   /// Set the pointer to the mesh block for this container
-  void setBlock(std::weak_ptr<MeshBlock> pmb) { pmy_block = pmb; }
-  void setBlock(const std::shared_ptr<Container<T>> &other) {
+  void SetBlockPointer(std::weak_ptr<MeshBlock> pmb) { pmy_block = pmb; }
+  void SetBlockPointer(const std::shared_ptr<Container<T>> &other) {
     pmy_block = other->GetBlockPointer();
   }
 

--- a/src/interface/container_collection.cpp
+++ b/src/interface/container_collection.cpp
@@ -31,7 +31,7 @@ void ContainerCollection<T>::Add(const std::string &name,
   }
 
   auto c = std::make_shared<Container<T>>();
-  c->pmy_block = src->pmy_block;
+  c->setBlock(src);
   for (auto v : src->GetCellVariableVector()) {
     if (v->IsSet(Metadata::OneCopy)) {
       // just copy the (shared) pointer

--- a/src/interface/container_collection.cpp
+++ b/src/interface/container_collection.cpp
@@ -31,7 +31,7 @@ void ContainerCollection<T>::Add(const std::string &name,
   }
 
   auto c = std::make_shared<Container<T>>();
-  c->setBlock(src);
+  c->SetBlockPointer(src);
   for (auto v : src->GetCellVariableVector()) {
     if (v->IsSet(Metadata::OneCopy)) {
       // just copy the (shared) pointer

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -29,7 +29,7 @@ namespace Update {
 
 TaskStatus FluxDivergence(std::shared_ptr<Container<Real>> &in,
                           std::shared_ptr<Container<Real>> &dudt_cont) {
-  std::shared_ptr<MeshBlock> pmb = in->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = in->GetBlockPointer();
 
   const IndexDomain interior = IndexDomain::interior;
   IndexRange ib = pmb->cellbounds.GetBoundsI(interior);
@@ -67,7 +67,7 @@ TaskStatus FluxDivergence(std::shared_ptr<Container<Real>> &in,
 void UpdateContainer(std::shared_ptr<Container<Real>> &in,
                      std::shared_ptr<Container<Real>> &dudt_cont, const Real dt,
                      std::shared_ptr<Container<Real>> &out) {
-  std::shared_ptr<MeshBlock> pmb = in->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = in->GetBlockPointer();
 
   auto vin = in->PackVariables({Metadata::Independent});
   auto vout = out->PackVariables({Metadata::Independent});
@@ -84,7 +84,7 @@ void UpdateContainer(std::shared_ptr<Container<Real>> &in,
 
 void AverageContainers(std::shared_ptr<Container<Real>> &c1,
                        std::shared_ptr<Container<Real>> &c2, const Real wgt1) {
-  std::shared_ptr<MeshBlock> pmb = c1->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = c1->GetBlockPointer();
   const IndexDomain interior = IndexDomain::interior;
   IndexRange ib = pmb->cellbounds.GetBoundsI(interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(interior);
@@ -103,7 +103,7 @@ void AverageContainers(std::shared_ptr<Container<Real>> &c1,
 }
 
 Real EstimateTimestep(std::shared_ptr<Container<Real>> &rc) {
-  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = rc->GetBlockPointer();
   Real dt_min = std::numeric_limits<Real>::max();
   for (auto &pkg : pmb->packages) {
     auto &desc = pkg.second;
@@ -130,7 +130,7 @@ TaskStatus FillDerivedVariables::FillDerived(std::shared_ptr<Container<Real>> &r
   if (pre_package_fill_ != nullptr) {
     pre_package_fill_(rc);
   }
-  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = rc->GetBlockPointer();
   for (auto &pkg : pmb->packages) {
     auto &desc = pkg.second;
     if (desc->FillDerived != nullptr) {

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -29,7 +29,7 @@ namespace Update {
 
 TaskStatus FluxDivergence(std::shared_ptr<Container<Real>> &in,
                           std::shared_ptr<Container<Real>> &dudt_cont) {
-  MeshBlock *pmb = in->pmy_block;
+  std::shared_ptr<MeshBlock> pmb = in->pmy_block.lock();
 
   const IndexDomain interior = IndexDomain::interior;
   IndexRange ib = pmb->cellbounds.GetBoundsI(interior);
@@ -67,7 +67,7 @@ TaskStatus FluxDivergence(std::shared_ptr<Container<Real>> &in,
 void UpdateContainer(std::shared_ptr<Container<Real>> &in,
                      std::shared_ptr<Container<Real>> &dudt_cont, const Real dt,
                      std::shared_ptr<Container<Real>> &out) {
-  MeshBlock *pmb = in->pmy_block;
+  std::shared_ptr<MeshBlock> pmb = in->pmy_block.lock();
 
   auto vin = in->PackVariables({Metadata::Independent});
   auto vout = out->PackVariables({Metadata::Independent});
@@ -84,7 +84,7 @@ void UpdateContainer(std::shared_ptr<Container<Real>> &in,
 
 void AverageContainers(std::shared_ptr<Container<Real>> &c1,
                        std::shared_ptr<Container<Real>> &c2, const Real wgt1) {
-  MeshBlock *pmb = c1->pmy_block;
+  std::shared_ptr<MeshBlock> pmb = c1->pmy_block.lock();
   const IndexDomain interior = IndexDomain::interior;
   IndexRange ib = pmb->cellbounds.GetBoundsI(interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(interior);
@@ -103,7 +103,7 @@ void AverageContainers(std::shared_ptr<Container<Real>> &c1,
 }
 
 Real EstimateTimestep(std::shared_ptr<Container<Real>> &rc) {
-  MeshBlock *pmb = rc->pmy_block;
+  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
   Real dt_min = std::numeric_limits<Real>::max();
   for (auto &pkg : pmb->packages) {
     auto &desc = pkg.second;
@@ -130,7 +130,8 @@ TaskStatus FillDerivedVariables::FillDerived(std::shared_ptr<Container<Real>> &r
   if (pre_package_fill_ != nullptr) {
     pre_package_fill_(rc);
   }
-  for (auto &pkg : rc->pmy_block->packages) {
+  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  for (auto &pkg : pmb->packages) {
     auto &desc = pkg.second;
     if (desc->FillDerived != nullptr) {
       desc->FillDerived(rc);

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -46,8 +46,8 @@ std::string CellVariable<T>::info() {
 
 // copy constructor
 template <typename T>
-std::shared_ptr<CellVariable<T>> CellVariable<T>::AllocateCopy(const bool allocComms,
-                                                               MeshBlock *pmb) {
+std::shared_ptr<CellVariable<T>>
+CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wpmb) {
   std::array<int, 6> dims = {GetDim(1), GetDim(2), GetDim(3),
                              GetDim(4), GetDim(5), GetDim(6)};
 
@@ -62,7 +62,7 @@ std::shared_ptr<CellVariable<T>> CellVariable<T>::AllocateCopy(const bool allocC
 
   if (IsSet(Metadata::FillGhost)) {
     if (allocComms) {
-      cv->allocateComms(pmb);
+      cv->allocateComms(wpmb);
     } else {
       // set data pointer for the boundary communication
       // Note that vbvar->var_cc will be set when stage is selected
@@ -73,8 +73,7 @@ std::shared_ptr<CellVariable<T>> CellVariable<T>::AllocateCopy(const bool allocC
         cv->flux[i] = flux[i];
       }
 
-      // These members are pointers,
-      // point at same memory as src
+      // These members are pointers,      // point at same memory as src
       cv->coarse_s = coarse_s;
     }
   }
@@ -84,7 +83,7 @@ std::shared_ptr<CellVariable<T>> CellVariable<T>::AllocateCopy(const bool allocC
 /// allocate communication space based on info in MeshBlock
 /// Initialize a 6D variable
 template <typename T>
-void CellVariable<T>::allocateComms(MeshBlock *pmb) {
+void CellVariable<T>::allocateComms(std::weak_ptr<MeshBlock> wpmb) {
   // set up fluxes
   std::string base_name = label();
   if (IsSet(Metadata::Independent)) {
@@ -98,7 +97,9 @@ void CellVariable<T>::allocateComms(MeshBlock *pmb) {
                                   GetDim(3), GetDim(2), GetDim(1));
   }
 
-  if (!pmb) return;
+  if (wpmb.expired()) return;
+
+  std::shared_ptr<MeshBlock> pmb = wpmb.lock();
 
   if (pmb->pmy_mesh->multilevel)
     coarse_s = ParArrayND<T>(base_name + ".coarse", GetDim(6), GetDim(5), GetDim(4),

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -58,7 +58,7 @@ class CellVariable {
 
   // make a new CellVariable based on an existing one
   std::shared_ptr<CellVariable<T>> AllocateCopy(const bool allocComms = false,
-                                                MeshBlock *pmb = nullptr);
+                                                std::weak_ptr<MeshBlock> wpmb = {});
 
   // accessors
 
@@ -82,7 +82,7 @@ class CellVariable {
   std::string info();
 
   /// allocate communication space based on info in MeshBlock
-  void allocateComms(MeshBlock *pmb);
+  void allocateComms(std::weak_ptr<MeshBlock> wpmb);
 
   /// Repoint vbvar's var_cc array at the current variable
   void resetBoundary() { vbvar->var_cc = data; }

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -603,9 +603,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         BoundaryFlag block_bcs[6];
         SetBlockSizeAndBoundaries(newloc[n], block_size, block_bcs);
         // append new block to list of MeshBlocks
-        new_block_list[n - nbs] = std::make_shared<MeshBlock>(
-            n, n - nbs, newloc[n], block_size, block_bcs, this, pin, app_in, properties,
-            packages, gflag, true);
+        new_block_list[n - nbs] =
+            MeshBlock::Make(n, n - nbs, newloc[n], block_size, block_bcs, this, pin,
+                            app_in, properties, packages, gflag);
         // fill the conservative variables
         if ((loclist[on].level > newloc[n].level)) { // fine to coarse (f2c)
           for (int ll = 0; ll < nleaf; ll++) {

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -734,8 +734,7 @@ void Mesh::PrepareSendSameLevel(MeshBlock *pmb, ParArray1D<Real> &sendbuf) {
     ParArray3D<Real> x1f = var_fc.x1f.Get<3>();
     ParArray3D<Real> x2f = var_fc.x2f.Get<3>();
     ParArray3D<Real> x3f = var_fc.x3f.Get<3>();
-    BufferUtility::PackData(x1f, sendbuf, ib.s, ib.e + 1, jb.s, jb.e, kb.s, kb.e, p,
-                            pmb);
+    BufferUtility::PackData(x1f, sendbuf, ib.s, ib.e + 1, jb.s, jb.e, kb.s, kb.e, p, pmb);
     BufferUtility::PackData(x2f, sendbuf, ib.s, ib.e, jb.s, jb.e + f2, kb.s, kb.e, p,
                             pmb);
     BufferUtility::PackData(x3f, sendbuf, ib.s, ib.e, jb.s, jb.e, kb.s, kb.e + f3, p,

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -476,11 +476,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Properties_t &properti
   for (int i = nbs; i <= nbe; i++) {
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
     // create a block and add into the link list
-    block_list[i - nbs] =
-        std::make_shared<MeshBlock>(i, i - nbs, loclist[i], block_size, block_bcs, this,
-                                    pin, app_in, properties, packages, gflag);
-    block_list[i - nbs]->pbval->SearchAndSetNeighbors(tree, ranklist.data(),
-                                                      nslist.data());
+    block_list[i - nbs] = MeshBlock::MakeAndSetNeighbors(
+        i, i - nbs, loclist[i], block_size, block_bcs, this, pin, app_in, properties,
+        packages, gflag, tree, ranklist, nslist);
   }
 
   ResetLoadBalanceVariables();
@@ -739,11 +737,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
 
     // create a block and add into the link list
-    block_list[i - nbs] = std::make_shared<MeshBlock>(
-        i, i - nbs, this, pin, app_in, properties, packages, loclist[i], block_size,
-        block_bcs, costlist[i], gflag);
-    block_list[i - nbs]->pbval->SearchAndSetNeighbors(tree, ranklist.data(),
-                                                      nslist.data());
+    block_list[i - nbs] = MeshBlock::MakeAndSetNeighbors(
+        i, i - nbs, loclist[i], block_size, block_bcs, this, pin, app_in, properties,
+        packages, gflag, tree, ranklist, nslist, costlist[i]);
   }
 
   ResetLoadBalanceVariables();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -476,9 +476,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Properties_t &properti
   for (int i = nbs; i <= nbe; i++) {
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
     // create a block and add into the link list
-    block_list[i - nbs] = MeshBlock::MakeAndSetNeighbors(
-        i, i - nbs, loclist[i], block_size, block_bcs, this, pin, app_in, properties,
-        packages, gflag, tree, ranklist, nslist);
+    block_list[i - nbs] = MeshBlock::Make(i, i - nbs, loclist[i], block_size, block_bcs,
+                                          this, pin, app_in, properties, packages, gflag);
+    block_list[i - nbs]->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
   }
 
   ResetLoadBalanceVariables();
@@ -737,9 +737,10 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
     SetBlockSizeAndBoundaries(loclist[i], block_size, block_bcs);
 
     // create a block and add into the link list
-    block_list[i - nbs] = MeshBlock::MakeAndSetNeighbors(
-        i, i - nbs, loclist[i], block_size, block_bcs, this, pin, app_in, properties,
-        packages, gflag, tree, ranklist, nslist, costlist[i]);
+    block_list[i - nbs] =
+        MeshBlock::Make(i, i - nbs, loclist[i], block_size, block_bcs, this, pin, app_in,
+                        properties, packages, gflag, costlist[i]);
+    block_list[i - nbs]->SearchAndSetNeighbors(tree, ranklist.data(), nslist.data());
   }
 
   ResetLoadBalanceVariables();

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -259,7 +259,7 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
     return block_size.nx1 * block_size.nx2 * block_size.nx3;
   }
   void SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist, int *nslist) {
-    pbval->SearchAndSetNeighbors(tree,ranklist,nslist);
+    pbval->SearchAndSetNeighbors(tree, ranklist, nslist);
   }
   void WeightedAve(ParArrayND<Real> &u_out, ParArrayND<Real> &u_in1,
                    ParArrayND<Real> &u_in2, const Real wght[3]);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -488,19 +488,17 @@ class Mesh {
 
   // Mesh::RedistributeAndRefineMeshBlocks() helper functions:
   // step 6: send
-  void PrepareSendSameLevel(std::shared_ptr<MeshBlock> pb, ParArray1D<Real> &sendbuf);
-  void PrepareSendCoarseToFineAMR(std::shared_ptr<MeshBlock> pb,
-                                  ParArray1D<Real> &sendbuf, LogicalLocation &lloc);
-  void PrepareSendFineToCoarseAMR(std::shared_ptr<MeshBlock> pb,
-                                  ParArray1D<Real> &sendbuf);
+  void PrepareSendSameLevel(MeshBlock *pb, ParArray1D<Real> &sendbuf);
+  void PrepareSendCoarseToFineAMR(MeshBlock *pb, ParArray1D<Real> &sendbuf,
+                                  LogicalLocation &lloc);
+  void PrepareSendFineToCoarseAMR(MeshBlock *pb, ParArray1D<Real> &sendbuf);
   // step 7: create new MeshBlock list (same MPI rank but diff level: create new block)
   // moved public to be called from device
   // step 8: receive
-  void FinishRecvSameLevel(std::shared_ptr<MeshBlock> pb, ParArray1D<Real> &recvbuf);
-  void FinishRecvFineToCoarseAMR(std::shared_ptr<MeshBlock> pb, ParArray1D<Real> &recvbuf,
+  void FinishRecvSameLevel(MeshBlock *pb, ParArray1D<Real> &recvbuf);
+  void FinishRecvFineToCoarseAMR(MeshBlock *pb, ParArray1D<Real> &recvbuf,
                                  LogicalLocation &lloc);
-  void FinishRecvCoarseToFineAMR(std::shared_ptr<MeshBlock> pb,
-                                 ParArray1D<Real> &recvbuf);
+  void FinishRecvCoarseToFineAMR(MeshBlock *pb, ParArray1D<Real> &recvbuf);
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   static void InitUserMeshDataDefault(ParameterInput *pin);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -89,7 +89,7 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
                   BoundaryFlag *input_bcs, Mesh *pm, ParameterInput *pin,
                   ApplicationInput *app_in, Properties_t &properties,
                   Packages_t &packages, int igflag, double icost = 1.0);
-  // Factory method with deals with initialization for you
+  // Factory method deals with initialization for you
   static std::shared_ptr<MeshBlock>
   Make(int igid, int ilid, LogicalLocation iloc, RegionSize input_block,
        BoundaryFlag *input_bcs, Mesh *pm, ParameterInput *pin, ApplicationInput *app_in,

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -73,7 +73,7 @@ KOKKOS_INLINE_FUNCTION void par_for_inner(const team_mbr_t &team_member, const i
 //----------------------------------------------------------------------------------------
 //! \class MeshBlock
 //  \brief data/functions associated with a single block
-class MeshBlock {
+class MeshBlock : std::enable_shared_from_this<MeshBlock> {
   friend class RestartOutput;
   friend class Mesh;
 
@@ -469,17 +469,19 @@ class Mesh {
 
   // Mesh::RedistributeAndRefineMeshBlocks() helper functions:
   // step 6: send
-  void PrepareSendSameLevel(MeshBlock *pb, ParArray1D<Real> &sendbuf);
-  void PrepareSendCoarseToFineAMR(MeshBlock *pb, ParArray1D<Real> &sendbuf,
-                                  LogicalLocation &lloc);
-  void PrepareSendFineToCoarseAMR(MeshBlock *pb, ParArray1D<Real> &sendbuf);
+  void PrepareSendSameLevel(std::shared_ptr<MeshBlock> pb, ParArray1D<Real> &sendbuf);
+  void PrepareSendCoarseToFineAMR(std::shared_ptr<MeshBlock> pb,
+                                  ParArray1D<Real> &sendbuf, LogicalLocation &lloc);
+  void PrepareSendFineToCoarseAMR(std::shared_ptr<MeshBlock> pb,
+                                  ParArray1D<Real> &sendbuf);
   // step 7: create new MeshBlock list (same MPI rank but diff level: create new block)
   // moved public to be called from device
   // step 8: receive
-  void FinishRecvSameLevel(MeshBlock *pb, ParArray1D<Real> &recvbuf);
-  void FinishRecvFineToCoarseAMR(MeshBlock *pb, ParArray1D<Real> &recvbuf,
+  void FinishRecvSameLevel(std::shared_ptr<MeshBlock> pb, ParArray1D<Real> &recvbuf);
+  void FinishRecvFineToCoarseAMR(std::shared_ptr<MeshBlock> pb, ParArray1D<Real> &recvbuf,
                                  LogicalLocation &lloc);
-  void FinishRecvCoarseToFineAMR(MeshBlock *pb, ParArray1D<Real> &recvbuf);
+  void FinishRecvCoarseToFineAMR(std::shared_ptr<MeshBlock> pb,
+                                 ParArray1D<Real> &recvbuf);
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   static void InitUserMeshDataDefault(ParameterInput *pin);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -79,10 +79,6 @@ class MeshBlock : std::enable_shared_from_this<MeshBlock> {
 
  public:
   MeshBlock(const int n_side, const int ndim); // for Kokkos testing with ghost
-  MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_size,
-            BoundaryFlag *input_bcs, Mesh *pm, ParameterInput *pin,
-            ApplicationInput *app_in, Properties_t &properties, int igflag,
-            bool ref_flag = false);
   MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_block,
             BoundaryFlag *input_bcs, Mesh *pm, ParameterInput *pin,
             ApplicationInput *app_in, Properties_t &properties, Packages_t &packages,

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -68,7 +68,7 @@ void MeshRefinement::RestrictCellCenteredValues(const ParArrayND<Real> &fine,
                                                 ParArrayND<Real> &coarse, int sn, int en,
                                                 int csi, int cei, int csj, int cej,
                                                 int csk, int cek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
 
   auto coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
@@ -152,7 +152,7 @@ void MeshRefinement::RestrictCellCenteredValues(const ParArrayND<Real> &fine,
 void MeshRefinement::RestrictFieldX1(const ParArrayND<Real> &fine,
                                      ParArrayND<Real> &coarse, int csi, int cei, int csj,
                                      int cej, int csk, int cek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int si = (csi - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior);
@@ -210,7 +210,7 @@ void MeshRefinement::RestrictFieldX1(const ParArrayND<Real> &fine,
 void MeshRefinement::RestrictFieldX2(const ParArrayND<Real> &fine,
                                      ParArrayND<Real> &coarse, int csi, int cei, int csj,
                                      int cej, int csk, int cek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int si = (csi - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior);
@@ -273,7 +273,7 @@ void MeshRefinement::RestrictFieldX2(const ParArrayND<Real> &fine,
 void MeshRefinement::RestrictFieldX3(const ParArrayND<Real> &fine,
                                      ParArrayND<Real> &coarse, int csi, int cei, int csj,
                                      int cej, int csk, int cek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int si = (csi - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior),
@@ -342,7 +342,7 @@ void MeshRefinement::ProlongateCellCenteredValues(const ParArrayND<Real> &coarse
                                                   ParArrayND<Real> &fine, int sn, int en,
                                                   int si, int ei, int sj, int ej, int sk,
                                                   int ek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto coords = pmb->coords;
   auto coarse_coords = this->coarse_coords;
   const IndexDomain interior = IndexDomain::interior;
@@ -511,7 +511,7 @@ void MeshRefinement::ProlongateCellCenteredValues(const ParArrayND<Real> &coarse
 void MeshRefinement::ProlongateSharedFieldX1(const ParArrayND<Real> &coarse,
                                              ParArrayND<Real> &fine, int si, int ei,
                                              int sj, int ej, int sk, int ek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   if (pmb->block_size.nx3 > 1) {
@@ -595,7 +595,7 @@ void MeshRefinement::ProlongateSharedFieldX1(const ParArrayND<Real> &coarse,
 void MeshRefinement::ProlongateSharedFieldX2(const ParArrayND<Real> &coarse,
                                              ParArrayND<Real> &fine, int si, int ei,
                                              int sj, int ej, int sk, int ek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   const IndexDomain interior = IndexDomain::interior;
   auto &coords = pmb->coords;
   if (pmb->block_size.nx3 > 1) {
@@ -685,7 +685,7 @@ void MeshRefinement::ProlongateSharedFieldX2(const ParArrayND<Real> &coarse,
 void MeshRefinement::ProlongateSharedFieldX3(const ParArrayND<Real> &coarse,
                                              ParArrayND<Real> &fine, int si, int ei,
                                              int sj, int ej, int sk, int ek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   const IndexDomain interior = IndexDomain::interior;
   auto &coords = pmb->coords;
   if (pmb->block_size.nx3 > 1) {
@@ -798,7 +798,7 @@ void MeshRefinement::ProlongateSharedFieldX3(const ParArrayND<Real> &coarse,
 
 void MeshRefinement::ProlongateInternalField(FaceField &fine, int si, int ei, int sj,
                                              int ej, int sk, int ek) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int fsi = (si - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior),
@@ -995,7 +995,7 @@ void MeshRefinement::ProlongateInternalField(FaceField &fine, int si, int ei, in
 //  \brief Check refinement criteria
 
 void MeshRefinement::CheckRefinementCondition() {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   auto &rc = pmb->real_containers.Get();
   AmrTag ret = Refinement::CheckAllRefinement(rc);
   // if (AMRFlag_ != nullptr) ret = AMRFlag_(pmb);
@@ -1003,7 +1003,7 @@ void MeshRefinement::CheckRefinementCondition() {
 }
 
 void MeshRefinement::SetRefinement(AmrTag flag) {
-  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
+  std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   int aret = std::max(-1, static_cast<int>(flag));
 
   if (aret == 0) refine_flag_ = 0;

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -41,12 +42,12 @@ namespace parthenon {
 //! \fn MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin)
 //  \brief constructor
 
-MeshRefinement::MeshRefinement(MeshBlock *pmb, ParameterInput *pin)
+MeshRefinement::MeshRefinement(std::weak_ptr<MeshBlock> pmb, ParameterInput *pin)
     : pmy_block_(pmb), deref_count_(0),
       deref_threshold_(pin->GetOrAddInteger("parthenon/mesh", "derefine_count", 10)),
-      AMRFlag_(pmb->pmy_mesh->AMRFlag_) {
+      AMRFlag_(pmb.lock()->pmy_mesh->AMRFlag_) {
   // Create coarse mesh object for parent grid
-  coarse_coords = Coordinates_t(pmb->coords, 2);
+  coarse_coords = Coordinates_t(pmb.lock()->coords, 2);
 
   if (NGHOST % 2) {
     std::stringstream msg;
@@ -67,7 +68,7 @@ void MeshRefinement::RestrictCellCenteredValues(const ParArrayND<Real> &fine,
                                                 ParArrayND<Real> &coarse, int sn, int en,
                                                 int csi, int cei, int csj, int cej,
                                                 int csk, int cek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
 
   auto coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
@@ -151,7 +152,7 @@ void MeshRefinement::RestrictCellCenteredValues(const ParArrayND<Real> &fine,
 void MeshRefinement::RestrictFieldX1(const ParArrayND<Real> &fine,
                                      ParArrayND<Real> &coarse, int csi, int cei, int csj,
                                      int cej, int csk, int cek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int si = (csi - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior);
@@ -209,7 +210,7 @@ void MeshRefinement::RestrictFieldX1(const ParArrayND<Real> &fine,
 void MeshRefinement::RestrictFieldX2(const ParArrayND<Real> &fine,
                                      ParArrayND<Real> &coarse, int csi, int cei, int csj,
                                      int cej, int csk, int cek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int si = (csi - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior);
@@ -272,7 +273,7 @@ void MeshRefinement::RestrictFieldX2(const ParArrayND<Real> &fine,
 void MeshRefinement::RestrictFieldX3(const ParArrayND<Real> &fine,
                                      ParArrayND<Real> &coarse, int csi, int cei, int csj,
                                      int cej, int csk, int cek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int si = (csi - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior),
@@ -341,7 +342,7 @@ void MeshRefinement::ProlongateCellCenteredValues(const ParArrayND<Real> &coarse
                                                   ParArrayND<Real> &fine, int sn, int en,
                                                   int si, int ei, int sj, int ej, int sk,
                                                   int ek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto coords = pmb->coords;
   auto coarse_coords = this->coarse_coords;
   const IndexDomain interior = IndexDomain::interior;
@@ -510,7 +511,7 @@ void MeshRefinement::ProlongateCellCenteredValues(const ParArrayND<Real> &coarse
 void MeshRefinement::ProlongateSharedFieldX1(const ParArrayND<Real> &coarse,
                                              ParArrayND<Real> &fine, int si, int ei,
                                              int sj, int ej, int sk, int ek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   if (pmb->block_size.nx3 > 1) {
@@ -594,7 +595,7 @@ void MeshRefinement::ProlongateSharedFieldX1(const ParArrayND<Real> &coarse,
 void MeshRefinement::ProlongateSharedFieldX2(const ParArrayND<Real> &coarse,
                                              ParArrayND<Real> &fine, int si, int ei,
                                              int sj, int ej, int sk, int ek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   const IndexDomain interior = IndexDomain::interior;
   auto &coords = pmb->coords;
   if (pmb->block_size.nx3 > 1) {
@@ -684,7 +685,7 @@ void MeshRefinement::ProlongateSharedFieldX2(const ParArrayND<Real> &coarse,
 void MeshRefinement::ProlongateSharedFieldX3(const ParArrayND<Real> &coarse,
                                              ParArrayND<Real> &fine, int si, int ei,
                                              int sj, int ej, int sk, int ek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   const IndexDomain interior = IndexDomain::interior;
   auto &coords = pmb->coords;
   if (pmb->block_size.nx3 > 1) {
@@ -797,7 +798,7 @@ void MeshRefinement::ProlongateSharedFieldX3(const ParArrayND<Real> &coarse,
 
 void MeshRefinement::ProlongateInternalField(FaceField &fine, int si, int ei, int sj,
                                              int ej, int sk, int ek) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &coords = pmb->coords;
   const IndexDomain interior = IndexDomain::interior;
   int fsi = (si - pmb->c_cellbounds.is(interior)) * 2 + pmb->cellbounds.is(interior),
@@ -994,7 +995,7 @@ void MeshRefinement::ProlongateInternalField(FaceField &fine, int si, int ei, in
 //  \brief Check refinement criteria
 
 void MeshRefinement::CheckRefinementCondition() {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   auto &rc = pmb->real_containers.Get();
   AmrTag ret = Refinement::CheckAllRefinement(rc);
   // if (AMRFlag_ != nullptr) ret = AMRFlag_(pmb);
@@ -1002,7 +1003,7 @@ void MeshRefinement::CheckRefinementCondition() {
 }
 
 void MeshRefinement::SetRefinement(AmrTag flag) {
-  MeshBlock *pmb = pmy_block_;
+  std::shared_ptr<MeshBlock> pmb = pmy_block_.lock();
   int aret = std::max(-1, static_cast<int>(flag));
 
   if (aret == 0) refine_flag_ = 0;

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -19,6 +19,7 @@
 //! \file mesh_refinement.hpp
 //  \brief defines MeshRefinement class used for static/adaptive mesh refinement
 
+#include <memory>
 #include <tuple>
 #include <vector>
 
@@ -45,7 +46,7 @@ class MeshRefinement {
   friend class Mesh;
 
  public:
-  MeshRefinement(MeshBlock *pmb, ParameterInput *pin);
+  MeshRefinement(std::weak_ptr<MeshBlock> pmb, ParameterInput *pin);
 
   // functions
   void RestrictCellCenteredValues(const ParArrayND<Real> &fine, ParArrayND<Real> &coarse,
@@ -78,7 +79,7 @@ class MeshRefinement {
 
  private:
   // data
-  MeshBlock *pmy_block_;
+  std::weak_ptr<MeshBlock> pmy_block_;
   Coordinates_t coarse_coords;
 
   int refine_flag_, neighbor_rflag_, deref_count_, deref_threshold_;

--- a/src/mesh/mesh_refinement.hpp
+++ b/src/mesh/mesh_refinement.hpp
@@ -90,6 +90,14 @@ class MeshRefinement {
   // tuples of references to AMR-enrolled arrays (quantity, coarse_quantity)
   std::vector<std::tuple<ParArrayND<Real>, ParArrayND<Real>>> pvars_cc_;
   std::vector<std::tuple<FaceField *, FaceField *>> pvars_fc_;
+
+  // Returns shared pointer to a block
+  std::shared_ptr<MeshBlock> GetBlockPointer() {
+    if (pmy_block_.expired()) {
+      PARTHENON_THROW("Invalid pointer to MeshBlock!");
+    }
+    return pmy_block_.lock();
+  }
 };
 
 } // namespace parthenon

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -96,7 +96,8 @@ MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_
 
   auto &real_container = real_containers.Get();
   // Set the block pointer for the containers
-  real_container->setBlock(this);
+  // JMM: I hate this little bit of indirection.
+  real_container->setBlock(shared_from_this());
 
   // (probably don't need to preallocate space for references in these vectors)
   vars_cc_.reserve(3);
@@ -109,13 +110,13 @@ MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_
 
   // mesh-related objects
   // Boundary
-  pbval = std::make_unique<BoundaryValues>(this, input_bcs, pin);
+  pbval = std::make_unique<BoundaryValues>(shared_from_this(), input_bcs, pin);
   pbval->SetBoundaryFlags(boundary_flag);
 
   // Reconstruction: constructor may implicitly depend on Coordinates, and PPM variable
   // floors depend on EOS, but EOS isn't needed in Reconstruction constructor-> this is
   // ok
-  precon = std::make_unique<Reconstruction>(this, pin);
+  precon = std::make_unique<Reconstruction>(shared_from_this(), pin);
 
   // Add field properties data
   for (int i = 0; i < properties.size(); i++) {
@@ -149,7 +150,7 @@ MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_
   }
 
   if (pm->multilevel) {
-    pmr = std::make_unique<MeshRefinement>(this, pin);
+    pmr = std::make_unique<MeshRefinement>(shared_from_this(), pin);
     // This is very redundant, I think, but necessary for now
     for (int n = 0; n < nindependent; n++) {
       pmr->AddToRefinement(ci.vars[n]->data, ci.vars[n]->coarse_s);
@@ -204,7 +205,7 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
 
   auto &real_container = real_containers.Get();
   // Set the block pointer for the containers
-  real_container->setBlock(this);
+  real_container->setBlock(shared_from_this());
 
   // (probably don't need to preallocate space for references in these vectors)
   vars_cc_.reserve(3);
@@ -217,10 +218,10 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
   //           << ":" << xmin[0] << ":" << xmin[1] << std::endl;
 
   // Boundary
-  pbval = std::make_unique<BoundaryValues>(this, input_bcs, pin);
+  pbval = std::make_unique<BoundaryValues>(shared_from_this(), input_bcs, pin);
 
   // Reconstruction (constructor may implicitly depend on Coordinates)
-  precon = std::make_unique<Reconstruction>(this, pin);
+  precon = std::make_unique<Reconstruction>(shared_from_this(), pin);
 
   // Add field properties data
   for (int i = 0; i < properties.size(); i++) {
@@ -254,7 +255,7 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
   }
 
   if (pm->multilevel) {
-    pmr = std::make_unique<MeshRefinement>(this, pin);
+    pmr = std::make_unique<MeshRefinement>(shared_from_this(), pin);
     // This is very redundant, I think, but necessary for now
     for (int n = 0; n < nindependent; n++) {
       pmr->AddToRefinement(ci.vars[n]->data, ci.vars[n]->coarse_s);
@@ -284,19 +285,19 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
   InitializeIndexShapes(block_size.nx1, block_size.nx2, block_size.nx3);
 
   // Set the block pointer for the containers
-  real_containers.Get().setBlock(this);
+  real_containers.Get().setBlock(shared_from_this());
 
   // (re-)create mesh-related objects in MeshBlock
 
   coords = Coordinates_t(block_size, pin);
 
   // Boundary
-  pbval = std::make_unique<BoundaryValues>(this, input_bcs, pin);
+  pbval = std::make_unique<BoundaryValues>(shared_from_this(), input_bcs, pin);
 
   // Reconstruction (constructor may implicitly depend on Coordinates)
-  precon = std::make_unique<Reconstruction>(this, pin);
+  precon = std::make_unique<Reconstruction>(shared_from_this(), pin);
 
-  if (pm->multilevel) pmr = std::make_unique<MeshRefinement>(this, pin);
+  if (pm->multilevel) pmr = std::make_unique<MeshRefinement>(shared_from_this(), pin);
 
   app = InitApplicationMeshBlockData(pin);
   InitUserMeshBlockData(pin);

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -60,14 +60,22 @@ MeshBlock::MeshBlock(const int n_side, const int ndim)
   }
 }
 
-MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_block,
-                     BoundaryFlag *input_bcs, Mesh *pm, ParameterInput *pin,
-                     ApplicationInput *app_in, Properties_t &properties,
-                     Packages_t &packages, int igflag, bool ref_flag)
-    : exec_space(DevExecSpace()), pmy_mesh(pm), loc(iloc), block_size(input_block),
-      gid(igid), lid(ilid), gflag(igflag), properties(properties),
-      packages(packages), new_block_dt_{}, new_block_dt_hyperbolic_{},
-      new_block_dt_parabolic_{}, new_block_dt_user_{}, cost_(1.0) {
+void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
+                           RegionSize input_block, BoundaryFlag *input_bcs, Mesh *pm,
+                           ParameterInput *pin, ApplicationInput *app_in,
+                           Properties_t &properties, Packages_t &packages, int igflag,
+                           double icost) {
+  exec_space = DevExecSpace();
+  pmy_mesh = pm;
+  loc = iloc;
+  block_size = input_block;
+  gid = igid;
+  lid = ilid;
+  gflag = igflag;
+  this->properties = properties;
+  this->packages = packages;
+  cost_ = icost;
+
   // initialize grid indices
   if (pmy_mesh->ndim >= 3) {
     InitializeIndexShapes(block_size.nx1, block_size.nx2, block_size.nx3);
@@ -96,7 +104,6 @@ MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_
 
   auto &real_container = real_containers.Get();
   // Set the block pointer for the containers
-  // JMM: I hate this little bit of indirection.
   real_container->setBlock(shared_from_this());
 
   // (probably don't need to preallocate space for references in these vectors)
@@ -116,111 +123,6 @@ MeshBlock::MeshBlock(int igid, int ilid, LogicalLocation iloc, RegionSize input_
   // Reconstruction: constructor may implicitly depend on Coordinates, and PPM variable
   // floors depend on EOS, but EOS isn't needed in Reconstruction constructor-> this is
   // ok
-  precon = std::make_unique<Reconstruction>(shared_from_this(), pin);
-
-  // Add field properties data
-  for (int i = 0; i < properties.size(); i++) {
-    StateDescriptor &state = properties[i]->State();
-    for (auto const &q : state.AllFields()) {
-      real_container->Add(q.first, q.second);
-    }
-    for (auto const &q : state.AllSparseFields()) {
-      for (auto const &m : q.second) {
-        real_container->Add(q.first, m);
-      }
-    }
-  }
-  // Add physics data
-  for (auto const &pkg : packages) {
-    for (auto const &q : pkg.second->AllFields()) {
-      real_container->Add(q.first, q.second);
-    }
-    for (auto const &q : pkg.second->AllSparseFields()) {
-      for (auto const &m : q.second) {
-        real_container->Add(q.first, m);
-      }
-    }
-  }
-
-  // TODO(jdolence): Should these loops be moved to Variable creation
-  ContainerIterator<Real> ci(real_container, {Metadata::Independent});
-  int nindependent = ci.vars.size();
-  for (int n = 0; n < nindependent; n++) {
-    RegisterMeshBlockData(ci.vars[n]);
-  }
-
-  if (pm->multilevel) {
-    pmr = std::make_unique<MeshRefinement>(shared_from_this(), pin);
-    // This is very redundant, I think, but necessary for now
-    for (int n = 0; n < nindependent; n++) {
-      pmr->AddToRefinement(ci.vars[n]->data, ci.vars[n]->coarse_s);
-    }
-  }
-
-  // Create user mesh data
-  // InitUserMeshBlockData(pin);
-  app = InitApplicationMeshBlockData(pin);
-}
-
-//----------------------------------------------------------------------------------------
-// MeshBlock constructor for restarts
-// Creates block but loads no data
-MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
-                     ApplicationInput *app_in, Properties_t &properties,
-                     Packages_t &packages, LogicalLocation iloc, RegionSize input_block,
-                     BoundaryFlag *input_bcs, double icost, int igflag)
-    : exec_space(DevExecSpace()), pmy_mesh(pm), loc(iloc), block_size(input_block),
-      gid(igid), lid(ilid), gflag(igflag), properties(properties),
-      packages(packages), new_block_dt_{}, new_block_dt_hyperbolic_{},
-      new_block_dt_parabolic_{}, new_block_dt_user_{}, cost_(1.0) {
-
-  // initialize grid indices
-  // Allow for user overrides to default Parthenon functions
-  if (app_in->InitApplicationMeshBlockData != nullptr) {
-    InitApplicationMeshBlockData = app_in->InitApplicationMeshBlockData;
-  }
-  if (app_in->InitUserMeshBlockData != nullptr) {
-    InitUserMeshBlockData = app_in->InitUserMeshBlockData;
-  }
-  if (app_in->ProblemGenerator != nullptr) {
-    ProblemGenerator = app_in->ProblemGenerator;
-  }
-  if (app_in->MeshBlockUserWorkInLoop != nullptr) {
-    UserWorkInLoop = app_in->MeshBlockUserWorkInLoop;
-  }
-  if (app_in->UserWorkBeforeOutput != nullptr) {
-    UserWorkBeforeOutput = app_in->UserWorkBeforeOutput;
-  }
-
-  // std::cerr << "WHY AM I HERE???" << std::endl;
-
-  // initialize grid indices
-  if (pmy_mesh->ndim >= 3) {
-    InitializeIndexShapes(block_size.nx1, block_size.nx2, block_size.nx3);
-  } else if (pmy_mesh->ndim >= 2) {
-    InitializeIndexShapes(block_size.nx1, block_size.nx2, 0);
-  } else {
-    InitializeIndexShapes(block_size.nx1, 0, 0);
-  }
-
-  auto &real_container = real_containers.Get();
-  // Set the block pointer for the containers
-  real_container->setBlock(shared_from_this());
-
-  // (probably don't need to preallocate space for references in these vectors)
-  vars_cc_.reserve(3);
-  vars_fc_.reserve(3);
-
-  // (re-)create mesh-related objects in MeshBlock
-  coords = Coordinates_t(block_size, pin);
-  auto xmin = coords.GetXmin();
-  // std::cout << "XY:" << igid << ":" << iloc.lx1 << ":" << iloc.lx2 << ":" << iloc.level
-  //           << ":" << xmin[0] << ":" << xmin[1] << std::endl;
-
-  // Boundary
-  pbval = std::make_unique<BoundaryValues>(shared_from_this(), input_bcs, pin);
-
-  // Reconstruction (constructor may implicitly depend on Coordinates)
   precon = std::make_unique<Reconstruction>(shared_from_this(), pin);
 
   // Add field properties data

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -104,7 +104,7 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
 
   auto &real_container = real_containers.Get();
   // Set the block pointer for the containers
-  real_container->setBlock(shared_from_this());
+  real_container->SetBlockPointer(shared_from_this());
 
   // (probably don't need to preallocate space for references in these vectors)
   vars_cc_.reserve(3);

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -267,58 +267,6 @@ MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
   app = InitApplicationMeshBlockData(pin);
   return;
 }
-#if 0
-MeshBlock::MeshBlock(int igid, int ilid, Mesh *pm, ParameterInput *pin,
-                     Properties_t &properties, Packages_t &packages, LogicalLocation iloc,
-                     RegionSize input_block, BoundaryFlag *input_bcs, double icost,
-                     int igflag)
-    : pmy_mesh(pm), loc(iloc), block_size(input_block), gid(igid), lid(ilid),
-      gflag(igflag), nuser_out_var(), properties(properties), packages(packages),
-      new_block_dt_{}, new_block_dt_hyperbolic_{},
-      new_block_dt_parabolic_{}, new_block_dt_user_{}, nreal_user_meshblock_data_(),
-      nint_user_meshblock_data_(), cost_(icost), exec_space(DevExecSpace()) {
-  // initialize grid indices
-
-  // std::cerr << "WHY AM I HERE???" << std::endl;
-
-  // initialize grid indices
-  InitializeIndexShapes(block_size.nx1, block_size.nx2, block_size.nx3);
-
-  // Set the block pointer for the containers
-  real_containers.Get().setBlock(shared_from_this());
-
-  // (re-)create mesh-related objects in MeshBlock
-
-  coords = Coordinates_t(block_size, pin);
-
-  // Boundary
-  pbval = std::make_unique<BoundaryValues>(shared_from_this(), input_bcs, pin);
-
-  // Reconstruction (constructor may implicitly depend on Coordinates)
-  precon = std::make_unique<Reconstruction>(shared_from_this(), pin);
-
-  if (pm->multilevel) pmr = std::make_unique<MeshRefinement>(shared_from_this(), pin);
-
-  app = InitApplicationMeshBlockData(pin);
-  InitUserMeshBlockData(pin);
-
-  std::size_t os = 0;
-
-  // load user MeshBlock data
-  for (int n = 0; n < nint_user_meshblock_data_; n++) {
-    std::memcpy(iuser_meshblock_data[n].data(), &(mbdata[os]),
-                iuser_meshblock_data[n].GetSizeInBytes());
-    os += iuser_meshblock_data[n].GetSizeInBytes();
-  }
-  for (int n = 0; n < nreal_user_meshblock_data_; n++) {
-    std::memcpy(ruser_meshblock_data[n].data(), &(mbdata[os]),
-                ruser_meshblock_data[n].GetSizeInBytes());
-    os += ruser_meshblock_data[n].GetSizeInBytes();
-  }
-
-  return;
-}
-#endif
 
 //----------------------------------------------------------------------------------------
 // MeshBlock destructor

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -92,7 +92,7 @@ auto PackMesh(BlockList_t &blocks, F &packing_function) {
   int b = 0;
   for (auto &pmb : blocks) {
     coords_host(b) = pmb->coords;
-    packs_host(b) = packing_function(pmb);
+    packs_host(b) = packing_function(pmb.get());
     b++;
   }
 
@@ -120,7 +120,7 @@ auto PackMesh(Mesh *pmesh, F &packing_function) {
 template <typename T, typename... Args>
 auto PackVariablesOnMesh(T &blocks, const std::string &container_name, Args &&... args) {
   using namespace mesh_pack_impl;
-  auto pack_function = [&](std::shared_ptr<MeshBlock> &pmb) {
+  auto pack_function = [&](MeshBlock *pmb) {
     auto container = pmb->real_containers.Get(container_name);
     return container->PackVariables(std::forward<Args>(args)...);
   };
@@ -130,7 +130,7 @@ template <typename T, typename... Args>
 auto PackVariablesAndFluxesOnMesh(T &blocks, const std::string &container_name,
                                   Args &&... args) {
   using namespace mesh_pack_impl;
-  auto pack_function = [&](std::shared_ptr<MeshBlock> &pmb) {
+  auto pack_function = [&](MeshBlock *pmb) {
     auto container = pmb->real_containers.Get(container_name);
     return container->PackVariablesAndFluxes(std::forward<Args>(args)...);
   };

--- a/src/reconstruct/plm.cpp
+++ b/src/reconstruct/plm.cpp
@@ -35,7 +35,7 @@ namespace parthenon {
 void Reconstruction::PiecewiseLinearX1(const int k, const int j, const int il,
                                        const int iu, const ParArrayND<Real> &q,
                                        ParArrayND<Real> &ql, ParArrayND<Real> &qr) {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   // set work arrays to shallow copies of scratch arrays
   ParArrayND<Real> &qc = scr1_ni_, &dql = scr2_ni_, &dqr = scr3_ni_, &dqm = scr4_ni_;
@@ -113,7 +113,7 @@ void Reconstruction::PiecewiseLinearX1(const int k, const int j, const int il,
 void Reconstruction::PiecewiseLinearX2(const int k, const int j, const int il,
                                        const int iu, const ParArrayND<Real> &q,
                                        ParArrayND<Real> &ql, ParArrayND<Real> &qr) {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   // set work arrays to shallow copies of scratch arrays
   ParArrayND<Real> &qc = scr1_ni_, &dql = scr2_ni_, &dqr = scr3_ni_, &dqm = scr4_ni_;
@@ -189,7 +189,7 @@ void Reconstruction::PiecewiseLinearX2(const int k, const int j, const int il,
 void Reconstruction::PiecewiseLinearX3(const int k, const int j, const int il,
                                        const int iu, const ParArrayND<Real> &q,
                                        ParArrayND<Real> &ql, ParArrayND<Real> &qr) {
-  auto pmb = pmy_block_.lock();
+  auto pmb = GetBlockPointer();
   auto &coords = pmb->coords;
   // set work arrays to shallow copies of scratch arrays
   ParArrayND<Real> &qc = scr1_ni_, &dql = scr2_ni_, &dqr = scr3_ni_, &dqm = scr4_ni_;

--- a/src/reconstruct/plm.cpp
+++ b/src/reconstruct/plm.cpp
@@ -35,7 +35,8 @@ namespace parthenon {
 void Reconstruction::PiecewiseLinearX1(const int k, const int j, const int il,
                                        const int iu, const ParArrayND<Real> &q,
                                        ParArrayND<Real> &ql, ParArrayND<Real> &qr) {
-  auto &coords = pmy_block_->coords;
+  auto pmb = pmy_block_.lock();
+  auto &coords = pmb->coords;
   // set work arrays to shallow copies of scratch arrays
   ParArrayND<Real> &qc = scr1_ni_, &dql = scr2_ni_, &dqr = scr3_ni_, &dqm = scr4_ni_;
   const int nu = q.GetDim(4) - 1;
@@ -112,7 +113,8 @@ void Reconstruction::PiecewiseLinearX1(const int k, const int j, const int il,
 void Reconstruction::PiecewiseLinearX2(const int k, const int j, const int il,
                                        const int iu, const ParArrayND<Real> &q,
                                        ParArrayND<Real> &ql, ParArrayND<Real> &qr) {
-  auto &coords = pmy_block_->coords;
+  auto pmb = pmy_block_.lock();
+  auto &coords = pmb->coords;
   // set work arrays to shallow copies of scratch arrays
   ParArrayND<Real> &qc = scr1_ni_, &dql = scr2_ni_, &dqr = scr3_ni_, &dqm = scr4_ni_;
   const int nu = q.GetDim(4) - 1;
@@ -187,7 +189,8 @@ void Reconstruction::PiecewiseLinearX2(const int k, const int j, const int il,
 void Reconstruction::PiecewiseLinearX3(const int k, const int j, const int il,
                                        const int iu, const ParArrayND<Real> &q,
                                        ParArrayND<Real> &ql, ParArrayND<Real> &qr) {
-  auto &coords = pmy_block_->coords;
+  auto pmb = pmy_block_.lock();
+  auto &coords = pmb->coords;
   // set work arrays to shallow copies of scratch arrays
   ParArrayND<Real> &qc = scr1_ni_, &dql = scr2_ni_, &dqr = scr3_ni_, &dqm = scr4_ni_;
   const int nu = q.GetDim(4) - 1;

--- a/src/reconstruct/reconstruction.cpp
+++ b/src/reconstruct/reconstruction.cpp
@@ -23,6 +23,7 @@
 #include <cstring>
 #include <iomanip>
 #include <limits>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -41,15 +42,17 @@ void DoolittleLUPSolve(Real **lu, int *pivot, Real *b, int n, Real *x);
 
 } // anonymous namespace
 
-Reconstruction::Reconstruction(MeshBlock *pmb, ParameterInput *pin)
+Reconstruction::Reconstruction(std::weak_ptr<MeshBlock> wpmb, ParameterInput *pin)
     : characteristic_projection{false}, uniform{true, true, true, true},
       // read fourth-order solver switches
       correct_ic{pin->GetOrAddBoolean("parthenon/time", "correct_ic", false)},
       correct_err{pin->GetOrAddBoolean("parthenon/time", "correct_err", false)},
-      pmy_block_{pmb} {
+      pmy_block_{wpmb} {
   // Read and set type of spatial reconstruction
   // --------------------------------
   std::string input_recon = pin->GetOrAddString("parthenon/mesh", "xorder", "2");
+  // meshblock
+  std::shared_ptr<MeshBlock> pmb = wpmb.lock();
   // Avoid pmb indirection
   const IndexDomain entire = IndexDomain::entire;
   const IndexDomain interior = IndexDomain::interior;

--- a/src/reconstruct/reconstruction.hpp
+++ b/src/reconstruct/reconstruction.hpp
@@ -23,6 +23,7 @@
 
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 
@@ -146,6 +147,14 @@ class Reconstruction {
   ParArrayND<Real> scr11_i_, scr12_i_, scr13_i_, scr14_i_;
   ParArrayND<Real> scr1_ni_, scr2_ni_, scr3_ni_, scr4_ni_, scr5_ni_;
   ParArrayND<Real> scr6_ni_, scr7_ni_, scr8_ni_;
+
+  // Returns shared pointer to a block
+  std::shared_ptr<MeshBlock> GetBlockPointer() {
+    if (pmy_block_.expired()) {
+      PARTHENON_THROW("Invalid pointer to MeshBlock!");
+    }
+    return pmy_block_.lock();
+  }
 };
 
 } // namespace parthenon

--- a/src/reconstruct/reconstruction.hpp
+++ b/src/reconstruct/reconstruction.hpp
@@ -19,6 +19,8 @@
 //! \file reconstruction.hpp
 //  \brief defines class Reconstruction, data and functions for spatial reconstruction
 
+#include <memory>
+
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
 
@@ -34,7 +36,7 @@ class Reconstruction {
  public:
   enum VelocityIndex { IVX = 1, IVY = 2, IVZ = 3 };
 
-  Reconstruction(MeshBlock *pmb, ParameterInput *pin);
+  Reconstruction(std::weak_ptr<MeshBlock> pmb, ParameterInput *pin);
 
   // data
   // switches for reconstruction method variants:
@@ -135,7 +137,8 @@ class Reconstruction {
                             ParArrayND<Real> &qr);
 
  private:
-  MeshBlock *pmy_block_; // ptr to MeshBlock containing this Reconstruction
+  // ptr to MeshBlock containing this Reconstruction
+  std::weak_ptr<MeshBlock> pmy_block_;
 
   // scratch arrays used in PLM and PPM reconstruction functions
   ParArrayND<Real> scr01_i_, scr02_i_, scr03_i_, scr04_i_, scr05_i_;

--- a/src/refinement/amr_criteria.cpp
+++ b/src/refinement/amr_criteria.cpp
@@ -56,7 +56,7 @@ AMRFirstDerivative::AMRFirstDerivative(ParameterInput *pin, std::string &block_n
 
 AmrTag AMRFirstDerivative::operator()(std::shared_ptr<Container<Real>> &rc) {
   ParArrayND<Real> q = rc->Get(field).data;
-  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = rc->GetBlockPointer();
   return Refinement::FirstDerivative(pmb->exec_space, q, refine_criteria,
                                      derefine_criteria);
 }

--- a/src/refinement/amr_criteria.cpp
+++ b/src/refinement/amr_criteria.cpp
@@ -56,7 +56,8 @@ AMRFirstDerivative::AMRFirstDerivative(ParameterInput *pin, std::string &block_n
 
 AmrTag AMRFirstDerivative::operator()(std::shared_ptr<Container<Real>> &rc) {
   ParArrayND<Real> q = rc->Get(field).data;
-  return Refinement::FirstDerivative(rc->pmy_block->exec_space, q, refine_criteria,
+  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  return Refinement::FirstDerivative(pmb->exec_space, q, refine_criteria,
                                      derefine_criteria);
 }
 

--- a/src/refinement/refinement.cpp
+++ b/src/refinement/refinement.cpp
@@ -55,7 +55,7 @@ AmrTag CheckAllRefinement(std::shared_ptr<Container<Real>> &rc) {
   //    2) the code must maintain proper nesting, which sometimes means a block that is
   //       tagged as "derefine" must be left alone (or possibly refined?) because of
   //       neighboring blocks.  Similarly for "do nothing"
-  MeshBlock *pmb = rc->pmy_block;
+  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
   // delta_level holds the max over all criteria.  default to derefining.
   AmrTag delta_level = AmrTag::derefine;
   for (auto &pkg : pmb->packages) {
@@ -73,7 +73,7 @@ AmrTag CheckAllRefinement(std::shared_ptr<Container<Real>> &rc) {
     for (auto &amr : desc->amr_criteria) {
       // get the recommended change in refinement level from this criteria
       AmrTag temp_delta = (*amr)(rc);
-      if ((temp_delta == AmrTag::refine) && rc->pmy_block->loc.level >= amr->max_level) {
+      if ((temp_delta == AmrTag::refine) && pmb->loc.level >= amr->max_level) {
         // don't refine if we're at the max level
         temp_delta = AmrTag::same;
       }

--- a/src/refinement/refinement.cpp
+++ b/src/refinement/refinement.cpp
@@ -55,7 +55,7 @@ AmrTag CheckAllRefinement(std::shared_ptr<Container<Real>> &rc) {
   //    2) the code must maintain proper nesting, which sometimes means a block that is
   //       tagged as "derefine" must be left alone (or possibly refined?) because of
   //       neighboring blocks.  Similarly for "do nothing"
-  std::shared_ptr<MeshBlock> pmb = rc->pmy_block.lock();
+  std::shared_ptr<MeshBlock> pmb = rc->GetBlockPointer();
   // delta_level holds the max over all criteria.  default to derefining.
   AmrTag delta_level = AmrTag::derefine;
   for (auto &pkg : pmb->packages) {

--- a/src/utils/buffer_utils.cpp
+++ b/src/utils/buffer_utils.cpp
@@ -38,8 +38,7 @@ namespace BufferUtility {
 
 template <typename T>
 void PackData(ParArray4D<T> &src, ParArray1D<T> &buf, int sn, int en, int si, int ei,
-              int sj, int ej, int sk, int ek, int &offset,
-              std::shared_ptr<MeshBlock> pmb) {
+              int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -63,7 +62,7 @@ void PackData(ParArray4D<T> &src, ParArray1D<T> &buf, int sn, int en, int si, in
 
 template <typename T>
 void PackData(ParArray3D<T> &src, ParArray1D<T> &buf, int si, int ei, int sj, int ej,
-              int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb) {
+              int sk, int ek, int &offset, MeshBlock *pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -85,8 +84,7 @@ void PackData(ParArray3D<T> &src, ParArray1D<T> &buf, int si, int ei, int sj, in
 
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray4D<T> &dst, int sn, int en, int si, int ei,
-                int sj, int ej, int sk, int ek, int &offset,
-                std::shared_ptr<MeshBlock> pmb) {
+                int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -111,7 +109,7 @@ void UnpackData(ParArray1D<T> &buf, ParArray4D<T> &dst, int sn, int en, int si, 
 
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray3D<T> &dst, int si, int ei, int sj, int ej,
-                int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb) {
+                int sk, int ek, int &offset, MeshBlock *pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -131,14 +129,14 @@ void UnpackData(ParArray1D<T> &buf, ParArray3D<T> &dst, int si, int ei, int sj, 
 
 // 13x files include buffer_utils.hpp
 template void UnpackData<Real>(ParArray1D<Real> &, ParArray4D<Real> &, int, int, int, int,
-                               int, int, int, int, int &, std::shared_ptr<MeshBlock>);
+                               int, int, int, int, int &, MeshBlock *);
 template void UnpackData<Real>(ParArray1D<Real> &, ParArray3D<Real> &, int, int, int, int,
-                               int, int, int &, std::shared_ptr<MeshBlock>);
+                               int, int, int &, MeshBlock *);
 
 template void PackData<Real>(ParArray4D<Real> &, ParArray1D<Real> &, int, int, int, int,
-                             int, int, int, int, int &, std::shared_ptr<MeshBlock>);
+                             int, int, int, int, int &, MeshBlock *);
 template void PackData<Real>(ParArray3D<Real> &, ParArray1D<Real> &, int, int, int, int,
-                             int, int, int &, std::shared_ptr<MeshBlock>);
+                             int, int, int &, MeshBlock *);
 
 } // namespace BufferUtility
 } // namespace parthenon

--- a/src/utils/buffer_utils.cpp
+++ b/src/utils/buffer_utils.cpp
@@ -17,8 +17,6 @@
 //! \file buffer_utils.cpp
 //  \brief namespace containing buffer utilities.
 
-#include <memory>
-
 #include "utils/buffer_utils.hpp"
 
 #include "defs.hpp"

--- a/src/utils/buffer_utils.cpp
+++ b/src/utils/buffer_utils.cpp
@@ -17,6 +17,8 @@
 //! \file buffer_utils.cpp
 //  \brief namespace containing buffer utilities.
 
+#include <memory>
+
 #include "utils/buffer_utils.hpp"
 
 #include "defs.hpp"
@@ -36,7 +38,8 @@ namespace BufferUtility {
 
 template <typename T>
 void PackData(ParArray4D<T> &src, ParArray1D<T> &buf, int sn, int en, int si, int ei,
-              int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb) {
+              int sj, int ej, int sk, int ek, int &offset,
+              std::shared_ptr<MeshBlock> pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -60,7 +63,7 @@ void PackData(ParArray4D<T> &src, ParArray1D<T> &buf, int sn, int en, int si, in
 
 template <typename T>
 void PackData(ParArray3D<T> &src, ParArray1D<T> &buf, int si, int ei, int sj, int ej,
-              int sk, int ek, int &offset, MeshBlock *pmb) {
+              int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -82,7 +85,8 @@ void PackData(ParArray3D<T> &src, ParArray1D<T> &buf, int si, int ei, int sj, in
 
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray4D<T> &dst, int sn, int en, int si, int ei,
-                int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb) {
+                int sj, int ej, int sk, int ek, int &offset,
+                std::shared_ptr<MeshBlock> pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -107,7 +111,7 @@ void UnpackData(ParArray1D<T> &buf, ParArray4D<T> &dst, int sn, int en, int si, 
 
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray3D<T> &dst, int si, int ei, int sj, int ej,
-                int sk, int ek, int &offset, MeshBlock *pmb) {
+                int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb) {
   const int ni = ei + 1 - si;
   const int nj = ej + 1 - sj;
   const int nk = ek + 1 - sk;
@@ -127,14 +131,14 @@ void UnpackData(ParArray1D<T> &buf, ParArray3D<T> &dst, int si, int ei, int sj, 
 
 // 13x files include buffer_utils.hpp
 template void UnpackData<Real>(ParArray1D<Real> &, ParArray4D<Real> &, int, int, int, int,
-                               int, int, int, int, int &, MeshBlock *);
+                               int, int, int, int, int &, std::shared_ptr<MeshBlock>);
 template void UnpackData<Real>(ParArray1D<Real> &, ParArray3D<Real> &, int, int, int, int,
-                               int, int, int &, MeshBlock *);
+                               int, int, int &, std::shared_ptr<MeshBlock>);
 
 template void PackData<Real>(ParArray4D<Real> &, ParArray1D<Real> &, int, int, int, int,
-                             int, int, int, int, int &, MeshBlock *);
+                             int, int, int, int, int &, std::shared_ptr<MeshBlock>);
 template void PackData<Real>(ParArray3D<Real> &, ParArray1D<Real> &, int, int, int, int,
-                             int, int, int &, MeshBlock *);
+                             int, int, int &, std::shared_ptr<MeshBlock>);
 
 } // namespace BufferUtility
 } // namespace parthenon

--- a/src/utils/buffer_utils.hpp
+++ b/src/utils/buffer_utils.hpp
@@ -19,8 +19,6 @@
 //! \file buffer_utils.hpp
 //  \brief prototypes of utility functions to pack/unpack buffers
 
-#include <memory>
-
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
 

--- a/src/utils/buffer_utils.hpp
+++ b/src/utils/buffer_utils.hpp
@@ -19,6 +19,8 @@
 //! \file buffer_utils.hpp
 //  \brief prototypes of utility functions to pack/unpack buffers
 
+#include <memory>
+
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
 
@@ -29,19 +31,21 @@ namespace BufferUtility {
 // 4D
 template <typename T>
 void PackData(ParArray4D<T> &src, ParArray1D<T> &buf, int sn, int en, int si, int ei,
-              int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb);
+              int sj, int ej, int sk, int ek, int &offset,
+              std::shared_ptr<MeshBlock> pmb);
 // 3D
 template <typename T>
 void PackData(ParArray3D<T> &src, ParArray1D<T> &buf, int si, int ei, int sj, int ej,
-              int sk, int ek, int &offset, MeshBlock *pmb);
+              int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb);
 // 4D
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray4D<T> &dst, int sn, int en, int si, int ei,
-                int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb);
+                int sj, int ej, int sk, int ek, int &offset,
+                std::shared_ptr<MeshBlock> pmb);
 // 3D
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray3D<T> &dst, int si, int ei, int sj, int ej,
-                int sk, int ek, int &offset, MeshBlock *pmb);
+                int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb);
 
 } // namespace BufferUtility
 } // namespace parthenon

--- a/src/utils/buffer_utils.hpp
+++ b/src/utils/buffer_utils.hpp
@@ -31,21 +31,19 @@ namespace BufferUtility {
 // 4D
 template <typename T>
 void PackData(ParArray4D<T> &src, ParArray1D<T> &buf, int sn, int en, int si, int ei,
-              int sj, int ej, int sk, int ek, int &offset,
-              std::shared_ptr<MeshBlock> pmb);
+              int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb);
 // 3D
 template <typename T>
 void PackData(ParArray3D<T> &src, ParArray1D<T> &buf, int si, int ei, int sj, int ej,
-              int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb);
+              int sk, int ek, int &offset, MeshBlock *pmb);
 // 4D
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray4D<T> &dst, int sn, int en, int si, int ei,
-                int sj, int ej, int sk, int ek, int &offset,
-                std::shared_ptr<MeshBlock> pmb);
+                int sj, int ej, int sk, int ek, int &offset, MeshBlock *pmb);
 // 3D
 template <typename T>
 void UnpackData(ParArray1D<T> &buf, ParArray3D<T> &dst, int si, int ei, int sj, int ej,
-                int sk, int ek, int &offset, std::shared_ptr<MeshBlock> pmb);
+                int sk, int ek, int &offset, MeshBlock *pmb);
 
 } // namespace BufferUtility
 } // namespace parthenon


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As discussed in #306 and #303, smart pointers to meshblocks means we can use them elsewhere in the code, for example, with weak back pointers. This Implements that change.

In addition, I substantially clean up the MeshBlock class. I noticed that all three constructors had the same functionality copy-pasted. I therefore removed all but one of them. I also changed the constructors to a factory method. This was necessary because of a subtlety with smart pointers. You cannot create a weak pointer to an object in its own constructor.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [X] New features are documented.
- [X] Adds a test for any bugs fixed. Adds tests for new features.
- [X] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
