### PR TITLE
WIP: Split init/finalize

### DIFF
--- a/src/parthenon_manager.hpp
+++ b/src/parthenon_manager.hpp
@@ -36,6 +36,8 @@ class ParthenonManager {
   ParthenonManager() { app_input.reset(new ApplicationInput()); }
   ParthenonStatus ParthenonInit(int argc, char *argv[]);
   ParthenonStatus ParthenonFinalize();
+  ParthenonStatus ParthenonInitParallel(int argc, char *argv[]);
+  ParthenonStatus ParthenonFinalizeParallel();
 
   bool Restart() { return (arg.restart_filename == nullptr ? false : true); }
   static Properties_t ProcessPropertiesDefault(std::unique_ptr<ParameterInput> &pin);

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_library(catch2_define catch2_define.cpp)
-target_link_libraries(catch2_define PUBLIC Catch2::Catch2 Kokkos::kokkos)
+target_link_libraries(catch2_define PUBLIC Catch2::Catch2 Parthenon::parthenon)
 
 if(${PARTHENON_ENABLE_UNIT_TESTS})
   message(STATUS "Building unit tests.")

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -15,12 +15,14 @@
 
 #include <catch2/catch.hpp>
 
-#include <Kokkos_Core.hpp>
+#include "parthenon_manager.hpp"
+using parthenon::ParthenonManager;
 
 int main(int argc, char *argv[]) {
   // global setup...
   int result;
-  Kokkos::initialize(argc, argv);
+  ParthenonManager pman;
+  pman.ParthenonInitParallel(argc, argv);
 
   {
     result = Catch::Session().run(argc, argv);
@@ -28,6 +30,6 @@ int main(int argc, char *argv[]) {
     // global clean-up...
   }
 
-  Kokkos::finalize();
+  pman.ParthenonFinalizeParallel();
   return result;
 }

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -22,7 +22,10 @@ int main(int argc, char *argv[]) {
   // global setup...
   int result;
   ParthenonManager pman;
-  pman.ParthenonInitParallel(argc, argv);
+  auto status = pman.ParthenonInitParallel(argc, argv);
+  if (status == parthenon::ParthenonStatus::error) {
+    throw std::runtime_error("Problem encountered in ParthenonInitParallel");
+  }
 
   {
     result = Catch::Session().run(argc, argv);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Splits out MPI/OpenMP/Kokkos setup and takedown from `ParthenonInit` and `ParthenonFinalize`.  This allows the parthenon provided parallel init/finalize to be used in the unit tests.

This is a trivial change that shouldn't impact anyone.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
