### PR TITLE
Disable outputs when dt < 0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 461]](https://github.com/lanl/parthenon/pull/461) A negative `dt` in an output blovck disables it.
 - [[PR 406]](https://github.com/lanl/parthenon/pull/406) Add `stochastic_subgrid` example that performs a random amount of work per cell (drawn from a power law distribution)
 - [[PR 440]](https://github.com/lanl/parthenon/pull/440) Add abstraction for allocating a `unique_ptr` to an object in device memory
 - [[PR 438]](https://github.com/lanl/parthenon/pull/438) More diagnostic runtime output (AMR/Loadbalance and mesh structure) controlled via `parthenon/time/ncycle_out_mesh` input parameter (default 0 - off)

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -2,6 +2,8 @@
 
 Outputs from Parthenon are controled via ```<parthenon/output*>``` blocks, where ```*``` should be replaced by a unique integer for each block.
 
+To disable an output block without removing it from the intput file set the block's `dt < 0.0`.
+
 ## HDF5
 
 Parthenon allows users to select which fields are captured in the HDF5 (```.phdf```) dumps at runtime.  In the input file, include a ```<parthenon/output*>``` block, list of variables, and specify ```file_type = hdf5```.  A ```dt``` parameter controls the frequency of outputs for simulations involving evolution. A ```<parthenon/output*>``` block might look like

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -249,10 +249,23 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
 #ifdef HDF5OUTPUT
         pnew_type = new PHDF5Output(op);
 #else
-        msg << "### FATAL ERROR in Outputs constructor" << std::endl
-            << "Executable not configured for HDF5 outputs, but HDF5 file format "
-            << "is requested in output block '" << op.block_name << "'" << std::endl;
-        PARTHENON_FAIL(msg);
+        if (op.dt < 0.0) {
+          msg << "### WARNING in Outputs constructor" << std::endl
+              << "Executable not configured for HDF5 outputs, but HDF5 file format "
+              << "is requested in output block '" << op.block_name
+              << "' (but disabled by using a negative dt). You cannot enable this block "
+              << "by setting a positive dt without recompiling with HDF5 support."
+              << std::endl;
+          PARTHENON_WARN(msg);
+          pib = pib->pnext; // move to next input block name
+          continue;
+        } else {
+          msg << "### FATAL ERROR in Outputs constructor" << std::endl
+              << "Executable not configured for HDF5 outputs, but HDF5 file format "
+              << "is requested in output block '" << op.block_name
+              << "'. You can disable this block by setting a negative dt." << std::endl;
+          PARTHENON_FAIL(msg);
+        }
 #endif
       } else {
         msg << "### FATAL ERROR in Outputs constructor" << std::endl


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Small quality of life improvement that "soft disables" output when dt is negative.
Sometime I compile without hdf5 and thus even doing a test run would fail if there's a restart or hdf5 output block in the input file.
Now one can simply disabling the block even from the command line.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md

