### PR TITLE
Extend packages for customized outputs and their control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR 400]](https://github.com/lanl/parthenon/pull/400) Extend `StateDescriptor` for customizable output via user-customizable function pointer `OutputDiagnosticsMesh`
+- [[PR 400]](https://github.com/lanl/parthenon/pull/400) Extend `StateDescriptor` for customizable output via user-customizable function pointers `PreStepDiagnosticsMesh` and `PostStepDiagnosticsMesh`
 - [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetSparseId` and `VariablePack<T>::GetSparseIndex` to return global sparse ids and pack-local sparse index, repsectively.
 - [[PR 381]](https://github.com/lanl/parthenon/pull/381) Overload `DataCollection::Add` to build `MeshData` and `MeshBlockData` objects with a subset of variables.
 - [[PR 378]](https://github.com/lanl/parthenon/pull/378) Add Kokkos profiling regions throughout the code to allow the collection characteristic application profiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 400]](https://github.com/lanl/parthenon/pull/400) Extend `StateDescriptor` for customizable output via user-customizable function pointer `OutputDiagnosticsMesh`
 - [[PR 391]](https://github.com/lanl/parthenon/pull/391) Add `VariablePack<T>::GetSparseId` and `VariablePack<T>::GetSparseIndex` to return global sparse ids and pack-local sparse index, repsectively.
 - [[PR 381]](https://github.com/lanl/parthenon/pull/381) Overload `DataCollection::Add` to build `MeshData` and `MeshBlockData` objects with a subset of variables.
 - [[PR 378]](https://github.com/lanl/parthenon/pull/378) Add Kokkos profiling regions throughout the code to allow the collection characteristic application profiles
@@ -12,6 +13,7 @@
 - [[PR 386]](https://github.com/lanl/parthenon/pull/386) Introduce `Private`, `Provides`, `Requires`, and `Overridable` variable metadata, allowing fine-grained control of conflict resolution between packages.
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 400]](https://github.com/lanl/parthenon/pull/400) Change `Mesh`, `ApplicationInput`, and `Driver` to suppport pre- and post- step user work
 - [[PR 394]](https://github.com/lanl/parthenon/pull/332) Make `Params.Get` const-correct.
 - [[PR 332]](https://github.com/lanl/parthenon/pull/332) Rewrote boundary conditions to work on GPUs with variable packs. Re-enabled user-defined boundary conditions via `ApplicationInput`.
 

--- a/docs/interface/state.md
+++ b/docs/interface/state.md
@@ -4,45 +4,44 @@ Parthenon manages simulation data through a hierarchy of classes designed to pro
 
 # Metadata
 
-The ```Metadata``` class provides a means of defining self-describing variables within Parthenon.  It's documentation can be found [here](Metadata.md).
+The `Metadata` class provides a means of defining self-describing variables within Parthenon.  It's documentation can be found [here](Metadata.md).
 
 # StateDescriptor
 
-The ```StateDescriptor``` class is intended to be used to inform Parthenon about the needs of an application and store relevant parameters that control application-specific behavior at runtime.  The class provides several useful features and functions.
-* ```bool AddField(const std::string& field_name, Metadata& m, DerivedOwnership owner=DerivedOwnership::unique)```
-Provides the means to add new variables to a Parthenon-based application with associated ```Metadata```.  This function does not allocate any storage or create any of the objects below, it simply adds the name and ```Metadata``` to a list so that those objects can be populated at the appropriate time.
-* ```void AddParam<T>(const std::string& key, T& value)``` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name ```key``` and value ```value```.
-* ```const T& Param(const std::string& key)``` provides the getter to access parameters previously added by ```AddParam```.
-* ```void (*FillDerivedBlock)(std::shared_ptr<MeshBlockData<Real>>& rc)``` is a function pointer (defaults to ```nullptr``` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshBlockData<Real>`.
-* ```void (*FillDerivedMesh)(std::shared_ptr<MeshData<Real>>& rc)``` is identical to the previous function but operates on a `MeshData<Real>` object.
-* ```Real (*EstimateTimestepBlock)(std::shared_ptr<MeshBlockData<Real>>& rc)``` is a function pointer (defaults to ```nullptr``` and therefore a no-op) that allows an application to provide a means of computing stable/accurate timesteps.
-* ```Real (*EstimateTimestepMesh)(std::shared_ptr<MeshData<Real>>& rc)``` is identical to the previous function but operates on a `MeshData<Real>` object.
-* ```AmrTag (*CheckRefinement)(std::shared_ptr<MeshBlockData<Real>>& rc)``` is a function pointer (defaults to ```nullptr``` and therefore a no-op) that allows an application to define an application-specific refinement/de-refinement tagging function.
+The `StateDescriptor` class is intended to be used to inform Parthenon about the needs of an application and store relevant parameters that control application-specific behavior at runtime.  The class provides several useful features and functions.
+* `bool AddField(const std::string& field_name, Metadata& m, DerivedOwnership owner=DerivedOwnership::unique)` provides the means to add new variables to a Parthenon-based application with associated `Metadata`.  This function does not allocate any storage or create any of the objects below, it simply adds the name and `Metadata` to a list so that those objects can be populated at the appropriate time.
+* `void AddParam<T>(const std::string& key, T& value)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`.
+* `const T& Param(const std::string& key)` provides the getter to access parameters previously added by `AddParam`.
+* `void FillDerivedBlock(MeshBlockData<Real>* rc)` delgates to the `std::function` member `FillDerivedBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshBlockData<Real>`.
+* `void FillDerivedMesh(MeshData<Real>* rc)` delgates to the `std::function` member `FillDerivedMesh` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshData<Real>`.
+* `Real EstimateTimestepBlock(MeshBlockData<Real>* rc)` delgates to the `std::function` member `EstimateTimestepBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a means of computing stable/accurate timesteps for a mesh block.
+* `Real EstimateTimestepMesh(MeshData<Real>* rc)` delgates to the `std::function` member `EstimateTimestepBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a means of computing stable/accurate timesteps for a mesh block.
+* `AmrTag CheckRefinement(MeshBlockData<Real>* rc)` delegates to the `std::function` member `CheckRefinementBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to define an application-specific refinement/de-refinement tagging function.
+* `void PreStepDiagnostics(SimTime const &simtime, MeshData<Real> *rc)` deletgates to the `std::function` member `PreStepDiagnosticsMesh` if set (defaults to `nullptr` an therefore a no-op) to print diagnostics before the time-integration advance
+* `void PostStepDiagnostics(SimTime const &simtime, MeshData<Real> *rc)` deletgates to the `std::function` member `PostStepDiagnosticsMesh` if set (defaults to `nullptr` an therefore a no-op) to print diagnostics after the time-integration advance
 
 The reasoning for providing `FillDerived*` and `EstimateTimestep*` function pointers appropriate for usage with both `MeshData` and `MeshBlockData` is to allow downstream applications better control over task/kernel granularity.  If, for example, the functionality needed in a package's `FillDerived*` function is minimal (e.g., computing velocity from momentum and mass), better performance may be acheived by making use of the `FillDerivedMesh` interface.  Note that applications and even individual packages can make simultaneous usage of _both_ `*Mesh` and `*Block` functions, so long as the appropriate tasks are called as needed by the application driver.
 
-In Parthenon, each ```Mesh``` and ```MeshBlock``` owns a ```Packages_t``` object, which is a ```std::map<std::string, std::shared_ptr<StateDescriptor>>```.  The object is intended to be populated with a ```StateDescriptor``` object per package via an ```Initialize``` function as in the advection example [here](../example/advection/advection.cpp).  When Parthenon makes use of the ```Packages_t``` object, it iterates over all entries in the ```std::map```.  Note that it's often useful to add a `StateDescriptor` to the `Packages_t` object for the overall application, allowing for a convenient way to define global parameters, for example.
-
-
+In Parthenon, each `Mesh` and `MeshBlock` owns a `Packages_t` object, which is a `std::map<std::string, std::shared_ptr<StateDescriptor>>`.  The object is intended to be populated with a `StateDescriptor` object per package via an `Initialize` function as in the advection example [here](../example/advection/advection.cpp).  When Parthenon makes use of the `Packages_t` object, it iterates over all entries in the `std::map`.  Note that it's often useful to add a `StateDescriptor` to the `Packages_t` object for the overall application, allowing for a convenient way to define global parameters, for example.
 
 # ParArrayND
 
-This provides a light wrapper around ```Kokkos::View``` with some convenience features.  It is described fully [here](../parthenon_arrays.md).
+This provides a light wrapper around `Kokkos::View` with some convenience features.  It is described fully [here](../parthenon_arrays.md).
 
 # CellVariable
 
-The ```CellVariable``` class collects several associated objects that are needed to store, describe, and update simulation data.  ```CellVariable``` is templated on type ```T``` and includes the following member data (names preceded by ```_``` have private scope):
+The `CellVariable` class collects several associated objects that are needed to store, describe, and update simulation data.  `CellVariable` is templated on type `T` and includes the following member data (names preceded by `_` have private scope):
 
 | Member Data | Description |
 |-|-|
-| ```ParArrayND<T> data``` | Storage for the cell-centered associated with the object. |
-| ```ParArrayND<T> flux[3]``` | Storage for the face-centered intercell fluxes in each direction.<br>Only allocated for fields registered with the ```Metadata::Independent``` flag. |
-| ```ParArrayND<T> coarse_s``` | Storage for coarse buffers need for multilevel setups. |
-| ```Metadata m_``` | See [here](Metadata.md). |
+| `ParArrayND<T> data` | Storage for the cell-centered associated with the object. |
+| `ParArrayND<T> flux[3]` | Storage for the face-centered intercell fluxes in each direction.<br>Only allocated for fields registered with the `Metadata::Independent` flag. |
+| `ParArrayND<T> coarse_s` | Storage for coarse buffers need for multilevel setups. |
+| `Metadata m_` | See [here](Metadata.md). |
 
-Additionally, the class overloads the ```()``` operator to provide convenient access to the ```data``` array, though this may be less efficient than operating directly on ```data``` or a reference/copy of that array.
+Additionally, the class overloads the `()` operator to provide convenient access to the `data` array, though this may be less efficient than operating directly on `data` or a reference/copy of that array.
 
-Finally, the ```bool IsSet(const MetadataFlag bit)``` member function provides a convenient mechanism to query whether a particular ```Metadata``` flag is set for the ```CellVariable```.
+Finally, the `bool IsSet(const MetadataFlag bit)` member function provides a convenient mechanism to query whether a particular `Metadata` flag is set for the `CellVariable`.
 
 # FaceVariable (Work in progress...)
 
@@ -50,17 +49,17 @@ Finally, the ```bool IsSet(const MetadataFlag bit)``` member function provides a
 
 # SparseVariable
 
-The ```SparseVariable``` class is designed to support multi-component state where not all components may be present and therefore need to be stored.  At its core, the data is represented using a map that associates an integer ID to a ```std::shared_ptr<CellVariable<T>>```.  Since all ```CellVariable``` entries are assumed to have identical ```Metadata``` flags, the class provides an ```IsSet``` member function identical to the ```CellVariable``` class that applies to all variables stored in the map.  The ```Get``` method takes an integer ID as input and returns a reference to the associated ```CellVariable```, or throws a ```std::invalid_argument``` error if it does not exist.  The ```GetVector``` method returns a dense ```std::vector```, eliminating the sparsity but also the association to particular IDs.  The ```GetIndex``` method provides the index in this vector associated with a given sparse ID, and returns -1 if the ID does not exist.
+The `SparseVariable` class is designed to support multi-component state where not all components may be present and therefore need to be stored.  At its core, the data is represented using a map that associates an integer ID to a `std::shared_ptr<CellVariable<T>>`.  Since all `CellVariable` entries are assumed to have identical `Metadata` flags, the class provides an `IsSet` member function identical to the `CellVariable` class that applies to all variables stored in the map.  The `Get` method takes an integer ID as input and returns a reference to the associated `CellVariable`, or throws a `std::invalid_argument` error if it does not exist.  The `GetVector` method returns a dense `std::vector`, eliminating the sparsity but also the association to particular IDs.  The `GetIndex` method provides the index in this vector associated with a given sparse ID, and returns -1 if the ID does not exist.
 
 # MeshBlockData
 
-The ```MeshBlockData``` class provides a means of organizing and accessing simulation data.  New `Variable`s are added to a `MeshBlockData` container via the ```Add``` member function and accessed via various ```Get*``` functions.  These ```Get*``` functions provide access to the various kinds of ```Variable``` objects described above, typically by name.
+The `MeshBlockData` class provides a means of organizing and accessing simulation data.  New `Variable`s are added to a `MeshBlockData` container via the `Add` member function and accessed via various `Get*` functions.  These `Get*` functions provide access to the various kinds of `Variable` objects described above, typically by name.
 
 # DataCollection
 
-The ```DataCollection``` class is the highest level abstraction in Parthenon's state management.  Each ```MeshBlock``` in a simulation owns a ```DataCollection``` that through the classes just described, manages all of the simulation data.  Every ```DataCollection``` is initialized with a ```MeshBlockData``` container named ```"base"```.  The ```Get``` function, when invoked without arguments, returns a reference to this base ```MeshBlockData``` container which is intended to contain all of the simulation data that persists between timesteps (if applicable).
+The `DataCollection` class is the highest level abstraction in Parthenon's state management.  Each `MeshBlock` in a simulation owns a `DataCollection` that through the classes just described, manages all of the simulation data.  Every `DataCollection` is initialized with a `MeshBlockData` container named `"base"`.  The `Get` function, when invoked without arguments, returns a reference to this base `MeshBlockData` container which is intended to contain all of the simulation data that persists between timesteps (if applicable).
 
-The ```Add(const std::string& label, MeshBlockData<T>& src)``` member function creates a new ```MeshBlockData``` container with the provided label.  This new ```MeshBlockData``` container is populated with all of the variables in ```src```.  When a variable has the ```Metadata::OneCopy``` flag set, the variables in the new ```MeshBlockData``` container are just shallow copies from ```src```, i.e. no new storage for data is allocated, the ```std::shared_ptr``` to the variable is just copied.  For variables that do not have ```Metadata::OneCopy``` set, new storage is allocated.  Once created, these new containers are accesible by calling ```Get``` with the name of the desired ```MeshBlockData``` container as an argument.  NOTE: The ```Add``` function checks if a ```MeshBlockData``` container by the name ```label``` already exists in the collection, immediately returning if one is found (or throwing a ```std::runtime_error``` if the new and pre-existing containers are not equivalent).  Therefore, adding a ```MeshBlockData``` container to the collection multiple times results in a single new container, with the remainder of the calls no-ops.
+The `Add(const std::string& label, MeshBlockData<T>& src)` member function creates a new `MeshBlockData` container with the provided label.  This new `MeshBlockData` container is populated with all of the variables in `src`.  When a variable has the `Metadata::OneCopy` flag set, the variables in the new `MeshBlockData` container are just shallow copies from `src`, i.e. no new storage for data is allocated, the `std::shared_ptr` to the variable is just copied.  For variables that do not have `Metadata::OneCopy` set, new storage is allocated.  Once created, these new containers are accesible by calling `Get` with the name of the desired `MeshBlockData` container as an argument.  NOTE: The `Add` function checks if a `MeshBlockData` container by the name `label` already exists in the collection, immediately returning if one is found (or throwing a `std::runtime_error` if the new and pre-existing containers are not equivalent).  Therefore, adding a `MeshBlockData` container to the collection multiple times results in a single new container, with the remainder of the calls no-ops.
 
 The overload `Add(const std::string &label, MeshBlockData<T> &src, const std::vector<std::string> &names)` provides the same functionality as the above `Add` function, but for a subset of variables provided in the vector of names.  This feature allows downstream applications to allocate storage in a more targeted fashion, as might be desirable to hold source terms for particular equations, for example.
 

--- a/docs/mesh/mesh.md
+++ b/docs/mesh/mesh.md
@@ -18,3 +18,11 @@ for (auto &pmb : pmesh->block_list) {
 ```
 where `pmesh` is a pointer to a `Mesh` object. This paradigm may appear, 
 for example, in an application driver.
+
+## Mesh Functions Controlling Evolulution and Diagnostics
+
+Some mesh functions are stored as `std::function` members and are called by the `EvolutionDriver`. They may be overridden by the application by reassigning the default values of the `std::function` member.
+* `PreStepUserWorkInLoop(Mesh*, ParameterInput*, SimTime const&)` is called to perform mesh-wide work _before_ the time-integration advance (the default is a no-op)
+* `PostStepUserWorkInLoop(Mesh*, ParameterInput*, SimTime const&)` is called to perform mesh-wide work _after_ the time-integration advance (the default is a no-op)
+* `PreStepUserDiagnosticsInLoop(Mesh*, ParameterInput*, SimTime const&)` is called to perform diagnostic calculations and/or edits _before_ the time-integration advance.  The default behavior calls to each package's (StateDesrcriptor's) `PreStepDiagnostics` method which, in turn, delgates to a `std::function` member that defaults to a no-op.
+* `PostStepUserDiagnosticsInLoop(Mesh*, ParameterInput*, SimTime const&)` is called to perform diagnostic calculations and/or edits _after_ the time-integration advance.  The default behavior calls to each package's (StateDesrcriptor's) `PreStepDiagnostics` method which, in turn, delgates to a `std::function` member that defaults to a no-op.

--- a/example/calculate_pi/calculate_pi.hpp
+++ b/example/calculate_pi/calculate_pi.hpp
@@ -28,7 +28,7 @@ using parthenon::ParArrayHost;
 using Pack_t = parthenon::MeshBlockVarPack<Real>;
 
 // Package Callbacks
-void SetInOrOut(std::shared_ptr<MeshBlockData<Real>> &rc);
+void SetInOrOut(MeshBlockData<Real> *rc);
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 
 // Task Implementations

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -37,10 +37,10 @@ struct ApplicationInput {
 
   // Mesh functions
   std::function<void(ParameterInput *)> InitUserMeshData = nullptr;
-  std::function<void(Mesh *, ParameterInput *, SimTime const &)> PreStepMeshUserWorkInLoop =
-      nullptr;
-  std::function<void(Mesh *, ParameterInput *, SimTime const &)> PostStepMeshUserWorkInLoop =
-      nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)>
+      PreStepMeshUserWorkInLoop = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)>
+      PostStepMeshUserWorkInLoop = nullptr;
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
   BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr, nullptr, nullptr,
                                                    nullptr, nullptr, nullptr};

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -37,10 +37,17 @@ struct ApplicationInput {
 
   // Mesh functions
   std::function<void(ParameterInput *)> InitUserMeshData = nullptr;
+
   std::function<void(Mesh *, ParameterInput *, SimTime const &)>
       PreStepMeshUserWorkInLoop = nullptr;
   std::function<void(Mesh *, ParameterInput *, SimTime const &)>
       PostStepMeshUserWorkInLoop = nullptr;
+
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)>
+      PreStepDiagnosticsInLoop = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)>
+      PostStepDiagnosticsInLoop = nullptr;
+
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
   BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr, nullptr, nullptr,
                                                    nullptr, nullptr, nullptr};

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -37,7 +37,8 @@ struct ApplicationInput {
 
   // Mesh functions
   std::function<void(ParameterInput *)> InitUserMeshData = nullptr;
-  std::function<void()> MeshUserWorkInLoop = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepMeshUserWorkInLoop = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> PostStepMeshUserWorkInLoop = nullptr;
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
   BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr, nullptr, nullptr,
                                                    nullptr, nullptr, nullptr};

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -37,8 +37,10 @@ struct ApplicationInput {
 
   // Mesh functions
   std::function<void(ParameterInput *)> InitUserMeshData = nullptr;
-  std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepMeshUserWorkInLoop = nullptr;
-  std::function<void(Mesh *, ParameterInput *, SimTime &)> PostStepMeshUserWorkInLoop = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepMeshUserWorkInLoop =
+      nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> PostStepMeshUserWorkInLoop =
+      nullptr;
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
   BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr, nullptr, nullptr,
                                                    nullptr, nullptr, nullptr};

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -37,9 +37,9 @@ struct ApplicationInput {
 
   // Mesh functions
   std::function<void(ParameterInput *)> InitUserMeshData = nullptr;
-  std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepMeshUserWorkInLoop =
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)> PreStepMeshUserWorkInLoop =
       nullptr;
-  std::function<void(Mesh *, ParameterInput *, SimTime &)> PostStepMeshUserWorkInLoop =
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)> PostStepMeshUserWorkInLoop =
       nullptr;
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
   BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr, nullptr, nullptr,

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -69,12 +69,12 @@ DriverStatus EvolutionDriver::Execute() {
       return DriverStatus::failed;
     }
 
-    pmesh->PostStepUserWorkInLoop(pmesh, pinput, tm);
-
     tm.ncycle++;
     tm.time += tm.dt;
     pmesh->mbcnt += pmesh->nbtotal;
     pmesh->step_since_lb++;
+
+    pmesh->PostStepUserWorkInLoop(pmesh, pinput, tm);
 
     pmesh->LoadBalancingAndAdaptiveMeshRefinement(pinput, app_input);
     if (pmesh->modified) InitializeBlockTimeSteps();

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -62,6 +62,7 @@ DriverStatus EvolutionDriver::Execute() {
     if (Globals::my_rank == 0) OutputCycleDiagnostics();
 
     pmesh->PreStepUserWorkInLoop(pmesh, pinput, tm);
+    pmesh->PreStepUserDiagnosticsInLoop(pmesh, pinput, tm);
 
     TaskListStatus status = Step();
     if (status != TaskListStatus::complete) {
@@ -75,6 +76,7 @@ DriverStatus EvolutionDriver::Execute() {
     pmesh->step_since_lb++;
 
     pmesh->PostStepUserWorkInLoop(pmesh, pinput, tm);
+    pmesh->PostStepUserDiagnosticsInLoop(pmesh, pinput, tm);
 
     pmesh->LoadBalancingAndAdaptiveMeshRefinement(pinput, app_input);
     if (pmesh->modified) InitializeBlockTimeSteps();

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -61,12 +61,16 @@ DriverStatus EvolutionDriver::Execute() {
   while (tm.KeepGoing()) {
     if (Globals::my_rank == 0) OutputCycleDiagnostics();
 
+    pmesh->PreStepUserWorkInLoop(pmesh, pinput, tm);
+
     TaskListStatus status = Step();
     if (status != TaskListStatus::complete) {
       std::cerr << "Step failed to complete all tasks." << std::endl;
       return DriverStatus::failed;
     }
-    // pmesh->UserWorkInLoop();
+
+    pmesh->PostStepUserWorkInLoop(pmesh, pinput, tm);
+
     tm.ncycle++;
     tm.time += tm.dt;
     pmesh->mbcnt += pmesh->nbtotal;

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -70,13 +70,13 @@ DriverStatus EvolutionDriver::Execute() {
       return DriverStatus::failed;
     }
 
+    pmesh->PostStepUserWorkInLoop(pmesh, pinput, tm);
+    pmesh->PostStepUserDiagnosticsInLoop(pmesh, pinput, tm);
+
     tm.ncycle++;
     tm.time += tm.dt;
     pmesh->mbcnt += pmesh->nbtotal;
     pmesh->step_since_lb++;
-
-    pmesh->PostStepUserWorkInLoop(pmesh, pinput, tm);
-    pmesh->PostStepUserDiagnosticsInLoop(pmesh, pinput, tm);
 
     pmesh->LoadBalancingAndAdaptiveMeshRefinement(pinput, app_input);
     if (pmesh->modified) InitializeBlockTimeSteps();

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -45,17 +45,12 @@ class StateDescriptor {
   StateDescriptor(const StateDescriptor &s) = delete;
 
   // Preferred constructor
-  explicit StateDescriptor(std::string label) : label_(label) {
-    PostFillDerivedBlock = nullptr;
-    PostFillDerivedMesh = nullptr;
-    PreFillDerivedBlock = nullptr;
-    PreFillDerivedMesh = nullptr;
-    FillDerivedBlock = nullptr;
-    FillDerivedMesh = nullptr;
-    EstimateTimestepBlock = nullptr;
-    EstimateTimestepMesh = nullptr;
-    CheckRefinementBlock = nullptr;
-  }
+  explicit StateDescriptor(std::string label)
+      : label_(label), PostFillDerivedBlock{nullptr}, PostFillDerivedMesh{nullptr},
+        PreFillDerivedBlock{nullptr}, PreFillDerivedMesh{nullptr},
+        FillDerivedBlock{nullptr}, FillDerivedMesh{nullptr},
+        OutputDiagnosticsMesh{nullptr}, EstimateTimestepBlock{nullptr},
+        EstimateTimestepMesh{nullptr}, CheckRefinementBlock{nullptr} {}
 
   template <typename T>
   void AddParam(const std::string &key, T value) {

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -45,12 +45,7 @@ class StateDescriptor {
   StateDescriptor(const StateDescriptor &s) = delete;
 
   // Preferred constructor
-  explicit StateDescriptor(std::string label)
-      : label_(label), PostFillDerivedBlock{nullptr}, PostFillDerivedMesh{nullptr},
-        PreFillDerivedBlock{nullptr}, PreFillDerivedMesh{nullptr},
-        FillDerivedBlock{nullptr}, FillDerivedMesh{nullptr},
-        OutputDiagnosticsMesh{nullptr}, EstimateTimestepBlock{nullptr},
-        EstimateTimestepMesh{nullptr}, CheckRefinementBlock{nullptr} {}
+  explicit StateDescriptor(std::string const& label) : label_(label) {}
 
   template <typename T>
   void AddParam(const std::string &key, T value) {
@@ -183,8 +178,11 @@ class StateDescriptor {
     if (FillDerivedMesh != nullptr) FillDerivedMesh(rc);
   }
 
-  void OutputDiagnostics(SimTime const &simtime, MeshData<Real> *rc) const {
-    if (OutputDiagnosticsMesh != nullptr) OutputDiagnosticsMesh(simtime, rc);
+  void PreStepDiagnostics(SimTime const &simtime, MeshData<Real> *rc) const {
+    if (PreStepDiagnosticsMesh != nullptr) PreStepDiagnosticsMesh(simtime, rc);
+  }
+  void PostStepDiagnostics(SimTime const &simtime, MeshData<Real> *rc) const {
+    if (PostStepDiagnosticsMesh != nullptr) PostStepDiagnosticsMesh(simtime, rc);
   }
 
   Real EstimateTimestep(MeshBlockData<Real> *rc) const {
@@ -203,19 +201,20 @@ class StateDescriptor {
 
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
 
-  void (*PreFillDerivedBlock)(MeshBlockData<Real> *rc);
-  void (*PreFillDerivedMesh)(MeshData<Real> *rc);
-  void (*PostFillDerivedBlock)(MeshBlockData<Real> *rc);
-  void (*PostFillDerivedMesh)(MeshData<Real> *rc);
-  void (*FillDerivedBlock)(MeshBlockData<Real> *rc);
-  void (*FillDerivedMesh)(MeshData<Real> *rc);
+  void (*PreFillDerivedBlock)(MeshBlockData<Real> *rc) = nullptr;
+  void (*PreFillDerivedMesh)(MeshData<Real> *rc) = nullptr;
+  void (*PostFillDerivedBlock)(MeshBlockData<Real> *rc) = nullptr;
+  void (*PostFillDerivedMesh)(MeshData<Real> *rc) = nullptr;
+  void (*FillDerivedBlock)(MeshBlockData<Real> *rc) = nullptr;
+  void (*FillDerivedMesh)(MeshData<Real> *rc) = nullptr;
 
-  void (*OutputDiagnosticsMesh)(SimTime const &simtime, MeshData<Real> *rc);
+  void (*PreStepDiagnosticsMesh)(SimTime const &simtime, MeshData<Real> *rc) = nullptr;
+  void (*PostStepDiagnosticsMesh)(SimTime const &simtime, MeshData<Real> *rc) = nullptr;
 
-  Real (*EstimateTimestepBlock)(MeshBlockData<Real> *rc);
-  Real (*EstimateTimestepMesh)(MeshData<Real> *rc);
+  Real (*EstimateTimestepBlock)(MeshBlockData<Real> *rc) = nullptr;
+  Real (*EstimateTimestepMesh)(MeshData<Real> *rc) = nullptr;
 
-  AmrTag (*CheckRefinementBlock)(MeshBlockData<Real> *rc);
+  AmrTag (*CheckRefinementBlock)(MeshBlockData<Real> *rc) = nullptr;
 
   friend std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd);
 

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -188,6 +188,10 @@ class StateDescriptor {
     if (FillDerivedMesh != nullptr) FillDerivedMesh(rc);
   }
 
+  void OutputDiagnostics(SimTime const &simtime, MeshData<Real> *rc) const {
+    if (OutputDiagnosticsMesh != nullptr) OutputDiagnosticsMesh(simtime, rc);
+  }
+
   Real EstimateTimestep(MeshBlockData<Real> *rc) const {
     if (EstimateTimestepBlock != nullptr) return EstimateTimestepBlock(rc);
     return std::numeric_limits<Real>::max();
@@ -203,14 +207,19 @@ class StateDescriptor {
   }
 
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
+
   void (*PreFillDerivedBlock)(MeshBlockData<Real> *rc);
   void (*PreFillDerivedMesh)(MeshData<Real> *rc);
   void (*PostFillDerivedBlock)(MeshBlockData<Real> *rc);
   void (*PostFillDerivedMesh)(MeshData<Real> *rc);
   void (*FillDerivedBlock)(MeshBlockData<Real> *rc);
   void (*FillDerivedMesh)(MeshData<Real> *rc);
+
+  void (*OutputDiagnosticsMesh)(SimTime const &simtime, MeshData<Real> *rc);
+
   Real (*EstimateTimestepBlock)(MeshBlockData<Real> *rc);
   Real (*EstimateTimestepMesh)(MeshData<Real> *rc);
+
   AmrTag (*CheckRefinementBlock)(MeshBlockData<Real> *rc);
 
   friend std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd);

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -45,7 +45,7 @@ class StateDescriptor {
   StateDescriptor(const StateDescriptor &s) = delete;
 
   // Preferred constructor
-  explicit StateDescriptor(std::string const& label) : label_(label) {}
+  explicit StateDescriptor(std::string const &label) : label_(label) {}
 
   template <typename T>
   void AddParam(const std::string &key, T value) {
@@ -201,20 +201,22 @@ class StateDescriptor {
 
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
 
-  void (*PreFillDerivedBlock)(MeshBlockData<Real> *rc) = nullptr;
-  void (*PreFillDerivedMesh)(MeshData<Real> *rc) = nullptr;
-  void (*PostFillDerivedBlock)(MeshBlockData<Real> *rc) = nullptr;
-  void (*PostFillDerivedMesh)(MeshData<Real> *rc) = nullptr;
-  void (*FillDerivedBlock)(MeshBlockData<Real> *rc) = nullptr;
-  void (*FillDerivedMesh)(MeshData<Real> *rc) = nullptr;
+  std::function<void(MeshBlockData<Real> *rc)> PreFillDerivedBlock = nullptr;
+  std::function<void(MeshData<Real> *rc)> PreFillDerivedMesh = nullptr;
+  std::function<void(MeshBlockData<Real> *rc)> PostFillDerivedBlock = nullptr;
+  std::function<void(MeshData<Real> *rc)> PostFillDerivedMesh = nullptr;
+  std::function<void(MeshBlockData<Real> *rc)> FillDerivedBlock = nullptr;
+  std::function<void(MeshData<Real> *rc)> FillDerivedMesh = nullptr;
 
-  void (*PreStepDiagnosticsMesh)(SimTime const &simtime, MeshData<Real> *rc) = nullptr;
-  void (*PostStepDiagnosticsMesh)(SimTime const &simtime, MeshData<Real> *rc) = nullptr;
+  std::function<void(SimTime const &simtime, MeshData<Real> *rc)> PreStepDiagnosticsMesh =
+      nullptr;
+  std::function<void(SimTime const &simtime, MeshData<Real> *rc)>
+      PostStepDiagnosticsMesh = nullptr;
 
-  Real (*EstimateTimestepBlock)(MeshBlockData<Real> *rc) = nullptr;
-  Real (*EstimateTimestepMesh)(MeshData<Real> *rc) = nullptr;
+  std::function<Real(MeshBlockData<Real> *rc)> EstimateTimestepBlock = nullptr;
+  std::function<Real(MeshData<Real> *rc)> EstimateTimestepMesh = nullptr;
 
-  AmrTag (*CheckRefinementBlock)(MeshBlockData<Real> *rc) = nullptr;
+  std::function<AmrTag(MeshBlockData<Real> *rc)> CheckRefinementBlock = nullptr;
 
   friend std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd);
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -178,6 +178,12 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Properties_t &properti
   if (app_in->PostStepMeshUserWorkInLoop != nullptr) {
     PostStepUserWorkInLoop = app_in->PostStepMeshUserWorkInLoop;
   }
+  if (app_in->PreStepDiagnosticsInLoop != nullptr) {
+    PreStepUserDiagnosticsInLoop = app_in->PreStepDiagnosticsInLoop;
+  }
+  if (app_in->PostStepDiagnosticsInLoop != nullptr) {
+    PostStepUserDiagnosticsInLoop = app_in->PostStepDiagnosticsInLoop;
+  }
   if (app_in->UserWorkAfterLoop != nullptr) {
     UserWorkAfterLoop = app_in->UserWorkAfterLoop;
   }
@@ -594,6 +600,12 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   }
   if (app_in->PostStepMeshUserWorkInLoop != nullptr) {
     PostStepUserWorkInLoop = app_in->PostStepMeshUserWorkInLoop;
+  }
+  if (app_in->PreStepDiagnosticsInLoop != nullptr) {
+    PreStepUserDiagnosticsInLoop = app_in->PreStepDiagnosticsInLoop;
+  }
+  if (app_in->PostStepDiagnosticsInLoop != nullptr) {
+    PostStepUserDiagnosticsInLoop = app_in->PostStepDiagnosticsInLoop;
   }
   if (app_in->UserWorkAfterLoop != nullptr) {
     UserWorkAfterLoop = app_in->UserWorkAfterLoop;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -172,8 +172,11 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Properties_t &properti
   if (app_in->InitUserMeshData != nullptr) {
     InitUserMeshData = app_in->InitUserMeshData;
   }
-  if (app_in->MeshUserWorkInLoop != nullptr) {
-    UserWorkInLoop = app_in->MeshUserWorkInLoop;
+  if (app_in->PreStepMeshUserWorkInLoop != nullptr) {
+    PreStepUserWorkInLoop = app_in->PreStepMeshUserWorkInLoop;
+  }
+  if (app_in->PostStepMeshUserWorkInLoop != nullptr) {
+    PostStepUserWorkInLoop = app_in->PostStepMeshUserWorkInLoop;
   }
   if (app_in->UserWorkAfterLoop != nullptr) {
     UserWorkAfterLoop = app_in->UserWorkAfterLoop;
@@ -586,8 +589,11 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   if (app_in->InitUserMeshData != nullptr) {
     InitUserMeshData = app_in->InitUserMeshData;
   }
-  if (app_in->MeshUserWorkInLoop != nullptr) {
-    UserWorkInLoop = app_in->MeshUserWorkInLoop;
+  if (app_in->PreStepMeshUserWorkInLoop != nullptr) {
+    PreStepUserWorkInLoop = app_in->PreStepMeshUserWorkInLoop;
+  }
+  if (app_in->PostStepMeshUserWorkInLoop != nullptr) {
+    PostStepUserWorkInLoop = app_in->PostStepMeshUserWorkInLoop;
   }
   if (app_in->UserWorkAfterLoop != nullptr) {
     UserWorkAfterLoop = app_in->UserWorkAfterLoop;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -147,8 +147,9 @@ class Mesh {
                                        SimTime &tm); // called in main loop
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop =
       &UserWorkAfterLoopDefault;
-  static void UserWorkInLoopDefault(Mesh *, ParameterInput *,
-                                    SimTime const &); // called in main after each cycle
+  static void UserWorkInLoopDefault(
+      Mesh *, ParameterInput *,
+      SimTime const &); // default behavior for pre- and post-step user work
   std::function<void(Mesh *, ParameterInput *, SimTime const &)> PreStepUserWorkInLoop =
       &UserWorkInLoopDefault;
   std::function<void(Mesh *, ParameterInput *, SimTime const &)> PostStepUserWorkInLoop =

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -147,8 +147,12 @@ class Mesh {
                                        SimTime &tm); // called in main loop
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop =
       &UserWorkAfterLoopDefault;
-  static void UserWorkInLoopDefault(); // called in main after each cycle
-  std::function<void()> UserWorkInLoop = &UserWorkInLoopDefault;
+  static void UserWorkInLoopDefault(Mesh *, ParameterInput *,
+                                    SimTime &); // called in main after each cycle
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepUserWorkInLoop =
+      &UserWorkInLoopDefault;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> PostStepUserWorkInLoop =
+      &UserWorkInLoopDefault;
   int GetRootLevel() const noexcept { return root_level; }
   int GetMaxLevel() const noexcept { return max_level; }
   int GetCurrentLevel() const noexcept { return current_level; }

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -148,10 +148,10 @@ class Mesh {
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop =
       &UserWorkAfterLoopDefault;
   static void UserWorkInLoopDefault(Mesh *, ParameterInput *,
-                                    SimTime &); // called in main after each cycle
-  std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepUserWorkInLoop =
+                                    SimTime const &); // called in main after each cycle
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)> PreStepUserWorkInLoop =
       &UserWorkInLoopDefault;
-  std::function<void(Mesh *, ParameterInput *, SimTime &)> PostStepUserWorkInLoop =
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)> PostStepUserWorkInLoop =
       &UserWorkInLoopDefault;
   int GetRootLevel() const noexcept { return root_level; }
   int GetMaxLevel() const noexcept { return max_level; }

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -153,6 +153,16 @@ class Mesh {
       &UserWorkInLoopDefault;
   std::function<void(Mesh *, ParameterInput *, SimTime const &)> PostStepUserWorkInLoop =
       &UserWorkInLoopDefault;
+
+  static void PreStepUserDiagnosticsInLoopDefault(Mesh *, ParameterInput *,
+                                                  SimTime const &);
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)>
+      PreStepUserDiagnosticsInLoop = PreStepUserDiagnosticsInLoopDefault;
+  static void PostStepUserDiagnosticsInLoopDefault(Mesh *, ParameterInput *,
+                                                   SimTime const &);
+  std::function<void(Mesh *, ParameterInput *, SimTime const &)>
+      PostStepUserDiagnosticsInLoop = PostStepUserDiagnosticsInLoopDefault;
+
   int GetRootLevel() const noexcept { return root_level; }
   int GetMaxLevel() const noexcept { return max_level; }
   int GetCurrentLevel() const noexcept { return current_level; }

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -49,7 +49,7 @@ void Mesh::InitUserMeshDataDefault(ParameterInput *pin) {
 //  \brief Function called once every time step for user-defined work.
 //========================================================================================
 
-void Mesh::UserWorkInLoopDefault(Mesh *, ParameterInput *, SimTime &) {
+void Mesh::UserWorkInLoopDefault(Mesh *, ParameterInput *, SimTime const &) {
   // do nothing
   return;
 }

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -54,6 +54,20 @@ void Mesh::UserWorkInLoopDefault(Mesh *, ParameterInput *, SimTime const &) {
   return;
 }
 
+void Mesh::PreStepUserDiagnosticsInLoopDefault(Mesh *pmesh, ParameterInput *,
+                                               SimTime const &simtime) {
+  for (auto &package : pmesh->packages) {
+    package.second->PreStepDiagnostics(simtime, pmesh->mesh_data.Get().get());
+  }
+}
+
+void Mesh::PostStepUserDiagnosticsInLoopDefault(Mesh *pmesh, ParameterInput *,
+                                                SimTime const &simtime) {
+  for (auto &package : pmesh->packages) {
+    package.second->PostStepDiagnostics(simtime, pmesh->mesh_data.Get().get());
+  }
+}
+
 //========================================================================================
 //! \fn void Mesh::UserWorkAfterLoopDefault(ParameterInput *pin, SimTime &tm)
 //  \brief Function called after main loop is finished for user-defined work.

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -49,7 +49,7 @@ void Mesh::InitUserMeshDataDefault(ParameterInput *pin) {
 //  \brief Function called once every time step for user-defined work.
 //========================================================================================
 
-void Mesh::UserWorkInLoopDefault() {
+void Mesh::UserWorkInLoopDefault(Mesh *, ParameterInput *, SimTime &) {
   // do nothing
   return;
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Extends `StateDescriptor`, `Mesh`, `Driver`, and `ApplicationInput` to support pre- and post-step user operations.  These could be used, for example, to provide custom edits on a per-package basis before and or after a step.  

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
