### PR TITLE
Avoid initializing MPI in regression tests

### DIFF
--- a/tst/regression/run_test.py
+++ b/tst/regression/run_test.py
@@ -21,6 +21,13 @@ import argparse
 import os
 import sys
 
+try:
+    # Configure mpi4py to not initialize MPI automatically
+    # See: https://github.com/lanl/parthenon/pull/320
+    import mpi4py
+    mpi4py.rc(initialize=False)
+except ImportError: ()
+
 """ To prevent littering up imported folders with .pyc files"""
 sys.dont_write_bytecode = True
 

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -16,11 +16,11 @@
 #========================================================================================
 
 # Modules
+import h5py
 import math
 import numpy as np
 import sys
 import os
-import subprocess
 import utils.test_case
 """ To prevent littering up imported folders with .pyc files or __pycache_ folder"""
 sys.dont_write_bytecode = True
@@ -44,40 +44,19 @@ class TestCase(utils.test_case.TestCaseAbs):
         return parameters
 
     def Analyse(self, parameters):
-        # HACK: On some systems, including LANL Darwin Power9, importing the
-        # h5py module causes future uses of `mpiexec` to fail - there appears to
-        # be some buried call to `MPI_Init` in the import of `h5py` that causes
-        # this. Therefore, we run the script in a child process for hygenic
-        # purposes.
-        #
-        # For more information, see:
-        # https://github.com/lanl/parthenon/issues/312
-        script = """
-import h5py
-import sys
+        # spotcheck one variable
+        goldFile = 'gold.out0.00002.rhdf'
+        silverFile = 'silver.out0.00002.rhdf'
 
-# spotcheck one variable
-goldFile = 'gold.out0.00002.rhdf'
-silverFile = 'silver.out0.00002.rhdf'
+        gold = h5py.File(goldFile,'r')
+        silver = h5py.File(silverFile,'r')
 
-gold = h5py.File(goldFile,'r')
-silver = h5py.File(silverFile,'r')
+        varName = "/advected"
+        goldData = gold[varName][:].flatten()
+        silverData = gold[varName][:].flatten()
 
-varName = "/advected"
-goldData = gold[varName][:].flatten()
-silverData = gold[varName][:].flatten()
+        # spot check on one variable
+        maxdiff = max(abs(goldData-silverData))
+        print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
 
-# spot check on one variable
-maxdiff = max(abs(goldData-silverData))
-print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
-
-if maxdiff == 0.0:
-    exit = 0
-else:
-    exit = 1
-
-sys.exit(exit)
-"""
-        proc = subprocess.run([sys.executable, "-c", script])
-
-        return (proc.returncode == 0)
+        return (maxdiff == 0.0)


### PR DESCRIPTION
~~Addresses an issue with hygiene when importing the h5py module.~~

Prevent `mpi4py` from initializing MPI.

Fixes #312

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Importing h5py causes future MPI operations in the process or child process to fail (probably due to unpaired MPI_Init) for some implementations of MPI, such as openmpi 4.0.2 on Darwin Power9. ~~Therefore, this change runs restart.py's TestCase.Analyse script in a child process to maintain hygiene in the test process.~~ This change stops the `mpi4py` transitive dependency from initializing MPI when present.

~~A possible alternative solution would be to import h5py in the scope of the Analyse function. My concern with this is that future `mpiexec` commands would fail, and I don't know if we're guaranteed to never have any more. This solution is more complete, but less pretty.~~

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md (N/A - test fix)
