### PR TITLE
make inner loop pattern tags constexpr. resolves #319

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [[PR 293]](https://github.com/lanl/parthenon/pull/293) Changed `VariablePack` and related objects to use `ParArray1D` objects instead of `ParArrayND` objects under the hood to reduce the size of the captured objects.
 - [[PR 310]](https://github.com/lanl/parthenon/pull/310) Fix Cuda 11 builds.
 - [[PR 313]](https://github.com/lanl/parthenon/pull/313) Add include guards for Kokkos in cmake.
+- [[PR 321]](https://github.com/lanl/parthenon/pull/321) Make inner loop pattern tags constexpr
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -111,14 +111,15 @@ static struct LoopPatternUndefined {
 // Currently the only available option.
 static struct OuterLoopPatternTeams {
 } outer_loop_pattern_teams_tag;
+// Inner loop pattern tags must be constexpr so they're available on device
 // Translate to a Kokkos::TeamVectorRange as innermost loop (single index)
-static struct InnerLoopPatternTVR {
-} inner_loop_pattern_tvr_tag;
+struct InnerLoopPatternTVR {};
+constexpr InnerLoopPatternTVR inner_loop_pattern_tvr_tag;
 // Translate to a non-Kokkos plain C++ innermost loop (single index)
 // decorated with #pragma omp simd
 // IMPORTANT: currently only supported on CPUs
-static struct InnerLoopPatternSimdFor {
-} inner_loop_pattern_simdfor_tag;
+struct InnerLoopPatternSimdFor {};
+constexpr InnerLoopPatternSimdFor inner_loop_pattern_simdfor_tag;
 
 namespace dispatch_impl {
 static struct ParallelForDispatch {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As discussed in issue #319, the inner loop pattern tag dispatch can fail on lower optimization levels, because the tags do not have `device` scope. One way to fix this is to add `__device__` to each tag, but this is not performance portable. Another way is to make the tags `constexpr` so that they can pull `device` from local scope when they are used. This implements the latter solution.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
