### PR TITLE
Fix Darwin config use spectrum with ppc64le

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [[PR 407]](https://github.com/lanl/parthenon/pull/407) More cleanup, removed old bash scripts for ci.
 - [[PR 428]](https://github.com/lanl/parthenon/pull/428) Triad Copyright 2021
 - [[PR 413]](https://github.com/lanl/parthenon/pull/413) LANL Snow machine configuration
+- [[PR 443]](https://github.com/lanl/parthenon/pull/443) Fix Darwin machine config - use spectrum mpi
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -73,7 +73,6 @@ function(process_mpi_args nproc)
     list(APPEND TMPARGS "${TEST_MPIEXEC}")
   # use CMake determined mpiexec
   else()
-    message("MPI executable ${MPIEXEC_EXECUTABLE}")
     list(APPEND TMPARGS "${MPIEXEC_EXECUTABLE}")
   endif()
   # use custom numproc flag

--- a/cmake/machinecfg/Darwin.cmake
+++ b/cmake/machinecfg/Darwin.cmake
@@ -237,11 +237,11 @@ endif()
 # MPI - We use the system modules since replicating them in spack can be
 # difficult.
 if (DARWIN_COMPILER MATCHES "GCC")
-  if(DARWIN_MPI_PACKAGE MATCHES "openmpi")
+  if(DARWIN_MPI_PACKAGE STREQUAL "openmpi")
     set(MPI_ROOT 
     /projects/opt/${DARWIN_ARCH}${DARWIN_MICROARCH_PATH}/openmpi/${DARWIN_MPI_VERSION}-gcc_${DARWIN_${DARWIN_COMPILER}_VERSION}
         CACHE STRING "MPI Location")
-  else()
+  elseif(DARWIN_MPI_PACKAGE STREQUAL "smpi")
     set(MPI_ROOT /projects/opt/${DARWIN_ARCH}/ibm/smpi-${DARWIN_MPI_VERSION}
         CACHE STRING "MPI Location")
   endif()

--- a/cmake/machinecfg/Darwin.cmake
+++ b/cmake/machinecfg/Darwin.cmake
@@ -3,7 +3,7 @@
 # Copyright(C) 2020 The Parthenon collaboration
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 #========================================================================================
-# (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -56,22 +56,27 @@ if (DARWIN_ARCH STREQUAL "x86_64")
 
     set(DARWIN_GCC9_VERSION "9.3.0")
 
+    set(DARWIN_MPI_PACKAGE "openmpi")
     set(DARWIN_MPI_VERSION "4.0.3")
     set(DARWIN_CUDA_VERSION "11.0")
 
     set(DARWIN_CUDA_DEFAULT OFF)
 elseif (DARWIN_ARCH STREQUAL "ppc64le")
-    set(DARWIN_VIEW_DATE_LATEST "2020-10-28")
+    set(DARWIN_VIEW_DATE_LATEST "2021-02-08")
     set(DARWIN_GCC_PREFERRED "GCC9")
     set(DARWIN_COMPILER_PREFERRED "GCC")
 
-    set(DARWIN_GCC9_VERSION "9.2.0")
+    set(DARWIN_GCC9_VERSION "9.3.0")
     set(DARWIN_MICROARCH_PATH "/p9")
 
-    set(DARWIN_MPI_VERSION "4.0.2")
+    set(DARWIN_MPI_PACKAGE "smpi")
+    set(DARWIN_MPI_VERSION "10.3.0.1")
     set(DARWIN_CUDA_VERSION "11.0")
 
     set(DARWIN_CUDA_DEFAULT ON)
+    # Because using spectrum serial version requires calling mpiexec
+    set(SERIAL_WITH_MPIEXEC ON)
+    string(APPEND TEST_MPIOPTS "-gpu")
 else()
     message(
         FATAL_ERROR
@@ -232,9 +237,14 @@ endif()
 # MPI - We use the system modules since replicating them in spack can be
 # difficult.
 if (DARWIN_COMPILER MATCHES "GCC")
-    set(MPI_ROOT
-        /projects/opt/${DARWIN_ARCH}${DARWIN_MICROARCH_PATH}/openmpi/${DARWIN_MPI_VERSION}-gcc_${DARWIN_${DARWIN_COMPILER}_VERSION}
+  if(DARWIN_MPI_PACKAGE MATCHES "openmpi")
+    set(MPI_ROOT 
+    /projects/opt/${DARWIN_ARCH}${DARWIN_MICROARCH_PATH}/openmpi/${DARWIN_MPI_VERSION}-gcc_${DARWIN_${DARWIN_COMPILER}_VERSION}
         CACHE STRING "MPI Location")
+  else()
+    set(MPI_ROOT /projects/opt/${DARWIN_ARCH}/ibm/smpi-${DARWIN_MPI_VERSION}
+        CACHE STRING "MPI Location")
+  endif()
 endif()
 
 # clang-format
@@ -263,7 +273,6 @@ if (DARWIN_CUDA AND GPU_COUNT LESS 2)
 else()
     set(NUM_RANKS 2)
 endif()
-
 set(NUM_MPI_PROC_TESTING ${NUM_RANKS} CACHE STRING "CI runs tests with 2 MPI ranks")
 set(NUM_GPU_DEVICES_PER_NODE ${NUM_RANKS} CACHE STRING "Number of gpu devices to use when testing if built with Kokkos_ENABLE_CUDA")
 set(NUM_OMP_THREADS_PER_RANK 1 CACHE STRING "Number of threads to use when testing if built with Kokkos_ENABLE_OPENMP")


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
This pr fixes the default build configuration on Darwin. Openmpi compatibility with running gpus was causing problem spectrum mpi does not appear to have the same problems. Namely the advection convergence and performance tests were failing. 
<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] (@lanl.gov employees) Update copyright on changed files
