### PR TITLE
WIP: Make copy construction of MeshBlockPack and VariablePack from device code impossible

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -213,6 +213,7 @@ add_library(parthenon
   utils/change_rundir.cpp
   utils/error_checking.hpp
   utils/error_checking.cpp
+  utils/kokkos.cpp
   utils/partition_stl_containers.hpp
   utils/show_config.cpp
   utils/signal_handler.cpp

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -24,6 +24,7 @@
 #include <Kokkos_Core.hpp>
 
 #include "interface/metadata.hpp"
+#include "utils/kokkos.hpp"
 
 namespace parthenon {
 
@@ -66,7 +67,7 @@ using ViewOfParArrays = ParArray1D<ParArray3D<T>>;
 // Try to keep these Variable*Pack classes as lightweight as possible.
 // They go to the device.
 template <typename T>
-class VariablePack {
+class VariablePack : private KokkosDisableDeviceCopy {
  public:
   VariablePack() = default;
   VariablePack(const ViewOfParArrays<T> view, const ParArray1D<int> sparse_ids,

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -26,6 +26,7 @@
 #include "kokkos_abstraction.hpp"
 #include "mesh/domain.hpp"
 #include "mesh/meshblock.hpp" // TODO(JMM): Replace with forward declaration?
+#include "utils/kokkos.hpp"
 
 namespace parthenon {
 
@@ -36,7 +37,7 @@ class Mesh;
 // TODO(JMM): Using one IndexShape because its the same for all
 // meshblocks. This needs careful thought before sticking with it.
 template <typename T>
-class MeshBlockPack {
+class MeshBlockPack : private KokkosDisableDeviceCopy {
  public:
   MeshBlockPack() = default;
   MeshBlockPack(const ParArray1D<T> view, const IndexShape shape,

--- a/src/utils/kokkos.cpp
+++ b/src/utils/kokkos.cpp
@@ -27,9 +27,8 @@
 using namespace parthenon;
 
 KOKKOS_IMPL_HOST_FUNCTION
-KokkosDisableDeviceCopy::KokkosDisableDeviceCopy(KokkosDisableDeviceCopy const &) {}
+KokkosDisableDeviceCopy::KokkosDisableDeviceCopy(KokkosDisableDeviceCopy const &) =
+    default;
 
 KOKKOS_IMPL_HOST_FUNCTION KokkosDisableDeviceCopy &KokkosDisableDeviceCopy::
-operator=(KokkosDisableDeviceCopy const &) {
-  return *this;
-}
+operator=(KokkosDisableDeviceCopy const &) = default;

--- a/src/utils/kokkos.cpp
+++ b/src/utils/kokkos.cpp
@@ -1,0 +1,35 @@
+//========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2020 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+/**
+ * @file kokkos.cpp
+ * @author Andrew Gaspar <agaspar@lanl.gov>
+ * @brief Utilities for Kokkos
+ * @date 2020-11-19
+ */
+
+#include "kokkos.hpp"
+
+using namespace parthenon;
+
+KOKKOS_IMPL_HOST_FUNCTION
+KokkosDisableDeviceCopy::KokkosDisableDeviceCopy(KokkosDisableDeviceCopy const &) {}
+
+KOKKOS_IMPL_HOST_FUNCTION KokkosDisableDeviceCopy &KokkosDisableDeviceCopy::
+operator=(KokkosDisableDeviceCopy const &) {
+  return *this;
+}

--- a/src/utils/kokkos.hpp
+++ b/src/utils/kokkos.hpp
@@ -1,0 +1,53 @@
+//========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2020 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+/**
+ * @file kokkos.hpp
+ * @author Andrew Gaspar <agaspar@lanl.gov>
+ * @brief Utilities for kokkos
+ * @date 2020-11-19
+ */
+
+#ifndef UTILS_KOKKOS_HPP_
+#define UTILS_KOKKOS_HPP_
+
+#include <Kokkos_Core.hpp>
+
+namespace parthenon {
+/**
+ * @brief A class to disable copying on device, for avoiding accidental performance
+ * pitfalls
+ *
+ * To use, just make this a private base class.
+ */
+class KokkosDisableDeviceCopy {
+ public:
+  KokkosDisableDeviceCopy() = default;
+  ~KokkosDisableDeviceCopy() = default;
+
+  KOKKOS_IMPL_HOST_FUNCTION KokkosDisableDeviceCopy(KokkosDisableDeviceCopy const &other);
+  KOKKOS_IMPL_HOST_FUNCTION KokkosDisableDeviceCopy &
+  operator=(KokkosDisableDeviceCopy const &other);
+
+  KokkosDisableDeviceCopy(KokkosDisableDeviceCopy &&other) = default;
+  KokkosDisableDeviceCopy &operator=(KokkosDisableDeviceCopy &&other) = default;
+
+ private:
+};
+} // namespace parthenon
+
+#endif // UTILS_KOKKOS_HPP_


### PR DESCRIPTION

## PR Summary

This code shouldn't be merged. Demonstration only in case anybody has a better idea.

This change makes it impossible to copy a `VariablePack` or `MeshBlockPack` in device code - the code will fail to compile. Unfortunately, it makes it impossible to compile the code at all - the compiler is certain that there are copies of `VariablePack` happening even when I'm sure I have none.. Maybe somebody smarter can figure it out.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
