### PR TITLE
More diagnostic runtime output (AMR/Loadbalance and mesh structure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR 412]](https://github.com/lanl/parthenon/pull/412) Add capability to use host (pinned) memory for communication buffers (via PARTHENON_ENABLE_HOST_COMM_BUFFERS - default OFF)
+- [[PR 438]](https://github.com/lanl/parthenon/pull/438) More diagnostic runtime output (AMR/Loadbalance and mesh structure) controlled via `parthenon/time/ncycle_out_mesh` input parameter (default 0 - off)
+- [[PR 412]](https://github.com/lanl/parthenon/pull/412) Add capability to use host (pinned) memory for communication buffers (via `PARTHENON_ENABLE_HOST_COMM_BUFFERS` - default OFF)
 - [[PR 359]](https://github.com/lanl/parthenon/pull/359) MeshBlockPack support for buffer pack and unpack of CellCentered Variables
 
 ### Changed (changing behavior/API/variables/...)

--- a/docs/inputs.md
+++ b/docs/inputs.md
@@ -3,4 +3,6 @@
    |             Option                    | Default  | Type   | Description |
    | ------------------------------------: | :------- | :----- | :---------- |
    | <parthenon/time><br>perf_cycle_offset | 0        | int    | Skip the first N cycles when calculating the final performance (e.g., zone-cycles/wall_second). Allows to hide the initialization overhead in Parthenon, which usually takes place in the first cycles when Containers are allocated, etc. | 
+   | <parthenon/time><br>ncycle_out        | 1        | int    | Number of cycles between short diagnostic output to standard out containing, e.g., current time, dt, zone-update/wsec. Default: 1 (i.e, every cycle).|
+   | <parthenon/time><br>ncycle_out_mesh   | 0        | int    | Number of cycles between printing the mesh structure (e.g., total number of MeshBlocks and number of MeshBlocks per level) to standard out. Use a negative number to also print every time the mesh was modified. Default: 0 (i.e, off). |
    | <parthenon/mesh><br>nghost            | 2        | int    | Number of ghost cells for each mesh block on each side. | 

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -40,13 +40,14 @@ enum class AmrTag : int { derefine = -1, same = 0, refine = 1 };
 struct SimTime {
   SimTime() = default;
   SimTime(const Real tstart, const Real tstop, const int nmax, const int ncurr,
-          const int nout, const Real dt_in = std::numeric_limits<Real>::max())
+          const int nout, const int nout_mesh,
+          const Real dt_in = std::numeric_limits<Real>::max())
       : start_time(tstart), time(tstart), tlim(tstop), dt(dt_in), nlim(nmax),
-        ncycle(ncurr), ncycle_out(nout) {}
+        ncycle(ncurr), ncycle_out(nout), ncycle_out_mesh(nout_mesh) {}
   // beginning time, current time, maximum time, time step
   Real start_time, time, tlim, dt;
   // current cycle number, maximum number of cycles, cycles between diagnostic output
-  int ncycle, nlim, ncycle_out;
+  int ncycle, nlim, ncycle_out, ncycle_out_mesh;
 
   bool KeepGoing() { return ((time < tlim) && (nlim < 0 || ncycle < nlim)); }
 };

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -206,7 +206,7 @@ void EvolutionDriver::OutputCycleDiagnostics() {
     // output in fixed intervals
     if (tm.ncycle % tm.ncycle_out_mesh == 0) {
       pmesh->OutputMeshStructure(-1, false);
-    // output after mesh refinement (enabled by use of negative cycle number)
+      // output after mesh refinement (enabled by use of negative cycle number)
     } else if (tm.ncycle_out_mesh < 0 && pmesh->modified) {
       pmesh->OutputMeshStructure(-1, false);
     }

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -203,12 +203,18 @@ void EvolutionDriver::OutputCycleDiagnostics() {
     }
   }
   if (tm.ncycle_out_mesh != 0) {
-    // output in fixed intervals
-    if (tm.ncycle % tm.ncycle_out_mesh == 0) {
+    // output after mesh refinement (enabled by use of negative cycle number)
+    if (tm.ncycle_out_mesh < 0 && pmesh->modified) {
+      std::cout << "-------------- New Mesh structure after (de)refinement -------------";
       pmesh->OutputMeshStructure(-1, false);
-      // output after mesh refinement (enabled by use of negative cycle number)
-    } else if (tm.ncycle_out_mesh < 0 && pmesh->modified) {
+      std::cout << "--------------------------------------------------------------------"
+                << std::endl;
+      // output in fixed intervals
+    } else if (tm.ncycle % tm.ncycle_out_mesh == 0) {
+      std::cout << "---------------------- Current Mesh structure ----------------------";
       pmesh->OutputMeshStructure(-1, false);
+      std::cout << "--------------------------------------------------------------------"
+                << std::endl;
     }
   }
 }

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -66,10 +66,13 @@ class EvolutionDriver : public Driver {
                                          std::numeric_limits<Real>::infinity());
     Real dt =
         pinput->GetOrAddPrecise("parthenon/time", "dt", std::numeric_limits<Real>::max());
-    int ncycle = pinput->GetOrAddInteger("parthenon/time", "ncycle", 0);
-    int nmax = pinput->GetOrAddInteger("parthenon/time", "nlim", -1);
-    int nout = pinput->GetOrAddInteger("parthenon/time", "ncycle_out", 1);
-    tm = SimTime(start_time, tstop, nmax, ncycle, nout, dt);
+    const auto ncycle = pinput->GetOrAddInteger("parthenon/time", "ncycle", 0);
+    const auto nmax = pinput->GetOrAddInteger("parthenon/time", "nlim", -1);
+    const auto nout = pinput->GetOrAddInteger("parthenon/time", "ncycle_out", 1);
+    // disable mesh output by default
+    const auto nout_mesh =
+        pinput->GetOrAddInteger("parthenon/time", "ncycle_out_mesh", 0);
+    tm = SimTime(start_time, tstop, nmax, ncycle, nout, nout_mesh, dt);
     pouts = std::make_unique<Outputs>(pmesh, pinput, &tm);
   }
   DriverStatus Execute() override;

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -38,7 +38,7 @@ enum class DriverStatus { complete, timeout, failed };
 class Driver {
  public:
   Driver(ParameterInput *pin, ApplicationInput *app_in, Mesh *pm)
-      : pinput(pin), app_input(app_in), pmesh(pm), mbcnt_prev() {}
+      : pinput(pin), app_input(app_in), pmesh(pm), mbcnt_prev(), time_LBandAMR() {}
   virtual DriverStatus Execute() = 0;
   void InitializeOutputs() { pouts = std::make_unique<Outputs>(pmesh, pinput); }
 
@@ -48,7 +48,8 @@ class Driver {
   std::unique_ptr<Outputs> pouts;
 
  protected:
-  Kokkos::Timer timer_cycle, timer_main;
+  Kokkos::Timer timer_cycle, timer_main, timer_LBandAMR;
+  double time_LBandAMR;
   std::uint64_t mbcnt_prev;
   virtual void PreExecute();
   virtual void PostExecute(DriverStatus status);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -795,17 +795,9 @@ Mesh::~Mesh() = default;
 //! \fn void Mesh::OutputMeshStructure(int ndim)
 //  \brief print the mesh structure information
 
-void Mesh::OutputMeshStructure(int ndim) {
+void Mesh::OutputMeshStructure(int ndim, bool dump_mesh_structure /*= true*/) {
   RegionSize block_size;
   BoundaryFlag block_bcs[6];
-  FILE *fp = nullptr;
-
-  // open 'mesh_structure.dat' file
-  if ((fp = std::fopen("mesh_structure.dat", "wb")) == nullptr) {
-    std::cout << "### ERROR in function Mesh::OutputMeshStructure" << std::endl
-              << "Cannot open mesh_structure.dat" << std::endl;
-    return;
-  }
 
   // Write overall Mesh structure to stdout and file
   std::cout << std::endl;
@@ -835,6 +827,13 @@ void Mesh::OutputMeshStructure(int ndim) {
     }
   }
 
+  delete[] nb_per_plevel;
+  delete[] cost_per_plevel;
+
+  if (!dump_mesh_structure) {
+    return;
+  }
+
   // compute/output number of blocks per rank, and cost per rank
   std::cout << "Number of parallel ranks = " << Globals::nranks << std::endl;
   int *nb_per_rank = new int[Globals::nranks];
@@ -850,6 +849,18 @@ void Mesh::OutputMeshStructure(int ndim) {
   for (int i = 0; i < Globals::nranks; ++i) {
     std::cout << "  Rank = " << i << ": " << nb_per_rank[i]
               << " MeshBlocks, cost = " << cost_per_rank[i] << std::endl;
+  }
+
+  delete[] nb_per_rank;
+  delete[] cost_per_rank;
+
+  FILE *fp = nullptr;
+
+  // open 'mesh_structure.dat' file
+  if ((fp = std::fopen("mesh_structure.dat", "wb")) == nullptr) {
+    std::cout << "### ERROR in function Mesh::OutputMeshStructure" << std::endl
+              << "Cannot open mesh_structure.dat" << std::endl;
+    return;
   }
 
   // output relative size/locations of meshblock to file, for plotting
@@ -931,13 +942,6 @@ void Mesh::OutputMeshStructure(int ndim) {
   std::cout << "Use 'python ../vis/python/plot_mesh.py' or gnuplot"
             << " to visualize mesh structure." << std::endl
             << std::endl;
-
-  delete[] nb_per_plevel;
-  delete[] cost_per_plevel;
-  delete[] nb_per_rank;
-  delete[] cost_per_rank;
-
-  return;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <memory>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -795,7 +796,8 @@ Mesh::~Mesh() = default;
 //! \fn void Mesh::OutputMeshStructure(int ndim)
 //  \brief print the mesh structure information
 
-void Mesh::OutputMeshStructure(int ndim, bool dump_mesh_structure /*= true*/) {
+void Mesh::OutputMeshStructure(const int ndim,
+                               const bool dump_mesh_structure /*= true*/) {
   RegionSize block_size;
   BoundaryFlag block_bcs[6];
 
@@ -809,8 +811,8 @@ void Mesh::OutputMeshStructure(int ndim, bool dump_mesh_structure /*= true*/) {
   std::cout << "Number of logical  refinement levels = " << current_level << std::endl;
 
   // compute/output number of blocks per level, and cost per level
-  int *nb_per_plevel = new int[max_level];
-  int *cost_per_plevel = new int[max_level];
+  auto nb_per_plevel = std::make_unique<int[]>(max_level);
+  auto cost_per_plevel = std::make_unique<int[]>(max_level);
   for (int i = 0; i <= max_level; ++i) {
     nb_per_plevel[i] = 0;
     cost_per_plevel[i] = 0;
@@ -827,17 +829,14 @@ void Mesh::OutputMeshStructure(int ndim, bool dump_mesh_structure /*= true*/) {
     }
   }
 
-  delete[] nb_per_plevel;
-  delete[] cost_per_plevel;
-
   if (!dump_mesh_structure) {
     return;
   }
 
   // compute/output number of blocks per rank, and cost per rank
   std::cout << "Number of parallel ranks = " << Globals::nranks << std::endl;
-  int *nb_per_rank = new int[Globals::nranks];
-  int *cost_per_rank = new int[Globals::nranks];
+  auto nb_per_rank = std::make_unique<int[]>(Globals::nranks);
+  auto cost_per_rank = std::make_unique<int[]>(Globals::nranks);
   for (int i = 0; i < Globals::nranks; ++i) {
     nb_per_rank[i] = 0;
     cost_per_rank[i] = 0;
@@ -850,9 +849,6 @@ void Mesh::OutputMeshStructure(int ndim, bool dump_mesh_structure /*= true*/) {
     std::cout << "  Rank = " << i << ": " << nb_per_rank[i]
               << " MeshBlocks, cost = " << cost_per_rank[i] << std::endl;
   }
-
-  delete[] nb_per_rank;
-  delete[] cost_per_rank;
 
   FILE *fp = nullptr;
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -168,6 +168,8 @@ class Mesh {
   int GetCurrentLevel() const noexcept { return current_level; }
   std::vector<int> GetNbList() const noexcept { return nblist; }
 
+  void OutputMeshStructure(int dim, bool dump_mesh_structure = true);
+
  private:
   // data
   int next_phys_id_; // next unused value for encoding final component of MPI tag bitfield
@@ -216,7 +218,6 @@ class Mesh {
   SrcTermFunc UserSourceTerm_;
   TimeStepFunc UserTimeStep_;
 
-  void OutputMeshStructure(int dim);
   void CalculateLoadBalance(std::vector<double> const &costlist,
                             std::vector<int> &ranklist, std::vector<int> &nslist,
                             std::vector<int> &nblist);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -168,7 +168,7 @@ class Mesh {
   int GetCurrentLevel() const noexcept { return current_level; }
   std::vector<int> GetNbList() const noexcept { return nblist; }
 
-  void OutputMeshStructure(int dim, bool dump_mesh_structure = true);
+  void OutputMeshStructure(const int dim, const bool dump_mesh_structure = true);
 
  private:
   // data


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Adds additional cycle performance data (which should at a high level allow to measure the overhead of mesh refinement and load balancing) as well as output of the mesh structure.
The latter is off by default and controlled via the input file with the `parthenon/time/ncycle_out_mesh` parameter.

A sample output now may look like
```
cycle=28 time=5.1406510065595977e-05 dt=1.6932658600527559e-06 zone-cycles/wsec_step=2.24e+06 wsec_step=2.20e-01 zone-cycles/wsec=2.24e+06 wsec_AMR=1.54e-04
cycle=29 time=5.3099775925648732e-05 dt=1.6991523280397159e-06 zone-cycles/wsec_step=2.21e+06 wsec_step=2.22e-01 zone-cycles/wsec=2.21e+06 wsec_AMR=3.38e-04
cycle=30 time=5.4798928253688446e-05 dt=1.7045121209625266e-06 zone-cycles/wsec_step=2.20e+06 wsec_step=2.23e-01 zone-cycles/wsec=2.19e+06 wsec_AMR=1.72e-03
---------------------- Current Mesh structure ----------------------
Root grid = 8 x 8 x 8 MeshBlocks
Total number of MeshBlocks = 960
Number of physical refinement levels = 2
Number of logical  refinement levels = 5
  Physical level = 0 (logical level = 3): 480 MeshBlocks, cost = 480
  Physical level = 1 (logical level = 4): 224 MeshBlocks, cost = 224
  Physical level = 2 (logical level = 5): 256 MeshBlocks, cost = 256
--------------------------------------------------------------------
cycle=31 time=5.6503440374650975e-05 dt=1.7095544528615823e-06 zone-cycles/wsec_step=2.15e+06 wsec_step=2.28e-01 zone-cycles/wsec=2.15e+06 wsec_AMR=1.81e-04
cycle=32 time=5.8212994827512555e-05 dt=1.7143245852434286e-06 zone-cycles/wsec_step=2.24e+06 wsec_step=2.20e-01 zone-cycles/wsec=2.22e+06 wsec_AMR=1.27e-03
cycle=33 time=5.9927319412755980e-05 dt=1.7132534065589339e-06 zone-cycles/wsec_step=2.21e+06 wsec_step=2.22e-01 zone-cycles/wsec=2.21e+06 wsec_AMR=1.54e-04
cycle=34 time=6.1640572819314916e-05 dt=1.7123032206621521e-06 zone-cycles/wsec_step=2.12e+06 wsec_step=2.32e-01 zone-cycles/wsec=1.41e+06 wsec_AMR=1.16e-01
-------------- New Mesh structure after (de)refinement -------------
Root grid = 8 x 8 x 8 MeshBlocks
Total number of MeshBlocks = 1296
Number of physical refinement levels = 2
Number of logical  refinement levels = 5
  Physical level = 0 (logical level = 3): 456 MeshBlocks, cost = 456
  Physical level = 1 (logical level = 4): 392 MeshBlocks, cost = 392
  Physical level = 2 (logical level = 5): 448 MeshBlocks, cost = 448
--------------------------------------------------------------------
cycle=35 time=6.3352876039977064e-05 dt=1.7124939092645730e-06 zone-cycles/wsec_step=2.04e+06 wsec_step=3.25e-01 zone-cycles/wsec=2.04e+06 wsec_AMR=2.77e-04
cycle=36 time=6.5065369949241639e-05 dt=1.7139091408957631e-06 zone-cycles/wsec_step=2.15e+06 wsec_step=3.09e-01 zone-cycles/wsec=2.09e+06 wsec_AMR=9.22e-03


```


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
