### PR TITLE
Fix calls to get maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [[PR 303]](https://github.com/lanl/parthenon/pull/303) Changed `Mesh::BlockList` from a `std::list<MeshBlock>` to a `std::vector<std::shared_ptr<MeshBlock>>`, making `FindMeshBlock` run in constant, rather than linear, time. Loops over `block_list` in application drivers must be cahnged accordingly.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 310]](https://github.com/lanl/parthenon/pull/310) Fix Cuda 11 builds.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -142,7 +142,7 @@ class Container {
   // Queries related to CellVariable objects
   //
   const CellVariableVector<T> &GetCellVariableVector() const { return varVector_; }
-  const MapToCellVars<T> GetCellVariableMap() const { return varMap_; }
+  const MapToCellVars<T> &GetCellVariableMap() const { return varMap_; }
   CellVariable<T> &Get(std::string label) {
     auto it = varMap_.find(label);
     if (it == varMap_.end()) {
@@ -164,8 +164,8 @@ class Container {
   //
   // Queries related to SparseVariable objects
   //
-  const SparseVector<T> GetSparseVector() const { return sparseVector_; }
-  const MapToSparse<T> GetSparseMap() const { return sparseMap_; }
+  const SparseVector<T> &GetSparseVector() const { return sparseVector_; }
+  const MapToSparse<T> &GetSparseMap() const { return sparseMap_; }
   SparseVariable<T> &GetSparseVariable(const std::string &label) {
     auto it = sparseMap_.find(label);
     if (it == sparseMap_.end()) {
@@ -194,7 +194,7 @@ class Container {
   // Queries related to FaceVariable objects
   //
   const FaceVector<T> &GetFaceVector() const { return faceVector_; }
-  const MapToFace<T> GetFaceMap() const { return faceMap_; }
+  const MapToFace<T> &GetFaceMap() const { return faceMap_; }
   FaceVariable<T> &GetFace(std::string label) {
     auto it = faceMap_.find(label);
     if (it == faceMap_.end()) {


### PR DESCRIPTION
## PR Summary

NVCC didn't like the non-reference const calls and failed to build on Cuda 11.
Now Cuda 11 builds are fine.

Closes #258 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [does not apply] New features are documented.
- [does not apply] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
