### PR TITLE
Separate num ranks from other mpi options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,10 @@
 ### Fixed (not changing behavior/API/variables/...)
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 435]](https://github.com/lanl/parthenon/pull/435) Fix ctest logic for parsing number of ranks in MPI tests
 - [[PR 407]](https://github.com/lanl/parthenon/pull/407) More cleanup, removed old bash scripts for ci.
 - [[PR 428]](https://github.com/lanl/parthenon/pull/428) Triad Copyright 2021
+- [[PR 413]](https://github.com/lanl/parthenon/pull/413) LANL Snow machine configuration
 
 ### Removed (removing behavior/API/varaibles/...)
 
@@ -53,7 +55,6 @@ Date: 01/19/2021
 - [[PR 382]](https://github.com/lanl/parthenon/pull/382) Adds output on fail for fast ci implementation on Darwin.
 - [[PR 362]](https://github.com/lanl/parthenon/pull/362) Small fix to clean regression tests output folder on reruns
 - [[PR 403]](https://github.com/lanl/parthenon/pull/403) Cleanup Codacy warnings
-- [[PR 413]](https://github.com/lanl/parthenon/pull/413) LANL Snow machine configuration
 
 ### Removed (removing behavior/API/varaibles/...)
 - [[PR 410]](https://github.com/lanl/parthenon/pull/410) Addresses issue of cpp linter calling python instead of python3

--- a/cmake/PythonModuleCheck.cmake
+++ b/cmake/PythonModuleCheck.cmake
@@ -19,9 +19,7 @@ function(required_python_modules_found module_list)
   if(${Python3_Interpreter_FOUND})
     set(IMPORT_ERROR 0)
     foreach(module IN LISTS module_list )
-      # Run test under mpiexec equivalent - some modules like h5py may require
-      # it.
-      execute_process(COMMAND ${TEST_MPIEXEC} ${Python3_EXECUTABLE} -c "import ${module}"
+      execute_process(COMMAND ${Python3_EXECUTABLE} -c "import ${module}"
         RESULT_VARIABLE IMPORT_MODULE ERROR_QUIET)
     
       if(NOT ${IMPORT_MODULE} EQUAL 0)

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -98,12 +98,12 @@ function(process_mpi_args nproc)
   endif()
   # use custom numproc flag
   if (TEST_NUMPROC_FLAG)
-    list(APPEND TMPARGS "--mpirun_ranks=${TEST_NUMPROC_FLAG}")
+    list(APPEND TMPARGS "--mpirun_ranks_flag=${TEST_NUMPROC_FLAG}")
   # use CMake determined numproc flag
   else()
-    list(APPEND TMPARGS "--mpirun_ranks=${MPIEXEC_NUMPROC_FLAG}")
+    list(APPEND TMPARGS "--mpirun_ranks_flag=${MPIEXEC_NUMPROC_FLAG}")
   endif()
-  list(APPEND TMPARGS "--mpirun_ranks=${nproc}")
+  list(APPEND TMPARGS "--mpirun_ranks_num=${nproc}")
   # set additional options from machine configuration
   foreach(MPIARG ${TEST_MPIOPTS})
     list(APPEND TMPARGS "--mpirun_opts=${MPIARG}")

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -98,12 +98,12 @@ function(process_mpi_args nproc)
   endif()
   # use custom numproc flag
   if (TEST_NUMPROC_FLAG)
-    list(APPEND TMPARGS "--mpirun_opts=${TEST_NUMPROC_FLAG}")
+    list(APPEND TMPARGS "--mpirun_ranks=${TEST_NUMPROC_FLAG}")
   # use CMake determined numproc flag
   else()
-    list(APPEND TMPARGS "--mpirun_opts=${MPIEXEC_NUMPROC_FLAG}")
+    list(APPEND TMPARGS "--mpirun_ranks=${MPIEXEC_NUMPROC_FLAG}")
   endif()
-  list(APPEND TMPARGS "--mpirun_opts=${nproc}")
+  list(APPEND TMPARGS "--mpirun_ranks=${nproc}")
   # set additional options from machine configuration
   foreach(MPIARG ${TEST_MPIOPTS})
     list(APPEND TMPARGS "--mpirun_opts=${MPIARG}")

--- a/tst/regression/run_test.py
+++ b/tst/regression/run_test.py
@@ -138,6 +138,11 @@ if __name__ == '__main__':
                         nargs=1,
                         help='change MPI run wrapper command (e.g. for job schedulers)')
 
+    parser.add_argument('--mpirun_ranks',
+                        default=[],
+                        action='append',
+                        help='add option to specify number of ranks')
+
     parser.add_argument('--mpirun_opts',
                         default=[],
                         action='append',

--- a/tst/regression/run_test.py
+++ b/tst/regression/run_test.py
@@ -138,10 +138,15 @@ if __name__ == '__main__':
                         nargs=1,
                         help='change MPI run wrapper command (e.g. for job schedulers)')
 
-    parser.add_argument('--mpirun_ranks',
-                        default=[],
-                        action='append',
-                        help='add option to specify number of ranks')
+    parser.add_argument('--mpirun_ranks_flag',
+                        default=None,
+                        type=str,
+                        help='Flag for the number of ranks')
+
+    parser.add_argument('--mpirun_ranks_num',
+                        default=1,
+                        type=int,
+                        help='Number of ranks')
 
     parser.add_argument('--mpirun_opts',
                         default=[],

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -106,20 +106,9 @@ class TestManager:
         self.parameters.output_path = output_path
         self.parameters.test_path = test_path
         self.parameters.mpi_cmd = mpi_executable
+        self.parameters.mpi_ranks = kwargs.pop('mpirun_ranks')
         self.parameters.mpi_opts = kwargs.pop('mpirun_opts')
-       
-        argstrings = ['-np','-n']
-        if len(set(argstrings) & set(self.parameters.mpi_opts)) > 1:
-          print('Warning! You have set both "-n" and "-np" in your MPI options.')
-          print(self.parameters.mpi_opts)
-        for s in argstrings:
-          if s in self.parameters.mpi_opts:
-            index = self.parameters.mpi_opts.index(s)
-            if index < len(self.parameters.mpi_opts) - 1:
-              try:
-                self.parameters.num_ranks = int(self.parameters.mpi_opts[index+1])
-              except ValueError:
-                pass
+        self.parameters.num_ranks = int(self.parameters.mpi_ranks[1])
 
         module = __import__(self.__test_module, globals(), locals(),
                 fromlist=['TestCase'])
@@ -201,6 +190,7 @@ class TestManager:
         run_command = []
         if self.parameters.mpi_cmd != "":
             run_command.extend(self.parameters.mpi_cmd)
+        run_command.extend(self.parameters.mpi_ranks)
         for opt in self.parameters.mpi_opts:
             run_command.extend(opt.split()) 
         run_command.append(self.parameters.driver_path)

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -106,10 +106,9 @@ class TestManager:
         self.parameters.output_path = output_path
         self.parameters.test_path = test_path
         self.parameters.mpi_cmd = mpi_executable
-        self.parameters.mpi_ranks = kwargs.pop('mpirun_ranks')
+        self.parameters.mpi_ranks_flag = kwargs.pop('mpirun_ranks_flag')
+        self.parameters.num_ranks = int(kwargs.pop('mpirun_ranks_num'))
         self.parameters.mpi_opts = kwargs.pop('mpirun_opts')
-        if len(self.parameters.mpi_ranks) == 2:
-            self.parameters.num_ranks = int(self.parameters.mpi_ranks[1])
 
         module = __import__(self.__test_module, globals(), locals(),
                 fromlist=['TestCase'])
@@ -191,7 +190,9 @@ class TestManager:
         run_command = []
         if self.parameters.mpi_cmd != "":
             run_command.extend(self.parameters.mpi_cmd)
-        run_command.extend(self.parameters.mpi_ranks)
+        if self.parameters.mpi_ranks_flag is not None:
+            run_command.append(self.parameters.mpi_ranks_flag)
+            run_command.append(str(self.parameters.num_ranks))
         for opt in self.parameters.mpi_opts:
             run_command.extend(opt.split()) 
         run_command.append(self.parameters.driver_path)

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -108,7 +108,8 @@ class TestManager:
         self.parameters.mpi_cmd = mpi_executable
         self.parameters.mpi_ranks = kwargs.pop('mpirun_ranks')
         self.parameters.mpi_opts = kwargs.pop('mpirun_opts')
-        self.parameters.num_ranks = int(self.parameters.mpi_ranks[1])
+        if len(self.parameters.mpi_ranks) == 2:
+            self.parameters.num_ranks = int(self.parameters.mpi_ranks[1])
 
         module = __import__(self.__test_module, globals(), locals(),
                 fromlist=['TestCase'])


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Currently the regression test manually parsed the number of ranks from `-n` or `-np`, which was then in turn used to adjust the MeshBlock sizes in the advection performance and convergence tests so that those test would work with 1+ ranks.

However, the current automated parsing logic was problematic when the number of ranks was not determined by the above options, e.g, when using `jsrun`  with `-a` (and `-n` carrying a different meaning).
Given that we already have a hardcoded CMake value for the number of ranks, this number is now directly used (instead of being derived).

Fixes some part of #377 and #433

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [X] Code passes cpplint
- [X] New features are documented.
- [X] Adds a test for any bugs fixed. Adds tests for new features.
- [X] Code is formatted
- [X] Changes are summarized in CHANGELOG.md

