### PR TITLE
Fix initital timestep calculation for `MeshData` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [[PR 332]](https://github.com/lanl/parthenon/pull/332) Rewrote boundary conditions to work on GPUs with variable packs. Re-enabled user-defined boundary conditions via `ApplicationInput`.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[\#401]](https://github.com/lanl/parthenon/issues/401) Fix missing initial timestep for MeshData functions
 - [[PR 387]](https://github.com/lanl/parthenon/pull/387) Add missing const that was needed
 - [[PR 353]](https://github.com/lanl/parthenon/pull/353) Fixed small error in input\_parameter logic
 - [[PR 352]](https://github.com/lanl/parthenon/pull/352) Code compiles cleanly (no warnings) with nvcc_wrapper

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -125,9 +125,15 @@ void EvolutionDriver::PostExecute(DriverStatus status) {
 }
 
 void EvolutionDriver::InitializeBlockTimeSteps() {
-  // calculate the first time step
+  // calculate the first time step using Block function
   for (auto &pmb : pmesh->block_list) {
     Update::EstimateTimestep(pmb->meshblock_data.Get().get());
+  }
+  // calculate the first time step using Mesh function
+  const int num_partitions = pmesh->DefaultNumPartitions();
+  for (int i = 0; i < num_partitions; i++) {
+    auto &mbase = pmesh->mesh_data.GetOrAdd("base", i);
+    Update::EstimateTimestep(mbase.get());
   }
 }
 
@@ -153,8 +159,6 @@ void EvolutionDriver::SetGlobalTimeStep() {
   if (tm.time < tm.tlim &&
       (tm.tlim - tm.time) < tm.dt) // timestep would take us past desired endpoint
     tm.dt = tm.tlim - tm.time;
-
-  return;
 }
 
 void EvolutionDriver::OutputCycleDiagnostics() {
@@ -179,7 +183,6 @@ void EvolutionDriver::OutputCycleDiagnostics() {
       }
     }
   }
-  return;
 }
 
 } // namespace parthenon

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -13,6 +13,7 @@
 #ifndef INTERFACE_MESH_DATA_HPP_
 #define INTERFACE_MESH_DATA_HPP_
 
+#include <algorithm>
 #include <limits>
 #include <map>
 #include <memory>
@@ -88,7 +89,7 @@ class MeshData {
 
   void SetAllowedDt(const Real dt) const {
     for (const auto &pbd : block_data_) {
-      pbd->SetAllowedDt(dt);
+      pbd->SetAllowedDt(std::min(dt, pbd->GetBlockPointer()->NewDt()));
     }
   }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -111,7 +111,6 @@ class Mesh {
   void Initialize(int res_flag, ParameterInput *pin, ApplicationInput *app_in);
   void SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size,
                                  BoundaryFlag *block_bcs);
-  void NewTimeStep();
   void OutputCycleDiagnostics();
   void LoadBalancingAndAdaptiveMeshRefinement(ParameterInput *pin,
                                               ApplicationInput *app_in);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Takes `MeshData` based functions into account when calculating the first timestep.

Fixes #401 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [does not apply] New features are documented.
- [?] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md

This "bug" made me wonder if we should split/duplicate/extend the advection example so that we test both the `MeshData` and `MeshBlockData` based machinery in Parthenon.
Maybe @jlippuner planned proxy app (going for AMR performance with small MeshBlocks where we definitely need the `MeshData` functions could exclusively use the `MeshData` framework and we keep the current advection example to only use the `MeshBlockData` based interface.

Any opinions?
