### PR TITLE
variable aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 339](https://github.com/lanl/parthenon/pull/339) Add support for variable aliases, allowing the user to have two names for the same variable.
 
 ### Changed (changing behavior/API/variables/...)
 

--- a/docs/interface/containers.md
+++ b/docs/interface/containers.md
@@ -10,7 +10,7 @@ or dense data. (For more details on anonymous variables, see
 shapes, e.g., scalar, tensor, etc.A variable can be added to a
 container as:
 ```C++
-parthenon::Container.Add(name, metadata, shape)
+parthenon::Container.Add(name, metadata, shape);
 ```
 where the name is a string, the metadata is a `std::vector` of
 metadata flags, and the shape is a `std::vector` of integers
@@ -32,6 +32,12 @@ lives, then shape is the shape of the full array. I.e., a
 `11x12x13x14` array would be added with a shape of
 ```C++
 shape = std::vector<int>({11,12,13,14});
+```
+
+You can also add an *alias* to a variable, which is a second name by
+which it can be referred via
+```C++
+parthenon::Container.Add(alias, name, metadata);
 ```
 
 It is often desirable to extract from a container a specific set of

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -71,6 +71,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Metadata m({Metadata::Cell, Metadata::Derived});
   package->AddField(field_name, m, DerivedOwnership::unique);
 
+  // You can add an alias for a field name. You can access the field
+  // by this name as well as its original name. However, they point to
+  // the same field.
+  package->AddFieldAlias("in_or_out_alias", "in_or_out");
+
   // Add a named MeshPack by registering a function that packs it
   package->AddMeshBlockPack("in_or_out", [](Mesh *pmesh) {
     int pack_size = pmesh->DefaultPackSize();

--- a/example/face_fields/face_fields_example.cpp
+++ b/example/face_fields/face_fields_example.cpp
@@ -60,6 +60,9 @@ Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
                array_size);
   package->AddField("f.f.face_averaged_value", m, DerivedOwnership::unique);
 
+  // You can alias face-centered objects too
+  package->AddFieldAlias("face_centered_alias", "f.f.face_averaged_value");
+
   packages["FaceFieldExample"] = package;
   return packages;
 }

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -54,13 +54,13 @@ void Container::Add(const std::string &alias, const std::string &label,
                     const Metadata &metadata) {
   // TODO(JMM): Edge, etc
   if (metadata.IsSet(Metadata::Sparse)) {
-    if (sparseMap_.count(label) == 0) Add(label,metadata);
+    if (sparseMap_.count(label) == 0) Add(label, metadata);
     sparseMap_[alias] = sparseMap_[label];
   } else if (metadata.where() == Metadata::Face) {
-    if (faceMap_.count(label) == 0) Add(label,metadata);
+    if (faceMap_.count(label) == 0) Add(label, metadata);
     faceMap_[alias] = sparseMap_[label];
   } else {
-    if (varMap_.count(label) == 0) Add(label,metadata);
+    if (varMap_.count(label) == 0) Add(label, metadata);
     varMap_[alias] = varMap_[label];
   }
 }

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -49,6 +49,22 @@ void Container<T>::Add(const std::vector<std::string> labelArray,
   }
 }
 
+template <typename T>
+void Container::Add(const std::string &alias, const std::string &label,
+                    const Metadata &metadata) {
+  // TODO(JMM): Edge, etc
+  if (metadata.IsSet(Metadata::Sparse)) {
+    if (sparseMap_.count(label) == 0) Add(label,metadata);
+    sparseMap_[alias] = sparseMap_[label];
+  } else if (metadata.where() == Metadata::Face) {
+    if (faceMap_.count(label) == 0) Add(label,metadata);
+    faceMap_[alias] = sparseMap_[label];
+  } else {
+    if (varMap_.count(label) == 0) Add(label,metadata);
+    varMap_[alias] = varMap_[label];
+  }
+}
+
 ///
 /// The internal routine for allocating an array.  This subroutine
 /// is topology aware and will allocate accordingly.

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -55,14 +55,12 @@ void Container<T>::Add(const std::string &alias, const std::string &label,
   // TODO(JMM): Edge, etc
   if (metadata.IsSet(Metadata::Sparse)) {
     if (sparseMap_.count(label) == 0) Add(label, metadata);
-    sparseMap_[alias] = sparseMap_[label];
   } else if (metadata.Where() == Metadata::Face) {
     if (faceMap_.count(label) == 0) Add(label, metadata);
-    faceMap_[alias] = faceMap_[label];
   } else {
     if (varMap_.count(label) == 0) Add(label, metadata);
-    varMap_[alias] = varMap_[label];
   }
+  aliasMap_[alias] = label;
 }
 
 ///

--- a/src/interface/container.cpp
+++ b/src/interface/container.cpp
@@ -50,15 +50,15 @@ void Container<T>::Add(const std::vector<std::string> labelArray,
 }
 
 template <typename T>
-void Container::Add(const std::string &alias, const std::string &label,
-                    const Metadata &metadata) {
+void Container<T>::Add(const std::string &alias, const std::string &label,
+                       const Metadata &metadata) {
   // TODO(JMM): Edge, etc
   if (metadata.IsSet(Metadata::Sparse)) {
     if (sparseMap_.count(label) == 0) Add(label, metadata);
     sparseMap_[alias] = sparseMap_[label];
-  } else if (metadata.where() == Metadata::Face) {
+  } else if (metadata.Where() == Metadata::Face) {
     if (faceMap_.count(label) == 0) Add(label, metadata);
-    faceMap_[alias] = sparseMap_[label];
+    faceMap_[alias] = faceMap_[label];
   } else {
     if (varMap_.count(label) == 0) Add(label, metadata);
     varMap_[alias] = varMap_[label];

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -16,6 +16,7 @@
 #include <map>
 #include <memory>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -154,6 +155,9 @@ class Container {
   const CellVariableVector<T> &GetCellVariableVector() const { return varVector_; }
   const MapToCellVars<T> &GetCellVariableMap() const { return varMap_; }
   CellVariable<T> &Get(std::string label) {
+    if (aliasMap_.count(label) > 0) {
+      label = aliasMap_[label];
+    }
     auto it = varMap_.find(label);
     if (it == varMap_.end()) {
       throw std::invalid_argument(std::string("\n") + std::string(label) +
@@ -176,7 +180,10 @@ class Container {
   //
   const SparseVector<T> &GetSparseVector() const { return sparseVector_; }
   const MapToSparse<T> &GetSparseMap() const { return sparseMap_; }
-  SparseVariable<T> &GetSparseVariable(const std::string &label) {
+  SparseVariable<T> &GetSparseVariable(std::string label) {
+    if (aliasMap_.count(label) > 0) {
+      label = aliasMap_[label];
+    }
     auto it = sparseMap_.find(label);
     if (it == sparseMap_.end()) {
       throw std::invalid_argument("sparseMap_ does not have " + label);
@@ -206,6 +213,9 @@ class Container {
   const FaceVector<T> &GetFaceVector() const { return faceVector_; }
   const MapToFace<T> &GetFaceMap() const { return faceMap_; }
   FaceVariable<T> &GetFace(std::string label) {
+    if (aliasMap_.count(label) > 0) {
+      label = aliasMap_[label];
+    }
     auto it = faceMap_.find(label);
     if (it == faceMap_.end()) {
       throw std::invalid_argument(std::string("\n") + std::string(label) +
@@ -239,7 +249,9 @@ class Container {
   int GetCellVariables(const std::vector<std::string> &names,
                        std::vector<CellVariable<T>> &vRet,
                        std::map<std::string, std::pair<int, int>> &indexCount,
-                       const std::vector<int> &sparse_ids = {});
+                       const std::vector<int> &sparse_ids = {}) {
+    PARTHENON_THROW("Not implemented\n");
+  }
 
   /// Queries related to variable packs
   VariableFluxPack<T> PackVariablesAndFluxes(const std::vector<std::string> &var_names,
@@ -315,6 +327,8 @@ class Container {
  private:
   int debug = 0;
   std::weak_ptr<MeshBlock> pmy_block;
+
+  std::unordered_map<std::string, std::string> aliasMap_;
 
   CellVariableVector<T> varVector_; ///< the saved variable array
   FaceVector<T> faceVector_;        ///< the saved face arrays

--- a/src/interface/container.hpp
+++ b/src/interface/container.hpp
@@ -145,6 +145,9 @@ class Container {
     sparseMap_[var->label()] = var;
   }
 
+  // Adds the alias to variable label
+  void Add(const std::string &alias, const std::string &label, const Metadata &metadata);
+
   //
   // Queries related to CellVariable objects
   //

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -234,13 +234,9 @@ class StateDescriptor {
     return false;
   }
 
-  bool AliasPresent(const std::string &name) {
-    return aliasMap_.count(name) > 0;
-  }
+  bool AliasPresent(const std::string &name) { return aliasMap_.count(name) > 0; }
 
-  const auto& GetAlias(const std::string &name) {
-    return aliasMap_[name];
-  }
+  const auto &GetAlias(const std::string &name) { return aliasMap_[name]; }
 
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
   void (*FillDerived)(std::shared_ptr<Container<Real>> &rc);

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -236,7 +236,7 @@ class StateDescriptor {
 
   bool AliasPresent(const std::string &name) { return aliasMap_.count(name) > 0; }
 
-  const auto &GetAlias(const std::string &name) { return aliasMap_[name]; }
+  const auto &GetAliases(const std::string &name) { return aliasMap_[name]; }
 
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
   void (*FillDerived)(std::shared_ptr<Container<Real>> &rc);

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -146,11 +146,11 @@ class StateDescriptor {
   // TODO(JMM): Should this work for swarms too? Ben?
   void AddFieldAlias(const std::string &alias_name, const std::string &field_name) {
     bool found = false;
-    for (auto &pair in metadataMap_) {
+    for (auto &pair : metadataMap_) {
       auto &name = pair.first;
       if (pair.first == field_name) found = true;
     }
-    for (auto &pair in sparseMetadataMap_) {
+    for (auto &pair : sparseMetadataMap_) {
       auto &name = pair.first;
       if (pair.first == field_name) found = true;
     }

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -133,11 +133,22 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   for (int i = 0; i < properties.size(); i++) {
     StateDescriptor &state = properties[i]->State();
     for (auto const &q : state.AllFields()) {
-      real_container->Add(q.first, q.second);
+      const auto &label = q.first;
+      const auto &m = q.second;
+      real_container->Add(label, m);
+      auto aliases = state.GetAliases(label);
+      for (auto const &alias : aliases) {
+        real_container->Add(alias,label,m);
+      }
     }
     for (auto const &q : state.AllSparseFields()) {
+      auto aliases = state.GetAliases(q.first);
       for (auto const &m : q.second) {
-        real_container->Add(q.first, m);
+        const auto &label = q.first;
+        real_container->Add(label, m);
+        for (auto const &alias : aliases) {
+          real_container->Add(alias,label,m);
+        }
       }
     }
   }

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -138,7 +138,7 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
       real_container->Add(label, m);
       auto aliases = state.GetAliases(label);
       for (auto const &alias : aliases) {
-        real_container->Add(alias,label,m);
+        real_container->Add(alias, label, m);
       }
     }
     for (auto const &q : state.AllSparseFields()) {
@@ -147,7 +147,7 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
         const auto &label = q.first;
         real_container->Add(label, m);
         for (auto const &alias : aliases) {
-          real_container->Add(alias,label,m);
+          real_container->Add(alias, label, m);
         }
       }
     }

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -31,6 +31,7 @@ list(APPEND unit_tests_SOURCES
     test_required_desired.cpp
     test_error_checking.cpp
     test_partitioning.cpp
+    test_variable_aliases.cpp
 )
 
 add_executable(unit_tests "${unit_tests_SOURCES}")

--- a/tst/unit/test_variable_aliases.cpp
+++ b/tst/unit/test_variable_aliases.cpp
@@ -60,7 +60,7 @@ TEST_CASE("We can add an alias to a variable in a container", "[ContainerAlias]"
         REQUIRE(pack.GetDim(4) == 1);
       }
       THEN("Packing both alias and the original names throws an error") {
-        REQUIRE_THROWS(rc.PackVariables(std::vector<std::string>{"var","alias"}));
+        REQUIRE_THROWS(rc.PackVariables(std::vector<std::string>{"var", "alias"}));
       }
     }
   }

--- a/tst/unit/test_variable_aliases.cpp
+++ b/tst/unit/test_variable_aliases.cpp
@@ -15,7 +15,8 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
-#invlude < vector>
+#include <string>
+#include <vector>
 
 #include <catch2/catch.hpp>
 
@@ -31,12 +32,13 @@
 
 using parthenon::Container;
 using parthenon::Metadata;
+using parthenon::Real;
 
 TEST_CASE("We can add an alias to a variable in a container", "[ContainerAlias]") {
   GIVEN("A container with a variable in it") {
     Container<Real> rc;
     std::vector<int> block_size = {16, 16, 16};
-    Metadata m({Metdata::Independent, Metadata::FillGhost}, block_size);
+    Metadata m({Metadata::Independent, Metadata::FillGhost}, block_size);
     rc.Add("var", m);
 
     WHEN("We add an alias") {
@@ -48,6 +50,17 @@ TEST_CASE("We can add an alias to a variable in a container", "[ContainerAlias]"
       THEN("The variable is only counted once in a variable pack") {
         auto pack = rc.PackVariables();
         REQUIRE(pack.GetDim(4) == 1);
+      }
+      THEN("We can pack based on the original name") {
+        auto pack = rc.PackVariables(std::vector<std::string>{"var"});
+        REQUIRE(pack.GetDim(4) == 1);
+      }
+      THEN("We can pack based on the aliased name") {
+        auto pack = rc.PackVariables(std::vector<std::string>{"alias"});
+        REQUIRE(pack.GetDim(4) == 1);
+      }
+      THEN("Packing both alias and the original names throws an error") {
+        REQUIRE_THROWS(rc.PackVariables(std::vector<std::string>{"var","alias"}));
       }
     }
   }

--- a/tst/unit/test_variable_aliases.cpp
+++ b/tst/unit/test_variable_aliases.cpp
@@ -1,0 +1,54 @@
+//========================================================================================
+// Athena++ astrophysical MHD code
+// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#invlude < vector>
+
+#include <catch2/catch.hpp>
+
+#include "basic_types.hpp"
+#include "config.hpp"
+#include "defs.hpp"
+#include "interface/container.hpp"
+#include "interface/metadata.hpp"
+#include "interface/variable.hpp"
+#include "interface/variable_pack.hpp"
+#include "kokkos_abstraction.hpp"
+#include "parthenon_arrays.hpp"
+
+using parthenon::Container;
+using parthenon::Metadata;
+
+TEST_CASE("We can add an alias to a variable in a container", "[ContainerAlias]") {
+  GIVEN("A container with a variable in it") {
+    Container<Real> rc;
+    std::vector<int> block_size = {16, 16, 16};
+    Metadata m({Metdata::Independent, Metadata::FillGhost}, block_size);
+    rc.Add("var", m);
+
+    WHEN("We add an alias") {
+      rc.Add("alias", "var", m);
+      THEN("We can extract the variable via either the alias or the original name") {
+        REQUIRE(rc.Get("var").label() == "var");
+        REQUIRE(rc.Get("alias").label() == "var");
+      }
+      THEN("The variable is only counted once in a variable pack") {
+        auto pack = rc.PackVariables();
+        REQUIRE(pack.GetDim(4) == 1);
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

We have discovered a need in our internal codebase to create aliases to variables, i.e., allow a variable to be referred to by two or more names. This is a very preliminary attempt to enable this.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
