### PR TITLE
Add const correctness to `Params.Get`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 328]](https://github.com/lanl/parthenon/pull/328) New `MeshBlock` packing interface using `DataCollection`s of `MeshData` and `MeshBlockData`.
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 394]](https://github.com/lanl/parthenon/pull/332) Make `Params.Get` const-correct.
 - [[PR 332]](https://github.com/lanl/parthenon/pull/332) Rewrote boundary conditions to work on GPUs with variable packs. Re-enabled user-defined boundary conditions via `ApplicationInput`.
 
 ### Fixed (not changing behavior/API/variables/...)

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -53,9 +53,8 @@ class Params {
   const T &Get(const std::string &key) const {
     auto const it = myParams_.find(key);
     PARTHENON_REQUIRE_THROWS(it != myParams_.end(), "Key " + key + " doesn't exist");
-    PARTHENON_REQUIRE_THROWS(
-        !(myTypes_.find(key)->second.compare(std::string(typeid(T).name()))),
-        "WRONG TYPE FOR KEY '" + key + "'");
+    PARTHENON_REQUIRE_THROWS(!(myTypes_.at(key).compare(std::string(typeid(T).name()))),
+                             "WRONG TYPE FOR KEY '" + key + "'");
     auto typed_ptr = dynamic_cast<Params::object_t<T> *>((it->second).get());
     return *typed_ptr->pValue;
   }

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -50,11 +50,12 @@ class Params {
   }
 
   template <typename T>
-  const T &Get(const std::string &key) {
-    auto it = myParams_.find(key);
+  const T &Get(const std::string &key) const {
+    auto const it = myParams_.find(key);
     PARTHENON_REQUIRE_THROWS(it != myParams_.end(), "Key " + key + " doesn't exist");
-    PARTHENON_REQUIRE_THROWS(!(myTypes_[key].compare(std::string(typeid(T).name()))),
-                             "WRONG TYPE FOR KEY '" + key + "'");
+    PARTHENON_REQUIRE_THROWS(
+        !(myTypes_.find(key)->second.compare(std::string(typeid(T).name()))),
+        "WRONG TYPE FOR KEY '" + key + "'");
     auto typed_ptr = dynamic_cast<Params::object_t<T> *>((it->second).get());
     return *typed_ptr->pValue;
   }

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -63,7 +63,7 @@ class StateDescriptor {
   }
 
   template <typename T>
-  const T &Param(const std::string &key) {
+  const T &Param(const std::string &key) const {
     return params_.Get<T>(key);
   }
 

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -31,6 +31,10 @@ TEST_CASE("Add and Get is called", "[Add,Get]") {
     params.Add(key, value);
     double output = params.Get<double>(key);
     REQUIRE(output == Approx(value));
+    WHEN("parameters are immutable") {
+      auto const &const_params = params;
+      REQUIRE(params.Get<double>(key) == Approx(value));
+    }
     WHEN("the same key is provided a second time") {
       REQUIRE_THROWS_AS(params.Add(key, value), std::runtime_error);
     }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Add const correctness to `Params.Get`

It was returning a const reference to something it owns, so it should be const.  The only thing preventing it was some of the error checks that can be rewritten to support const-ness.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
