### PR TITLE
Fix multi rank convergence tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [[PR 313]](https://github.com/lanl/parthenon/pull/313) Add include guards for Kokkos in cmake.
 - [[PR 321]](https://github.com/lanl/parthenon/pull/321) Make inner loop pattern tags constexpr
 - [[PR 281]](https://github.com/lanl/parthenon/pull/281) Allows one to run regression tests with more than one cuda device, Also improves readability of regression tests output.
+- [[PR 325]](https://github.com/lanl/parthenon/pull/325) Fixes regression in convergence tests with multiple MPI ranks.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/cmake/machinecfg/CI.cmake
+++ b/cmake/machinecfg/CI.cmake
@@ -20,7 +20,7 @@ message(STATUS "Loading machine configuration for default CI machine. "
 
 # common options
 set(Kokkos_ARCH_WSM ON CACHE BOOL "CPU architecture")
-set(NUM_MPI_PROC_TESTING "1" CACHE STRING "CI runs tests with 1 MPI rank")
+set(NUM_MPI_PROC_TESTING "2" CACHE STRING "CI runs tests with 2 MPI ranks")
 # variants
 if (${MACHINE_VARIANT} MATCHES "cuda")
   set(Kokkos_ARCH_PASCAL61 ON CACHE BOOL "GPU architecture")

--- a/tst/regression/test_suites/advection_convergence/advection_convergence.py
+++ b/tst/regression/test_suites/advection_convergence/advection_convergence.py
@@ -60,9 +60,10 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         n_res = len(lin_res)
         # make sure we can evenly distribute the MeshBlock sizes
-        assert parameters.num_ranks % 2 == 0, "Num ranks must be multiples of 2 for convergence test."
+        err_msg = "Num ranks must be multiples of 2 for convergence test."
+        assert parameters.num_ranks == 1 or parameters.num_ranks % 2 == 0, err_msg
         # ensure a minimum block size of 4
-        assert lin_res[0] / parameters.num_ranks <= 8, "Use <= 8 ranks for convergence test."
+        assert lin_res[0] / parameters.num_ranks >= 4, "Use <= 8 ranks for convergence test."
 
         # TEST: Advection only in x-direction 
         # using nx2 = nx3 = 4 > 1 for identical errors between dimensions

--- a/tst/regression/test_suites/advection_performance/advection_performance.py
+++ b/tst/regression/test_suites/advection_performance/advection_performance.py
@@ -73,7 +73,7 @@ class TestCase(utils.test_case.TestCaseAbs):
         for output in parameters.stdouts:
             for line in output.decode("utf-8").split('\n'):
                 print(line)
-                if 'zone-cycles/omp_wsecond' in line:
+                if 'zone-cycles/wallsecond' in line:
                     perfs.append(float(line.split(' ')[2]))
 
         perfs = np.array(perfs)

--- a/tst/regression/test_suites/advection_performance/advection_performance.py
+++ b/tst/regression/test_suites/advection_performance/advection_performance.py
@@ -33,12 +33,35 @@ mb_sizes = [256, 128, 64, 32, 16] # meshblock sizes
 class TestCase(utils.test_case.TestCaseAbs):
     def Prepare(self, parameters, step):
 
+        # splits integer n into the three largest factors
+        def get_split(n):
+            i = 2
+            factors = []
+            while i*i <= n:
+                if n % i != 0:
+                    i += 1
+                else:
+                    n //= i
+                    factors.append(i)
+            # always append remainder, could also be 1
+            factors.append(n)
+
+            # fill to 3 dims
+            while len(factors) < 3:
+                factors.append(1)
+            # split to 3 dims
+            while len(factors) > 3:
+                factors = sorted(factors[:-2] + [factors[-2]*factors[-1]], reverse=True)
+            return sorted(factors, reverse=True)
+
+        num_proc_x, num_proc_y, num_proc_z = get_split(parameters.num_ranks)
+
         parameters.driver_cmd_line_args = [
-            'parthenon/mesh/nx1=%d' % (parameters.num_ranks * 256),
+            'parthenon/mesh/nx1=%d' % (num_proc_x * 256),
             'parthenon/meshblock/nx1=%d' % mb_sizes[step - 1],
-            'parthenon/mesh/nx2=256',
+            'parthenon/mesh/nx2=%d' % (num_proc_y * 256),
             'parthenon/meshblock/nx2=%d' % mb_sizes[step - 1],
-            'parthenon/mesh/nx3=256',
+            'parthenon/mesh/nx3=%d' % (num_proc_z * 256),
             'parthenon/meshblock/nx3=%d' % mb_sizes[step - 1],
         ]
 

--- a/tst/regression/test_suites/calculate_pi/calculate_pi.py
+++ b/tst/regression/test_suites/calculate_pi/calculate_pi.py
@@ -50,7 +50,6 @@ class TestCase(utils.test_case.TestCaseAbs):
                 'time/tlim=0.4',
                 'mesh/nx1=400']
         """
-        parameters.driver_cmd_line_args = ['parthenon/mesh/nx1=%d' % (parameters.num_ranks *64)]
         parameters.coverage_status = "both"
         return parameters
 

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -41,7 +41,7 @@ class TestCase(utils.test_case.TestCaseAbs):
             parameters.driver_cmd_line_args = [
                 'parthenon/job/problem_id=advection_3d', # change name for new outputs
                 'parthenon/mesh/numlevel=2', # reduce AMR depth for smaller sim
-                'parthenon/mesh/nx1=%d' % (32 * parameters.num_ranks ),
+                'parthenon/mesh/nx1=32',
                 'parthenon/meshblock/nx1=8',
                 'parthenon/mesh/nx2=32',
                 'parthenon/meshblock/nx2=8',
@@ -62,7 +62,7 @@ class TestCase(utils.test_case.TestCaseAbs):
             parameters.driver_cmd_line_args = [
                 'parthenon/job/problem_id=advection_3d', # change name for new outputs
                 'parthenon/mesh/numlevel=2', # reduce AMR depth for smaller sim
-                'parthenon/mesh/nx1=%d' % (32 * parameters.num_ranks),
+                'parthenon/mesh/nx1=32',
                 'parthenon/meshblock/nx1=8',
                 'parthenon/mesh/nx2=32',
                 'parthenon/meshblock/nx2=8',

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -38,8 +38,7 @@ class TestCase(utils.test_case.TestCaseAbs):
             parameters.driver_cmd_line_args = [
                 '-r',
                 'gold.out0.00001.rhdf',
-                'parthenon/job/problem_id=silver',
-                'parthenon/mesh/nx1=%d' % (64 * parameters.num_ranks)
+                'parthenon/job/problem_id=silver'
             ]
             
         return parameters


### PR DESCRIPTION
## PR Summary

#281 introduced a dependency of the domain size with number of MPI ranks used for the regression tests.
This resulted in convergence tests failing when using different number of MPI ranks.

This PR fixes this while keeping the original intent, i.e., when more MPI ranks are used the blocks are getting smaller but the domain size remains constant.
This does not apply to AMR tests, as all the current tests already include enough blocks so that they can be distributed among all ranks.
In addition, the MPI tests in the CI suite now run with 2 processes (versus previously just one) so that this is automatically tested from now on.

Closes #323 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] Code passes cpplint
- [does not apply] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [X] Code is formatted
- [X] Changes are summarized in CHANGELOG.md
