### PR TITLE
Add parthenon root dir to parameters

### DIFF
--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -81,16 +81,7 @@ class TestCase(utils.test_case.TestCaseAbs):
         analyze_status = True
         print(os.getcwd())
 
-        # Determine path to parthenon installation
-        # Fallback to relative path on failure
-        try:
-            parthenonPath = os.path.realpath(__file__)
-            idx = parthenonPath.rindex('/parthenon/')
-            parthenonPath = os.path.join(parthenonPath[:idx],'parthenon')
-        except ValueError:
-            baseDir = os.path.dirname(__file__)
-            parthenonPath = baseDir + '/../../../..'
-        sys.path.insert(1, parthenonPath+'/scripts/python')
+        sys.path.insert(1, parameters.parthenon_path + '/scripts/python')
 
         try:
             import phdf_diff 
@@ -101,10 +92,10 @@ class TestCase(utils.test_case.TestCaseAbs):
         # TODO(pgrete) make sure this also works/doesn't fail for the user
         ret_2d = phdf_diff.compare([
             'advection_2d.out0.00001.phdf',
-            parthenonPath+'/tst/regression/gold_standard/advection_2d.out0.00001.phdf'])
+            parameters.parthenon_path + '/tst/regression/gold_standard/advection_2d.out0.00001.phdf'])
         ret_3d = phdf_diff.compare([
             'advection_3d.out0.00001.phdf',
-            parthenonPath+'/tst/regression/gold_standard/advection_3d.out0.00001.phdf'])
+            parameters.parthenon_path + '/tst/regression/gold_standard/advection_3d.out0.00001.phdf'])
         
         if ret_2d != 0 or ret_3d != 0:
             analyze_status = False

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -28,6 +28,7 @@ class Parameters():
     driver_input_path = ""
     test_path = ""
     output_path = ""
+    parthenon_path = ""
     mpi_cmd = ""
     num_ranks = 1
     mpi_opts = ""
@@ -81,6 +82,14 @@ class TestManager:
             output_path = os.path.abspath(test_path + "/output")
         else:
             output_path = os.path.abspath(output_path)
+
+        try:
+            parthenon_path = os.path.realpath(__file__)
+            idx = parthenon_path.rindex('/parthenon/')
+            self.parameters.parthenon_path = os.path.join(parthenon_path[:idx],'parthenon')
+        except ValueError:
+            baseDir = os.path.dirname(__file__)
+            self.parameters.parthenon_path = os.path.abspath(baseDir + '/../../../')
 
         self.__test_module = 'test_suites.' + test_base_name + '.' + test_base_name
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a small pr that moves some logic from some of the restart files to the python test_case class. Namely, the need to locate the parthenon root dir. This was used in the output_hdf5.py file as well as in the currently open pr related to the particles regression test. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
This change is to simply provide additional functionality when writing regression tests. 
<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
