### PR TITLE
Close h5py files after reading, and issue with np array access when using h5py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [[PR 321]](https://github.com/lanl/parthenon/pull/321) Make inner loop pattern tags constexpr
 - [[PR 281]](https://github.com/lanl/parthenon/pull/281) Allows one to run regression tests with more than one cuda device, Also improves readability of regression tests output.
 - [[PR 325]](https://github.com/lanl/parthenon/pull/325) Fixes regression in convergence tests with multiple MPI ranks.
+- [[PR 330]](https://github.com/lanl/parthenon/pull/330) Fixes restart regression test.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -54,7 +54,7 @@ class TestCase(utils.test_case.TestCaseAbs):
     with h5py.File(goldFile,'r') as gold, h5py.File(silverFile,'r') as silver:
       goldData = np.zeros(gold[varName].shape, dtype=np.float64)
       gold[varName].read_direct(goldData)
-      silverData = np.zeros(silver[varName].shape, dtype=np.single)
+      silverData = np.zeros(silver[varName].shape, dtype=np.float64)
       silver[varName].read_direct(silverData)
 
     goldData = goldData.flatten()

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -49,7 +49,9 @@ class TestCase(utils.test_case.TestCaseAbs):
         silverFile = 'silver.out0.00002.rhdf'
 
         gold = h5py.File(goldFile,'r')
+        gold.close()
         silver = h5py.File(silverFile,'r')
+        silver.close()
 
         varName = "/advected"
         goldData = gold[varName][:].flatten()

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -52,7 +52,7 @@ class TestCase(utils.test_case.TestCaseAbs):
 
     varName = "advected"
     with h5py.File(goldFile,'r') as gold, h5py.File(silverFile,'r') as silver:
-      goldData = np.zeros(gold[varName].shape, dtype=np.single)
+      goldData = np.zeros(gold[varName].shape, dtype=np.float64)
       gold[varName].read_direct(goldData)
       silverData = np.zeros(silver[varName].shape, dtype=np.single)
       silver[varName].read_direct(silverData)

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -57,8 +57,6 @@ class TestCase(utils.test_case.TestCaseAbs):
       silverData = np.zeros(silver[varName].shape, dtype=np.float64)
       silver[varName].read_direct(silverData)
 
-    goldData = goldData.flatten()
-    silverData = silverData.flatten()
-    maxdiff = max(abs(goldData-silverData))
+    maxdiff = np.abs(goldData-silverData).max()
     print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
     return (maxdiff == 0.0)

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -22,43 +22,43 @@ import numpy as np
 import sys
 import os
 import utils.test_case
+
+
 """ To prevent littering up imported folders with .pyc files or __pycache_ folder"""
 sys.dont_write_bytecode = True
 
 class TestCase(utils.test_case.TestCaseAbs):
-    def Prepare(self, parameters, step):
-            
-        # enable coverage testing on pass where restart
-        # files are both read and written
-        parameters.coverage_status = "both"
-        
-        if step == 1:
-            parameters.driver_cmd_line_args = ['parthenon/job/problem_id=gold']
-        else:
-            parameters.driver_cmd_line_args = [
-                '-r',
-                'gold.out0.00001.rhdf',
-                'parthenon/job/problem_id=silver'
-            ]
-            
-        return parameters
+  def Prepare(self, parameters, step):
 
-    def Analyse(self, parameters):
-        # spotcheck one variable
-        goldFile = 'gold.out0.00002.rhdf'
-        silverFile = 'silver.out0.00002.rhdf'
+    # enable coverage testing on pass where restart
+    # files are both read and written
+    parameters.coverage_status = "both"
 
-        gold = h5py.File(goldFile,'r')
-        gold.close()
-        silver = h5py.File(silverFile,'r')
-        silver.close()
+    if step == 1:
+      parameters.driver_cmd_line_args = ['parthenon/job/problem_id=gold']
+    else:
+      parameters.driver_cmd_line_args = [
+        '-r',
+        'gold.out0.00001.rhdf',
+        'parthenon/job/problem_id=silver'
+      ]
 
-        varName = "/advected"
-        goldData = gold[varName][:].flatten()
-        silverData = gold[varName][:].flatten()
+    return parameters
 
-        # spot check on one variable
-        maxdiff = max(abs(goldData-silverData))
-        print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
+  def Analyse(self, parameters):
+    # spotcheck one variable
+    goldFile = 'gold.out0.00002.rhdf'
+    silverFile = 'silver.out0.00002.rhdf'
 
-        return (maxdiff == 0.0)
+    varName = "advected"
+    with h5py.File(goldFile,'r') as gold, h5py.File(silverFile,'r') as silver:
+      goldData = np.zeros(gold[varName].shape, dtype=np.single)
+      gold[varName].read_direct(goldData)
+      silverData = np.zeros(gold[varName].shape, dtype=np.single)
+      gold[varName].read_direct(silverData)
+
+    goldData = goldData.flatten()
+    silverData = silverData.flatten()
+    maxdiff = max(abs(goldData-silverData))
+    print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
+    return (maxdiff == 0.0)

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -46,20 +46,20 @@ class TestCase(utils.test_case.TestCaseAbs):
         return parameters
 
     def Analyse(self, parameters):
-        # spotcheck one variable
-        goldFile = 'gold.out0.00002.rhdf'
-        silverFile = 'silver.out0.00002.rhdf'
+      # spotcheck one variable
+      goldFile = 'gold.out0.00002.rhdf'
+      silverFile = 'silver.out0.00002.rhdf'
+      varName = "advected"
+      with h5py.File(goldFile,'r') as gold, h5py.File(silverFile,'r') as silver:
+        goldData = np.zeros(gold[varName].shape, dtype=np.float64)
+        gold[varName].read_direct(goldData)
+        silverData = np.zeros(silver[varName].shape, dtype=np.float64)
+        silver[varName].read_direct(silverData)
 
-        gold = h5py.File(goldFile,'r')
-        silver = h5py.File(silverFile,'r')
-
-        varName = "/advected"
-        goldData = gold[varName][:].flatten()
-        silverData = silver[varName][:].flatten()
-
-        # spot check on one variable
-        maxdiff = max(abs(goldData-silverData))
-        print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
-
-        return (maxdiff == 0.0)
+      goldData = goldData.flatten()
+      maxdiff = np.abs(goldData-silverData).max()
+      silverData = silverData.flatten()
+      maxdiff = max(abs(goldData-silverData))
+      print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
+      return (maxdiff == 0.0)
 

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -56,10 +56,7 @@ class TestCase(utils.test_case.TestCaseAbs):
         silverData = np.zeros(silver[varName].shape, dtype=np.float64)
         silver[varName].read_direct(silverData)
 
-      goldData = goldData.flatten()
       maxdiff = np.abs(goldData-silverData).max()
-      silverData = silverData.flatten()
-      maxdiff = max(abs(goldData-silverData))
       print('Variable: %s, diff=%g, N=%d'%(varName,maxdiff,len(goldData)))
       return (maxdiff == 0.0)
 

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -55,7 +55,7 @@ class TestCase(utils.test_case.TestCaseAbs):
       goldData = np.zeros(gold[varName].shape, dtype=np.single)
       gold[varName].read_direct(goldData)
       silverData = np.zeros(gold[varName].shape, dtype=np.single)
-      gold[varName].read_direct(silverData)
+      silver[varName].read_direct(silverData)
 
     goldData = goldData.flatten()
     silverData = silverData.flatten()

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -54,7 +54,7 @@ class TestCase(utils.test_case.TestCaseAbs):
     with h5py.File(goldFile,'r') as gold, h5py.File(silverFile,'r') as silver:
       goldData = np.zeros(gold[varName].shape, dtype=np.single)
       gold[varName].read_direct(goldData)
-      silverData = np.zeros(gold[varName].shape, dtype=np.single)
+      silverData = np.zeros(silver[varName].shape, dtype=np.single)
       silver[varName].read_direct(silverData)
 
     goldData = goldData.flatten()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I noticed that the restart regression tests were for some reason failing when trying to get the ci to work on darwin. There was a segfault. 

The problem ended up being a result of a bad memory access from a np array, pre allocating the memory before reading in the data appeared to fix the problem. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented. - not really anything to document. 
- [ ] Adds a test for any bugs fixed. Adds tests for new features. - not sure how to test this other than to run it on darwin like I have been trying to do. 
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
