### PR TITLE
Add more profiling regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 378]](https://github.com/lanl/parthenon/pull/378) Add Kokkos profiling regions throughout the code to allow the collection characteristic application profiles
 - [[PR 358]](https://github.com/lanl/parthenon/pull/358) Generalize code that interfaces with downstream apps to work with both `MeshData` and `MeshBlockData`.
 - [[PR 335]](https://github.com/lanl/parthenon/pull/335) Support for project-relative `MACHINE_CFG` with `@PAR_ROOT@`
 - [[PR 328]](https://github.com/lanl/parthenon/pull/328) New `MeshBlock` packing interface using `DataCollection`s of `MeshData` and `MeshBlockData`.

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -56,10 +56,12 @@ TaskStatus UpdateMeshData(const int stage, Integrator *integrator,
                           std::shared_ptr<parthenon::MeshData<Real>> &base,
                           std::shared_ptr<parthenon::MeshData<Real>> &dudt,
                           std::shared_ptr<parthenon::MeshData<Real>> &out) {
+  Kokkos::Profiling::pushRegion("Task_Advection_UpdateMeshData");
   const Real beta = integrator->beta[stage - 1];
   const Real dt = integrator->dt;
   parthenon::Update::AverageIndependentData(in, base, beta);
   parthenon::Update::UpdateIndependentData(in, dudt, beta * dt, out);
+  Kokkos::Profiling::popRegion(); // Task_Advection_UpdateMeshData
   return TaskStatus::complete;
 }
 

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -305,6 +305,7 @@ Real EstimateTimestepBlock(std::shared_ptr<MeshBlockData<Real>> &rc) {
 // some field "advected" that we are pushing around.
 // This routine implements all the "physics" in this example
 TaskStatus CalculateFluxes(std::shared_ptr<MeshBlockData<Real>> &rc) {
+  Kokkos::Profiling::pushRegion("Task_Advection_CalculateFluxes");
   auto pmb = rc->GetBlockPointer();
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);
   IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior);
@@ -407,6 +408,7 @@ TaskStatus CalculateFluxes(std::shared_ptr<MeshBlockData<Real>> &rc) {
         });
   }
 
+  Kokkos::Profiling::popRegion(); // Task_Advection_CalculateFluxes
   return TaskStatus::complete;
 }
 

--- a/src/bvals/boundary_conditions.cpp
+++ b/src/bvals/boundary_conditions.cpp
@@ -30,6 +30,7 @@ bool DoPhysicalBoundary_(const BoundaryFlag flag, const BoundaryFace face,
 
 TaskStatus ProlongateBoundaries(std::shared_ptr<MeshBlockData<Real>> &rc) {
   if (!(rc->GetBlockPointer()->pmy_mesh->multilevel)) return TaskStatus::complete;
+  Kokkos::Profiling::pushRegion("Task_ProlongateBoundaries");
 
   // This hardcoded technique is also used to manually specify the coupling between
   // physical variables in:
@@ -51,11 +52,13 @@ TaskStatus ProlongateBoundaries(std::shared_ptr<MeshBlockData<Real>> &rc) {
   // Step 3. Finally, the ghost-ghost zones are ready for prolongation:
   rc->ProlongateBoundaries();
 
+  Kokkos::Profiling::popRegion(); // Task_ProlongateBoundaries
   return TaskStatus::complete;
 }
 
 TaskStatus ApplyBoundaryConditionsOnCoarseOrFine(std::shared_ptr<MeshBlockData<Real>> &rc,
                                                  bool coarse) {
+  Kokkos::Profiling::pushRegion("Task_ApplyBoundaryConditionsOnCoarseOrFine");
   using namespace boundary_cond_impl;
   std::shared_ptr<MeshBlock> pmb = rc->GetBlockPointer();
   Mesh *pmesh = pmb->pmy_mesh;
@@ -69,6 +72,7 @@ TaskStatus ApplyBoundaryConditionsOnCoarseOrFine(std::shared_ptr<MeshBlockData<R
     }
   }
 
+  Kokkos::Profiling::popRegion(); // Task_ApplyBoundaryConditionsOnCoarseOrFine
   return TaskStatus::complete;
 }
 

--- a/src/bvals/bvals_base.cpp
+++ b/src/bvals/bvals_base.cpp
@@ -299,6 +299,7 @@ int BoundaryBase::CreateBvalsMPITag(int lid, int bufid, int phys) {
 
 void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
                                          int *nslist) {
+  Kokkos::Profiling::pushRegion("SearchAndSetNeighbors");
   MeshBlockTree *neibt;
   int myox1, myox2 = 0, myox3 = 0, myfx1, myfx2, myfx3;
   myfx1 = ((loc.lx1 & 1LL) == 1LL);
@@ -363,7 +364,10 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
       nneighbor++;
     }
   }
-  if (block_size_.nx2 == 1) return;
+  if (block_size_.nx2 == 1) {
+    Kokkos::Profiling::popRegion(); // SearchAndSetNeighbors
+    return;
+  }
 
   // x2 face
   for (int n = -1; n <= 1; n += 2) {
@@ -494,7 +498,10 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
     }
   }
 
-  if (block_size_.nx3 == 1) return;
+  if (block_size_.nx3 == 1) {
+    Kokkos::Profiling::popRegion(); // SearchAndSetNeighbors
+    return;
+  }
 
   // x1x3 edge
   for (int m = -1; m <= 1; m += 2) {
@@ -613,7 +620,7 @@ void BoundaryBase::SearchAndSetNeighbors(MeshBlockTree &tree, int *ranklist,
       }
     }
   }
-  return;
+  Kokkos::Profiling::popRegion(); // SearchAndSetNeighbors
 }
 
 } // namespace parthenon

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -57,6 +57,7 @@ DriverStatus EvolutionDriver::Execute() {
   pmesh->mbcnt = 0;
   int perf_cycle_offset =
       pinput->GetOrAddInteger("parthenon/time", "perf_cycle_offset", 0);
+  Kokkos::Profiling::pushRegion("Driver_Main");
   while (tm.KeepGoing()) {
     if (Globals::my_rank == 0) OutputCycleDiagnostics();
 
@@ -86,6 +87,7 @@ DriverStatus EvolutionDriver::Execute() {
       timer_main.reset();
     }
   } // END OF MAIN INTEGRATION LOOP ======================================================
+  Kokkos::Profiling::popRegion(); // Driver_Main
 
   pmesh->UserWorkAfterLoop(pmesh, pinput, tm);
 

--- a/src/driver/multistage.cpp
+++ b/src/driver/multistage.cpp
@@ -59,6 +59,7 @@ MultiStageDriver::MultiStageDriver(ParameterInput *pin, ApplicationInput *app_in
 }
 
 TaskListStatus MultiStageBlockTaskDriver::Step() {
+  Kokkos::Profiling::pushRegion("MultiStage_Step");
   using DriverUtils::ConstructAndExecuteTaskLists;
   TaskListStatus status;
   integrator->dt = tm.dt;
@@ -66,6 +67,7 @@ TaskListStatus MultiStageBlockTaskDriver::Step() {
     status = ConstructAndExecuteTaskLists<>(this, stage);
     if (status != TaskListStatus::complete) break;
   }
+  Kokkos::Profiling::popRegion(); // MultiStage_Step
   return status;
 }
 

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -249,8 +249,8 @@ void Mesh::UpdateMeshBlockTree(int &nnew, int &ndel) {
     tnref += nref[n];
     tnderef += nderef[n];
   }
-  if (tnref == 0 && tnderef < nleaf) {// nothing to do
-    Kokkos::Profiling::popRegion(); // UpdateMeshBlockTree
+  if (tnref == 0 && tnderef < nleaf) { // nothing to do
+    Kokkos::Profiling::popRegion();    // UpdateMeshBlockTree
     return;
   }
 
@@ -617,9 +617,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         sb_idx++;
       }
     }
-  }    // if (nsend !=0)
+  }                               // if (nsend !=0)
   Kokkos::Profiling::popRegion(); // Step 6
-#endif // MPI_PARALLEL
+#endif                            // MPI_PARALLEL
 
   // Step 7. construct a new MeshBlock list (moving the data within the MPI rank)
   Kokkos::Profiling::pushRegion("Step 7: Construct new MeshBlockList");

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -47,6 +47,7 @@ namespace parthenon {
 
 void Mesh::LoadBalancingAndAdaptiveMeshRefinement(ParameterInput *pin,
                                                   ApplicationInput *app_in) {
+  Kokkos::Profiling::pushRegion("LoadBalancingAndAdaptiveMeshRefinement");
   int nnew = 0, ndel = 0;
 
   if (adaptive) {
@@ -71,7 +72,7 @@ void Mesh::LoadBalancingAndAdaptiveMeshRefinement(ParameterInput *pin,
     }
     lb_flag_ = false;
   }
-  return;
+  Kokkos::Profiling::popRegion(); // LoadBalancingAndAdaptiveMeshRefinement
 }
 
 // Private routines
@@ -134,6 +135,7 @@ void UpdateBlockList(std::vector<int> const &ranklist, std::vector<int> &nslist,
 void Mesh::CalculateLoadBalance(std::vector<double> const &costlist,
                                 std::vector<int> &ranklist, std::vector<int> &nslist,
                                 std::vector<int> &nblist) {
+  Kokkos::Profiling::pushRegion("CalculateLoadBalance");
   auto const total_blocks = costlist.size();
 
   using it = std::vector<double>::const_iterator;
@@ -180,6 +182,7 @@ void Mesh::CalculateLoadBalance(std::vector<double> const &costlist,
                 << std::endl;
     }
   }
+  Kokkos::Profiling::popRegion(); // CalculateLoadBalance
 }
 
 //----------------------------------------------------------------------------------------
@@ -219,6 +222,7 @@ void Mesh::UpdateCostList() {
 // \brief collect refinement flags and manipulate the MeshBlockTree
 
 void Mesh::UpdateMeshBlockTree(int &nnew, int &ndel) {
+  Kokkos::Profiling::pushRegion("UpdateMeshBlockTree");
   // compute nleaf= number of leaf MeshBlocks per refined block
   int nleaf = 2;
   if (mesh_size.nx2 > 1) nleaf = 4;
@@ -245,8 +249,10 @@ void Mesh::UpdateMeshBlockTree(int &nnew, int &ndel) {
     tnref += nref[n];
     tnderef += nderef[n];
   }
-  if (tnref == 0 && tnderef < nleaf) // nothing to do
+  if (tnref == 0 && tnderef < nleaf) {// nothing to do
+    Kokkos::Profiling::popRegion(); // UpdateMeshBlockTree
     return;
+  }
 
   int rd = 0, dd = 0;
   for (int n = 0; n < Globals::nranks; n++) {
@@ -346,7 +352,7 @@ void Mesh::UpdateMeshBlockTree(int &nnew, int &ndel) {
   }
   if (tnderef >= nleaf) delete[] clderef;
 
-  return;
+  Kokkos::Profiling::popRegion(); // UpdateMeshBlockTree
 }
 
 //----------------------------------------------------------------------------------------
@@ -387,6 +393,7 @@ bool Mesh::GatherCostListAndCheckBalance() {
 
 void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput *app_in,
                                            int ntot) {
+  Kokkos::Profiling::pushRegion("RedistributeAndRefineMeshBlocks");
   // kill any cached packs
   mesh_data.PurgeNonBase();
   mesh_data.Get()->ClearCaches();
@@ -397,6 +404,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   if (mesh_size.nx3 > 1) nleaf = 8;
 
   // Step 1. construct new lists
+  Kokkos::Profiling::pushRegion("Step1: Construct new list");
   std::vector<LogicalLocation> newloc(ntot);
   std::vector<int> newrank(ntot);
   std::vector<double> newcost(ntot);
@@ -442,6 +450,8 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   int onbs = nslist[Globals::my_rank];
   int onbe = onbs + nblist[Globals::my_rank] - 1;
 #endif
+  Kokkos::Profiling::popRegion(); // Step 1
+
   // Step 2. Calculate new load balance
   CalculateLoadBalance(newcost, newrank, nslist, nblist);
 
@@ -453,6 +463,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   int bnx2 = GetBlockSize().nx2;
   int bnx3 = GetBlockSize().nx3;
   // Step 3. count the number of the blocks to be sent / received
+  Kokkos::Profiling::pushRegion("Step 3: Count blocks");
   int nsend = 0, nrecv = 0;
   for (int n = nbs; n <= nbe; n++) {
     int on = newtoold[n];
@@ -475,7 +486,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     }
   }
 
+  Kokkos::Profiling::popRegion(); // Step 3
   // Step 4. calculate buffer sizes
+  Kokkos::Profiling::pushRegion("Step 4: Calc buffer sizes");
   ParArray1D<Real> *sendbuf, *recvbuf;
   // use the first MeshBlock in the linked list of blocks belonging to this MPI rank as a
   // representative of all MeshBlocks for counting the "load-balancing registered" and
@@ -512,9 +525,11 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
        (bnx1 / 2 + 2) * ((bnx2 + 1) / 2 + 2 * f2) * (((bnx3 + 1) / 2) + f3 + 2 * f3));
   // add one more element to buffer size for storing the derefinement counter
   bssame++;
+  Kokkos::Profiling::popRegion(); // Step 4
 
   MPI_Request *req_send, *req_recv;
   // Step 5. allocate and start receiving buffers
+  Kokkos::Profiling::pushRegion("Step 5: Alloc buffer and start recv");
   if (nrecv != 0) {
     recvbuf = new ParArray1D<Real>[nrecv];
     req_recv = new MPI_Request[nrecv];
@@ -553,7 +568,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       }
     }
   }
+  Kokkos::Profiling::popRegion(); // Step 5
   // Step 6. allocate, pack and start sending buffers
+  Kokkos::Profiling::pushRegion("Step 6: Alloc, pack, and send buffers");
   if (nsend != 0) {
     sendbuf = new ParArray1D<Real>[nsend];
     req_send = new MPI_Request[nsend];
@@ -601,9 +618,11 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       }
     }
   }    // if (nsend !=0)
+  Kokkos::Profiling::popRegion(); // Step 6
 #endif // MPI_PARALLEL
 
   // Step 7. construct a new MeshBlock list (moving the data within the MPI rank)
+  Kokkos::Profiling::pushRegion("Step 7: Construct new MeshBlockList");
   {
     RegionSize block_size = GetBlockSize();
 
@@ -649,8 +668,10 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       block_list[n - nbs]->lid = n - nbs;
     }
   }
+  Kokkos::Profiling::popRegion(); // Step 7: Construct new MeshBlockList
 
   // Step 8. Receive the data and load into MeshBlocks
+  Kokkos::Profiling::pushRegion("Step 8: Recv data and unpack");
   // This is a test: try MPI_Waitall later.
 #ifdef MPI_PARALLEL
   if (nrecv != 0) {
@@ -697,6 +718,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     delete[] req_recv;
   }
 #endif
+  Kokkos::Profiling::popRegion(); // Step 8
 
   // update the lists
   loclist = std::move(newloc);
@@ -711,7 +733,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
   ResetLoadBalanceVariables();
 
-  return;
+  Kokkos::Profiling::popRegion(); // RedistributeAndRefineMeshBlocks
 }
 
 // AMR: step 6, branch 1 (same2same: just pack+send)

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1022,6 +1022,7 @@ void Mesh::ApplyUserWorkBeforeOutput(ParameterInput *pin) {
 // \brief  initialization before the main loop
 
 void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_in) {
+  Kokkos::Profiling::pushRegion("Mesh::Initialize");
   bool iflag = true;
   int inb = nbtotal;
 #ifdef OPENMP_PARALLEL
@@ -1125,7 +1126,7 @@ void Mesh::Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_i
     }
   } while (!iflag);
 
-  return;
+  Kokkos::Profiling::popRegion(); // Mesh::Initialize
 }
 
 /// Finds location of a block with ID `tgid`. Can provide an optional "hint" to start

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -416,6 +416,7 @@ void OutputType::ClearOutputData() {
 //  \brief scans through singly linked list of OutputTypes and makes any outputs needed.
 
 void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
+  Kokkos::Profiling::pushRegion("MakeOutputs");
   bool first = true;
   OutputType *ptype = pfirst_type_;
   while (ptype != nullptr) {
@@ -431,6 +432,7 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     }
     ptype = ptype->pnext_type; // move to next OutputType node in signly linked list
   }
+  Kokkos::Profiling::popRegion(); // MakeOutputs
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/refinement/refinement.cpp
+++ b/src/refinement/refinement.cpp
@@ -131,16 +131,20 @@ AmrTag FirstDerivative(MeshBlock *pmb, const ParArrayND<Real> &q,
 }
 
 TaskStatus Tag(std::shared_ptr<MeshBlockData<Real>> &rc) {
+  Kokkos::Profiling::pushRegion("Task_Tag_Block");
   auto pmb = rc->GetBlockPointer();
   pmb->pmr->SetRefinement(CheckAllRefinement(rc));
+  Kokkos::Profiling::popRegion(); // Task_Tag_Block
   return TaskStatus::complete;
 }
 
 TaskStatus Tag(std::shared_ptr<MeshData<Real>> &rc) {
+  Kokkos::Profiling::pushRegion("Task_Tag_Mesh");
   for (int i = 0; i < rc->NumBlocks(); i++) {
     auto &pbd = rc->GetBlockData(i);
     auto status = Tag(pbd);
   }
+  Kokkos::Profiling::popRegion(); // Task_Tag_Mesh
   return TaskStatus::complete;
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Those new regions should allow us to create a more detailed full application profile and make it easier to track hot spots.
For example, a static grid run without outputs may look like
```
TOP-DOWN TIME TREE:
<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
=================== 
|-> 1.18e+00 sec 89.5% 26.5% 0.0% 0.0% 5.71e+02 1 Driver_Main [region]
|   |-> 1.18e+00 sec 89.5% 26.5% 0.0% 0.1% 5.71e+02 10 MultiStage_Step [region]
|   |   |-> 4.26e-01 sec 32.4% 0.0% 0.0% 0.0% 4.22e+01 20 Task_FillDerived [region]
|   |   |   |-> 3.23e-01 sec 24.5% 0.0% 0.0% 0.1% 1.86e+01 20 PostFillDerived [region]
|   |   |   |   |-> 3.23e-01 sec 24.5% 0.0% 0.0% 100.0% 0.00e+00 20 advection_package::PostFill [region]
|   |   |   |-> 5.29e-02 sec 4.0% 0.0% 0.0% 0.4% 1.13e+02 20 PreFillDerived [region]
|   |   |   |   |-> 5.27e-02 sec 4.0% 0.0% 0.0% 100.0% 0.00e+00 20 advection_package::PreFill [region]
|   |   |   |-> 5.07e-02 sec 3.9% 0.0% 0.0% 0.4% 1.18e+02 20 FillDerived [region]
|   |   |       |-> 5.05e-02 sec 3.8% 0.0% 0.0% 100.0% 0.00e+00 20 advection_package::SquareIt [region]
|   |   |-> 2.82e-01 sec 21.4% 99.9% 0.0% 0.1% 2.13e+02 20 Task_Advection_CalculateFluxes [region]
|   |   |   |-> 1.06e-01 sec 8.1% 100.0% 0.0% ------ 20 x2 flux [for]
|   |   |   |-> 1.05e-01 sec 7.9% 100.0% 0.0% ------ 20 x3 flux [for]
|   |   |   |-> 7.09e-02 sec 5.4% 100.0% 0.0% ------ 20 x1 flux [for]
|   |   |-> 2.42e-01 sec 18.4% 0.0% 0.0% 100.0% 0.00e+00 20 FluxDivergenceMesh [region]
|   |   |-> 1.79e-01 sec 13.6% 0.0% 0.0% 0.3% 1.12e+02 20 Task_Advection_UpdateMeshData [region]
|   |   |   |-> 9.85e-02 sec 7.5% 0.0% 0.0% 100.0% 0.00e+00 20 UpdateMeshData [region]
|   |   |   |-> 8.03e-02 sec 6.1% 0.0% 0.0% 100.0% 0.00e+00 20 AverageMeshData [region]
|   |   |-> 1.78e-02 sec 1.4% 99.7% 0.0% 0.3% 5.62e+02 10 Task_EstimateTimestep [region]
|   |   |   |-> 1.77e-02 sec 1.3% 100.0% 0.0% ------ 10 advection_package::EstimateTimestep [reduce]
|   |   |-> 1.28e-02 sec 1.0% 17.7% 0.0% 4.2% 4.06e+04 20 Task_SendBoundaryBuffers [region]
|   |   |   |-> 9.99e-03 sec 0.8% 0.0% 0.0% 100.0% 0.00e+00 520 PackData 4D [region]
|   |   |-> 1.02e-02 sec 0.8% 100.0% 0.0% ------ 2 Kokkos::View::initialization [advected] [for]
|   |   |-> 5.52e-03 sec 0.4% 0.0% 0.0% 2.1% 0.00e+00 20 Task_SetBoundaries [region]
|   |   |   |-> 5.40e-03 sec 0.4% 0.0% 0.0% 100.0% 0.00e+00 520 UnpackData 4D [region]
...
```

and an AMR run (here our short test) may look like
```
TOP-DOWN TIME TREE:
<average time> <percent of total time> <percent time in Kokkos> <percent MPI imbalance> <remainder> <kernels per second> <number of calls> <name> [type]
=================== 
|-> 1.97e+01 sec 97.6% 1.2% 0.0% 0.2% 1.66e+04 1 Driver_Main [region]
|   |-> 1.79e+01 sec 88.4% 0.1% 0.0% 0.0% 4.52e+03 214 LoadBalancingAndAdaptiveMeshRefinement [region]
|   |   |-> 1.77e+01 sec 87.3% 0.1% 0.0% 0.0% 4.57e+03 30 RedistributeAndRefineMeshBlocks [region]
|   |   |   |-> 1.00e+01 sec 49.5% 0.0% 0.0% 0.1% 3.01e+03 30 Mesh::Initialize [region]
|   |   |   |   |-> 9.89e+00 sec 48.9% 0.0% 0.0% 99.9% 0.00e+00 1770 Task_ReceiveAndSetBoundariesWithWait [region]
|   |   |   |   |-> 4.33e-02 sec 0.2% 0.9% 0.0% 1.1% 1.12e+05 1800 Task_FillDerived [region]
|   |   |   |   |   |-> 2.16e-02 sec 0.1% 0.6% 0.0% 40.2% 7.51e+04 1800 PostFillDerived [region]
|   |   |   |   |-> 4.02e-02 sec 0.2% 6.6% 0.0% 74.0% 6.28e+05 1770 Task_SendBoundaryBuffers [region]
|   |   |   |-> 6.84e+00 sec 33.8% 0.2% 0.0% 99.8% 7.32e+03 30 Step 7: Construct new MeshBlockList [region]
|   |   |   |-> 8.07e-01 sec 4.0% 0.0% 0.0% 100.0% 1.23e+02 30 Step 8: Recv data and unpack [region]
|   |   |-> 2.15e-01 sec 1.1% 0.0% 0.0% 100.0% 0.00e+00 214 UpdateMeshBlockTree [region]
|   |-> 1.82e+00 sec 9.0% 12.0% 0.0% 18.9% 1.35e+05 214 MultiStage_Step [region]
|   |   |-> 3.11e-01 sec 1.5% 6.3% 0.0% 76.4% 5.53e+05 12041 Task_SendBoundaryBuffers [region]
|   |   |   |-> 4.83e-02 sec 0.2% 0.0% 0.0% 100.0% 0.00e+00 286279 PackData 4D [region]
|   |   |-> 2.36e-01 sec 1.2% 0.0% 0.0% 1.3% 0.00e+00 12041 Task_FillDerived [region]
|   |   |   |-> 1.32e-01 sec 0.7% 0.0% 0.0% 30.9% 0.00e+00 12041 PostFillDerived [region]
|   |   |   |   |-> 9.10e-02 sec 0.4% 0.0% 0.0% 100.0% 0.00e+00 12041 advection_package::PostFill [region]
|   |   |   |-> 5.39e-02 sec 0.3% 0.0% 0.0% 59.3% 0.00e+00 12041 PreFillDerived [region]
|   |   |   |   |-> 2.20e-02 sec 0.1% 0.0% 0.0% 100.0% 0.00e+00 12041 advection_package::PreFill [region]
|   |   |   |-> 4.72e-02 sec 0.2% 0.0% 0.0% 49.3% 0.00e+00 12041 FillDerived [region]
|   |   |       |-> 2.39e-02 sec 0.1% 0.0% 0.0% 100.0% 0.00e+00 12041 advection_package::SquareIt [region]
|   |   |-> 2.12e-01 sec 1.0% 0.0% 0.0% 100.0% 0.00e+00 27784 Task_ReceiveBoundaryBuffers [region]
|   |   |-> 1.88e-01 sec 0.9% 89.5% 0.0% 10.5% 1.92e+05 12041 Task_Advection_CalculateFluxes [region]
|   |   |   |-> 6.18e-02 sec 0.3% 100.0% 0.0% ------ 12041 x3 flux [for]
|   |   |   |-> 5.78e-02 sec 0.3% 100.0% 0.0% ------ 12041 x2 flux [for]
|   |   |   |-> 4.85e-02 sec 0.2% 100.0% 0.0% ------ 12041 x1 flux [for]
|   |   |-> 1.38e-01 sec 0.7% 0.0% 0.0% 50.2% 0.00e+00 12041 Task_SetBoundaries [region]
|   |   |   |-> 6.85e-02 sec 0.3% 0.0% 0.0% 100.0% 0.00e+00 286279 UnpackData 4D [region]
|   |   |-> 1.35e-01 sec 0.7% 0.2% 0.0% 43.7% 1.43e+04 214 Task_Advection_UpdateMeshData [region]
|   |   |   |-> 4.06e-02 sec 0.2% 0.0% 0.0% 100.0% 0.00e+00 214 UpdateMeshData [region]
|   |   |   |-> 3.50e-02 sec 0.2% 0.0% 0.0% 100.0% 0.00e+00 214 AverageMeshData [region]
|   |   |-> 6.18e-02 sec 0.3% 0.0% 0.0% 7.2% 0.00e+00 12041 Task_ProlongateBoundaries [region]
|   |   |   |-> 3.81e-02 sec 0.2% 0.0% 0.0% 82.2% 0.00e+00 12041 RestrictBoundaries [region]
|   |   |-> 5.12e-02 sec 0.3% 0.0% 0.0% 100.0% 0.00e+00 214 FluxDivergenceMesh [region]
|   |   |-> 4.72e-02 sec 0.2% 0.0% 0.0% 100.0% 0.00e+00 12041 Task_StartReceiving [region]
|   |   |-> 2.89e-02 sec 0.1% 72.3% 0.0% 27.7% 4.16e+05 12041 Task_Tag_Block [region]
|   |   |   |-> 2.09e-02 sec 0.1% 100.0% 0.0% ------ 12041 advection check refinement [reduce]
...
```

I'll add a basic script to process those result tomorrow (I have an older one that I can recycle) that could be the basis for the planned continuous benchmarking.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [does not apply] New features are documented.
- [does not apply] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
