### PR TITLE
Modify c++ linting for when parthenon is submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [[PR 352]](https://github.com/lanl/parthenon/pull/352) Code compiles cleanly (no warnings) with nvcc_wrapper
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 392]](https://github.com/lanl/parthenon/pull/392) Fix C++ linting for when parthenon is a submodule
 - [[PR 335]](https://github.com/lanl/parthenon/pull/335) New machine configuration file for LANL's Darwin cluster
 - [[PR 200]](https://github.com/lanl/parthenon/pull/200) Adds support for running ci on power9 nodes. 
 - [[PR 347]](https://github.com/lanl/parthenon/pull/347) Speed up darwin ci by using pre installed spack packages from project space

--- a/cmake/Lint.cmake
+++ b/cmake/Lint.cmake
@@ -37,11 +37,13 @@ function(lint_file SOURCE_DIR INPUT OUTPUT)
         OUTPUT ${OUTPUT}
         COMMAND
             ${PROJECT_SOURCE_DIR}/tst/style/cpplint.py
+                --repository=${PROJECT_SOURCE_DIR}
                 --counting=detailed
                 --quiet ${FILE_TO_LINT}
         ${MKDIR_COMMAND}
         COMMAND ${CMAKE_COMMAND} -E touch ${OUTPUT}
         DEPENDS ${INPUT}
+                ${PROJECT_SOURCE_DIR}/CPPLINT.cfg
         COMMENT "Linting ${INPUT}"
     )
 endfunction(lint_file)


### PR DESCRIPTION
* uses the `--repository` argument to cpplint to set the repository to
  the `${PROJECT_SOURCE_DIR}`

* adds `CPPLINT.cfg` as a dependency to the linting command so changes
  to it will trigger re-linting

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
