### PR TITLE
Add `GetGlobalSparseId` and `GetLocalSparseId` methods to `VariablePack`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetGlobalSparseID` and `VariablePack<T>::GetGlobalSparseID` to return global sparse ids and pack-local sparse ids, repsectively.
+- [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetGlobalSparseId` and `VariablePack<T>::GetGlobalSparseId` to return global sparse ids and pack-local sparse ids, repsectively.
 - [[PR 381]](https://github.com/lanl/parthenon/pull/381) Overload `DataCollection::Add` to build `MeshData` and `MeshBlockData` objects with a subset of variables.
 - [[PR 378]](https://github.com/lanl/parthenon/pull/378) Add Kokkos profiling regions throughout the code to allow the collection characteristic application profiles
 - [[PR 358]](https://github.com/lanl/parthenon/pull/358) Generalize code that interfaces with downstream apps to work with both `MeshData` and `MeshBlockData`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetGlobalSparseId` and `VariablePack<T>::GetGlobalSparseId` to return global sparse ids and pack-local sparse ids, repsectively.
+- [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetSparseId` and `VariablePack<T>::GetSparseIndex` to return global sparse ids and pack-local sparse index, repsectively.
 - [[PR 381]](https://github.com/lanl/parthenon/pull/381) Overload `DataCollection::Add` to build `MeshData` and `MeshBlockData` objects with a subset of variables.
 - [[PR 378]](https://github.com/lanl/parthenon/pull/378) Add Kokkos profiling regions throughout the code to allow the collection characteristic application profiles
 - [[PR 358]](https://github.com/lanl/parthenon/pull/358) Generalize code that interfaces with downstream apps to work with both `MeshData` and `MeshBlockData`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetGlobalSparseID` and `VariablePack<T>::GetGlobalSparseID` to return global sparse ids and pack-local sparse ids, repsectively.
 - [[PR 381]](https://github.com/lanl/parthenon/pull/381) Overload `DataCollection::Add` to build `MeshData` and `MeshBlockData` objects with a subset of variables.
 - [[PR 378]](https://github.com/lanl/parthenon/pull/378) Add Kokkos profiling regions throughout the code to allow the collection characteristic application profiles
 - [[PR 358]](https://github.com/lanl/parthenon/pull/358) Generalize code that interfaces with downstream apps to work with both `MeshData` and `MeshBlockData`.

--- a/README.md
+++ b/README.md
@@ -116,4 +116,5 @@ how to use them.
 | Daniel Holladay | @dholladay00 | LANL Computer Science |
 | Galen Shipman | @gshipman | LANL Computer Science |
 | Ben Ryan | @brryan | LANL Physics |
+| Clell J. (CJ) Solomon | @clellsolomon | LANL Physics |
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -95,9 +95,9 @@ class VariablePack {
     return sparse_ids_(n);
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  int GetGlobalSparseID(const int n) const { return GetSparse(n); }
+  int GetGlobalSparseId(const int n) const { return GetSparse(n); }
   KOKKOS_FORCEINLINE_FUNCTION
-  int GetLocalSparseID(const int n) const { return GetSparse(n); }
+  int GetLocalSparseId(const int n) const { return GetSparse(n); }
   KOKKOS_FORCEINLINE_FUNCTION
   bool IsVector(const int n) const {
     assert(0 <= n && n < dims_[3]);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -95,9 +95,9 @@ class VariablePack {
     return sparse_ids_(n);
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  int GetGlobalSparseId(const int n) const { return GetSparse(n); }
+  int GetSparseId(const int n) const { return GetSparse(n); }
   KOKKOS_FORCEINLINE_FUNCTION
-  int GetLocalSparseId(const int n) const { return GetSparse(n); }
+  int GetSparseIndex(const int n) const { return GetSparse(n); }
   KOKKOS_FORCEINLINE_FUNCTION
   bool IsVector(const int n) const {
     assert(0 <= n && n < dims_[3]);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -95,13 +95,9 @@ class VariablePack {
     return sparse_ids_(n);
   }
   KOKKOS_FORCEINLINE_FUNCTION
-  int GetGlobalSparseID(const int n) const {
-    return GetSparse(n);
-  }
+  int GetGlobalSparseID(const int n) const { return GetSparse(n); }
   KOKKOS_FORCEINLINE_FUNCTION
-  int GetLocalSparseID(const int n) const {
-    return GetSparse(n);
-  }
+  int GetLocalSparseID(const int n) const { return GetSparse(n); }
   KOKKOS_FORCEINLINE_FUNCTION
   bool IsVector(const int n) const {
     assert(0 <= n && n < dims_[3]);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -95,6 +95,14 @@ class VariablePack {
     return sparse_ids_(n);
   }
   KOKKOS_FORCEINLINE_FUNCTION
+  int GetGlobalSparseID(const int n) const {
+    return GetSparse(n);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  int GetLocalSparseID(const int n) const {
+    return GetSparse(n);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION
   bool IsVector(const int n) const {
     assert(0 <= n && n < dims_[3]);
     return vector_component_(n) != NODIR;

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -333,11 +333,11 @@ TEST_CASE("Can pull variables from containers based on Metadata",
         Kokkos::parallel_reduce(
             "add correct checks", 1,
             KOKKOS_LAMBDA(const int i, int &sum) {
-              sum = (v.GetGlobalSparseId(v3first) == -1);
-              sum += (v.GetGlobalSparseId(v6first) == -1);
-              sum += (v.GetGlobalSparseId(vsfirst) == 1);
-              sum += (v.GetGlobalSparseId(vsfirst + 1) == 13);
-              sum += (v.GetGlobalSparseId(vssecnd) == 42);
+              sum = (v.GetSparseId(v3first) == -1);
+              sum += (v.GetSparseId(v6first) == -1);
+              sum += (v.GetSparseId(vsfirst) == 1);
+              sum += (v.GetSparseId(vsfirst + 1) == 13);
+              sum += (v.GetSparseId(vssecnd) == 42);
             },
             correct);
         REQUIRE(correct == 5);
@@ -346,11 +346,11 @@ TEST_CASE("Can pull variables from containers based on Metadata",
         Kokkos::parallel_reduce(
             "add correct checks", 1,
             KOKKOS_LAMBDA(const int i, int &sum) {
-              sum = (v.GetLocalSparseId(v3first) == -1);
-              sum += (v.GetLocalSparseId(v6first) == -1);
-              sum += (v.GetLocalSparseId(vsfirst) == 1);
-              sum += (v.GetLocalSparseId(vsfirst + 1) == 13);
-              sum += (v.GetLocalSparseId(vssecnd) == 42);
+              sum = (v.GetSparseIndex(v3first) == -1);
+              sum += (v.GetSparseIndex(v6first) == -1);
+              sum += (v.GetSparseIndex(vsfirst) == 1);
+              sum += (v.GetSparseIndex(vsfirst + 1) == 13);
+              sum += (v.GetSparseIndex(vssecnd) == 42);
             },
             correct);
         REQUIRE(correct == 5);

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -333,11 +333,11 @@ TEST_CASE("Can pull variables from containers based on Metadata",
         Kokkos::parallel_reduce(
             "add correct checks", 1,
             KOKKOS_LAMBDA(const int i, int &sum) {
-              sum = (v.GetGlobalSparseID(v3first) == -1);
-              sum += (v.GetGlobalSparseID(v6first) == -1);
-              sum += (v.GetGlobalSparseID(vsfirst) == 1);
-              sum += (v.GetGlobalSparseID(vsfirst + 1) == 13);
-              sum += (v.GetGlobalSparseID(vssecnd) == 42);
+              sum = (v.GetGlobalSparseId(v3first) == -1);
+              sum += (v.GetGlobalSparseId(v6first) == -1);
+              sum += (v.GetGlobalSparseId(vsfirst) == 1);
+              sum += (v.GetGlobalSparseId(vsfirst + 1) == 13);
+              sum += (v.GetGlobalSparseId(vssecnd) == 42);
             },
             correct);
         REQUIRE(correct == 5);
@@ -346,11 +346,11 @@ TEST_CASE("Can pull variables from containers based on Metadata",
         Kokkos::parallel_reduce(
             "add correct checks", 1,
             KOKKOS_LAMBDA(const int i, int &sum) {
-              sum = (v.GetLocalSparseID(v3first) == -1);
-              sum += (v.GetLocalSparseID(v6first) == -1);
-              sum += (v.GetLocalSparseID(vsfirst) == 1);
-              sum += (v.GetLocalSparseID(vsfirst + 1) == 13);
-              sum += (v.GetLocalSparseID(vssecnd) == 42);
+              sum = (v.GetLocalSparseId(v3first) == -1);
+              sum += (v.GetLocalSparseId(v6first) == -1);
+              sum += (v.GetLocalSparseId(vsfirst) == 1);
+              sum += (v.GetLocalSparseId(vsfirst + 1) == 13);
+              sum += (v.GetLocalSparseId(vssecnd) == 42);
             },
             correct);
         REQUIRE(correct == 5);

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -328,6 +328,32 @@ TEST_CASE("Can pull variables from containers based on Metadata",
             },
             correct);
         REQUIRE(correct == 5);
+
+        correct = 0;
+        Kokkos::parallel_reduce(
+            "add correct checks", 1,
+            KOKKOS_LAMBDA(const int i, int &sum) {
+              sum = (v.GetGlobalSparseID(v3first) == -1);
+              sum += (v.GetGlobalSparseID(v6first) == -1);
+              sum += (v.GetGlobalSparseID(vsfirst) == 1);
+              sum += (v.GetGlobalSparseID(vsfirst + 1) == 13);
+              sum += (v.GetGlobalSparseID(vssecnd) == 42);
+            },
+            correct);
+        REQUIRE(correct == 5);
+
+        correct = 0;
+        Kokkos::parallel_reduce(
+            "add correct checks", 1,
+            KOKKOS_LAMBDA(const int i, int &sum) {
+              sum = (v.GetLocalSparseID(v3first) == -1);
+              sum += (v.GetLocalSparseID(v6first) == -1);
+              sum += (v.GetLocalSparseID(vsfirst) == 1);
+              sum += (v.GetLocalSparseID(vsfirst + 1) == 13);
+              sum += (v.GetLocalSparseID(vssecnd) == 42);
+            },
+            correct);
+        REQUIRE(correct == 5);
       }
     }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Add GetGlobalSparseId and GetLocalSparseId to VariablePack
    
* For now both these functions dispatch to GetSparse
    
* When sparse variables are actually being used, GetGlobalSparseID
   should return the global id and GetLocalSparseID should return the
   variable-pack-local id

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
