### PR TITLE
Extend HDF5 output for yt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,9 +63,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 3 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 4 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=2445000a031aafc9a85a684aa7e82fb5ccda05530c5652ab432a8fb254642c7b18252ff55d8306b1120aba898713712b28b804eb30272b06278698046a6461cc"
+  "SHA512=8f9da3589ad549b5640065d37d1e26a15fdc348568a28c09b332ad2b0e612884282a9ce13acf3747505d3da9859b7d3990b95bc6d919ec8faa09f5c124afb006"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -59,3 +59,114 @@ which will produce a ```png``` image per dump suitable for encoding into a movie
 ## Visualization software
 
 Both [ParaView](https://www.paraview.org/) and [VisIt](https://wci.llnl.gov/simulation/computer-codes/visit/) are capable of opening and visualizing Parthenon graphics dumps.  In both cases, the ```.xdmf``` files should be opened.  In ParaView, select the "XDMF Reader" when prompted.
+
+## Preparing outputs for ```yt```
+
+Parthenon HDF5 outputs can be read with the python visualization library
+[yt](https://yt-project.org/) as certain variables are named when adding
+fields via ```StateDescriptor::AddField```. Variable names are added as a
+```std::vector<std::string>``` in the variable metadata. These labels are
+optional and are only used for output to HDF5. 4D variables are named with a
+list of names for each row while 3D variables are named with a single name.
+For example, the following configurations are acceptable:
+
+```c++
+auto pkg = std::make_shared<StateDescriptor>("Hydro");
+
+/* ... */
+const int nhydro = 5;
+std::vector<std::string> cons_labels(nhydro);
+cons_labels[0]="Density";
+cons_labels[1]="MomentumDensity1";
+cons_labels[2]="MomentumDensity2";
+cons_labels[3]="MomentumDensity3";
+cons_labels[4]="TotalEnergyDensity";
+Metadata m({Metadata::Cell, Metadata::Independent, Metadata::FillGhost},
+           std::vector<int>({nhydro}), cons_labels);
+pkg->AddField("cons", m);
+
+const int ndensity = 1;
+std::vector<std::string> density_labels(ndensity);
+density_labels[0]="Density";
+m = Metadata({Metadata::Cell, Metadata::Derived}, std::vector<int>({ndensity}), density_labels);
+pkg->AddField("dens", m);
+
+const int nvelocity = 3;
+std::vector<std::string> velocity_labels(nvelocity);
+velocity_labels[0]="Velocity1";
+velocity_labels[1]="Velocity2";
+velocity_labels[2]="Velocity3";
+m = Metadata({Metadata::Cell, Metadata::Derived}, std::vector<int>({nvelocity}), velocity_labels);
+pkg->AddField("vel", m);
+
+const int npressure = 1;
+std::vector<std::string> pressure_labels(npressure);
+pressure_labels[0]="Pressure";
+m = Metadata({Metadata::Cell, Metadata::Derived}, std::vector<int>({npressure}), pressure_labels);
+pkg->AddField("pres", m);
+```
+
+The `yt` frontend needs either the hydrodynamic conserved variables or
+primitive compute derived quantities. The conserved variables must have the
+names ```"Density"```, ```"MomentumDensity1"```, ```"MomentumDensity2"```,
+```"MomentumDensity3"```, ```"TotalEnergyDensity"``` while the primitive
+variables must have the names ```"Density"```, ```"Velocity1"```,
+```"Velocity2"```, ```"Velocity3"```, ```"Pressure"```. Either of these sets of
+variables must be named and present in the output, with the primitive variables
+taking precedence over the conserved variables when computing derived
+quantities such as specific thermal energy. In the above example, including
+either ```"cons"``` or ```"dens"```, ```"vel"```, and ```"pres"``` in the  HDF5
+output would allow ```yt``` to read the data.
+
+Additional parameters can also be packaged into the HDF5 file to help ```yt```
+interpret the data, namely adiabatic index and code unit information. These are
+identified by passing ```true``` as an optional boolean argument when adding
+parameters via ```StateDescriptor::AddParam```. For example, 
+```c++
+pkg->AddParam<double>("CodeLength", 100,true);
+pkg->AddParam<double>("CodeMass", 1000,true);
+pkg->AddParam<double>("CodeTime", 1,true);
+pkg->AddParam<double>("AdibaticIndex", 5./3.,true);
+
+pkg->AddParam<int>("IntParam", 0,true);
+pkg->AddParam<std::string>("EquationOfState", "Adiabatic",true);
+```
+adds the parameters ```CodeLength```, ```CodeMass```, ```CodeTime```,
+```AdiabaticIndex```, ```IntParam```, and ```EquationOfState``` to the HDF5
+output. Currently, only ```int```, ```float```, and ```std::string```
+parameters can be included with the HDF5.
+
+Code units can be defined for ```yt``` by including the parameters
+```CodeLength```, ```CodeMass```, and ```CodeTime```, which specify the code
+units used by Parthenon in terms of centimeters, grams, and seconds by writing
+the parameters.  In the above example, these parameters dictate ```yt``` to
+interpret code lengths in the data in units of 100 centimeters (or 1 meter per
+code unit), code masses in units of 1000 grams (or 1 kilogram per code units)
+and code times in units of seconds (or 1 second per code time).
+Alternatively, this unit information can also be supplied to the ```yt```
+frontend when loading the data. If code units are not defined in the HDF5 file
+or at load time, ```yt``` will assume that the data is in ```CGS```.
+
+The adiabatic index can also be specified via the parameter
+```AdiabaticIndex```, defined at load time for ```yt```, or left as its default
+```5./3.```.
+
+For example, the following methods are valid to load data with ```yt```
+```python
+filename = "parthenon.out0.00000.phdf"
+
+#Read units and adiabatic index from the HDF5 file or use defaults
+ds = yt.load(filename)
+
+#Specify units and adiabatic index explicitly
+units_override = {"length_unit" : (100, "cm"),
+                  "time_unit"   : (1,   "s"),
+                  "mass_unit"   : (1000,"g")}
+
+ds = yt.load(filename,units_override=units_override,gamma=5./3.)
+```
+
+Currently, the ```yt``` frontend for Parthenon is hosted on the
+```athenapk-frontend``` [on this ```yt```
+fork](https://github.com/forrestglines/yt/tree/athenapk-frontend). In the
+future, the Parthenon frontend will be included in the main ```yt``` repo.

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -143,8 +143,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   const auto num_vars = pin->GetOrAddInteger("Advection", "num_vars", 1);
 
   std::string field_name = "advected";
+  // Give a custom labels to advected in the data output
+  std::vector<std::string> advected_labels;
+  advected_labels.reserve(num_vars);
+  for (int i = 0; i < num_vars; i++) {
+    advected_labels.push_back("Advected_" + std::to_string(i));
+  }
   Metadata m({Metadata::Cell, Metadata::Independent, Metadata::FillGhost},
-             std::vector<int>({num_vars}));
+             std::vector<int>({num_vars}), advected_labels);
   pkg->AddField(field_name, m);
 
   field_name = "one_minus_advected";

--- a/scripts/python/phdf_diff.py
+++ b/scripts/python/phdf_diff.py
@@ -26,15 +26,16 @@ import argparse
 def Usage():
     print("""
 
-    Usage: %s [-quiet] [-brief] [-all] [-one] [--tol=eps] file1.phdf file2.phdf
+    Usage: %s [-quiet] [-brief] [-all] [-one] [--tol=eps] [-ignore_metadata] file1.phdf file2.phdf
 
-           -all: report all diffs at all positions
-           -one: Quit after first different variable
-         -brief: Only report if files are different
-                 Overrides --all
-         -quiet: Only report if files are different and
-                 don't print any extraneous info.
-      --tol=eps: set tolerance to eps.  Default 1.0e-12
+                  -all: report all diffs at all positions
+                  -one: Quit after first different variable
+                -brief: Only report if files are different
+                        Overrides --all
+                -quiet: Only report if files are different and
+                        don't print any extraneous info.
+             --tol=eps: set tolerance to eps.  Default 1.0e-12
+      -ignore_metadata: Ignore differences in metadata
 
     This example takes two hdf files and compares them to see if there are
     differences in the state variables.
@@ -53,6 +54,7 @@ def processArgs():
     parser.add_argument('-o', '-one', action='store_true', help='Only report data for first different variable.')
     parser.add_argument('-b', '-brief', action='store_true', help='Only report if files are different.  Overrides -all')
     parser.add_argument('-q', '-quiet', action='store_true', help='Only report if files are different.  No other output. Overrides -all')
+    parser.add_argument('-i', '-ignore_metadata', action='store_true', help='Ignore differences in metadata. Overrides -all')
     parser.add_argument('files', nargs='*')
 
     return parser.parse_args()
@@ -64,8 +66,162 @@ def addPath():
     #sys.path.insert(0,myPath+'/../vis/python')
     #sys.path.insert(0,myPath+'/vis/python')
 
-def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
-    """ compares two hdf files """
+def compare_metadata( f0, f1, tol=1.0e-12):
+    """ compares metadata of two hdf files f0 and f1. Returns 0 if the files are equivalent.
+
+        Error codes:
+            10 : Times in hdf files differ
+            11 : Attribute names in Info of hdf files differ
+            12 : Values of attributes in Info of hdf files differ
+            13 : Attribute names in Params of hdf files differ
+            14 : Values of attributes in Params of hdf files differ
+            15 : Meta variables (Locations, VolumeLocations, LogicalLocations, Levels) differ
+    """
+    ERROR_TIME_DIFF=10
+    ERROR_INFO_ATTRS_DIFF=11
+    ERROR_INFO_VALUES_DIFF=12
+    ERROR_PARAMS_ATTR_DIFF=13
+    ERROR_PARAMS_VALUES_DIFF=14
+    ERROR_META_VARS_DIFF=15
+
+
+    #Compare the time in both files
+    errTime = np.abs(f0.Time- f1.Time)
+    if errTime > tol:
+        print(f"""
+        Time of outputs differ by {f0.Time - f1.Time}
+
+        Quitting...
+        """)
+        return(ERROR_TIME_DIFF)
+
+    #Compare the names of attributes in /Info, except "Time"
+    f0_Info = { key:value for key,value in f0.Info.items() if key != "Time" and key != "BlocksPerPE" }
+    f1_Info = { key:value for key,value in f1.Info.items() if key != "Time" and key != "BlocksPerPE" }
+    if sorted(f0_Info.keys()) != sorted(f1_Info.keys()):
+        print("""
+        Names of attributes in '/Info' of differ
+
+        Quitting...
+        """)
+        return(ERROR_INFO_ATTRS_DIFF)
+
+    #Compare the values of attributes in /Info
+    info_diffs = list( key for key in f0_Info.keys() if np.any(f0_Info[key] != f1_Info[key]))
+    if len(info_diffs) > 0:
+        print("\nValues of attributes in '/Info' differ\n")
+        print("Differing attributes: ", info_diffs )
+        print("\nQuitting...\n")
+        return(ERROR_INFO_VALUES_DIFF)
+    else:
+        print('  %20s: no diffs'%"Info")
+
+    f0_Params = f0.Params
+    f1_Params = f1.Params
+    #Comparing all params at once might work except for float point Params
+    if sorted(f0_Params.keys()) != sorted(f1_Params.keys()):
+        print("""
+        Names of attributes in '/Params' of differ
+
+        Quitting...
+        """)
+        return(ERROR_PARAMS_ATTRS_DIFF)
+
+    #Check that the values of non-floats in Params match
+    params_nonfloats_diffs = list(key for key in f0_Params.keys()
+            if not isinstance(f0_Params[key], float) and f0_Params[key] != f1_Params[key] )
+
+
+    #Check that the values of floats Params match
+    params_floats_diffs = list(key for key in f0_Params.keys()
+            if isinstance(f0_Params[key], float) and np.abs(f0_Params[key] - f1_Params[key]) > tol )
+
+    if len(params_nonfloats_diffs) > 0 or len(params_floats_diffs) > 0:
+        if len(params_nonfloats_diffs) > 0:
+            print("\nValues of non-float attributes in '/Params' differ\n")
+            print("Differing attributes: ",params_nonfloats_diffs  )
+            print("\nQuitting...\n")
+        elif len(params_floats_diffs) > 0:
+            print("\nValues of float attributes in '/Params' differ\n")
+            for key in params_floats_diffs:
+                print(f"Param {key} differs by {f0_Params[key] - f1_Params[key]} ")
+            print("\nQuitting...\n")
+        return(ERROR_PARAMS_VALUES_DIFF)
+    else:
+        print('  %20s: no diffs'%"Params")
+
+    # Now go through all variables in first file
+    # and hunt for them in second file.
+    #
+    # Note that indices don't match when blocks
+    # are different
+    no_meta_variables_diff = True
+
+    otherBlockIdx = list(f0.findBlockIdxInOther(f1,i) for i in range(f0.NumBlocks))
+
+    for var in set(f0.Variables+f1.Variables):
+        if var in ['Locations', 'VolumeLocations']:
+            for key in f0.fid[var].keys():
+                #Compare raw data of these variables
+                val0 = f0.fid[var][key]
+                val1 = f1.fid[var][key]
+
+                #Sort val1 by otherBlockIdx
+                val1 = val1[otherBlockIdx]
+
+                # Compute norm error, check against tolerance
+                errVal = np.abs(val0 - val1)
+                errMag = np.linalg.norm(errVal)
+                if(errMag > tol):
+                    no_meta_variables_diff = False
+                    if not quiet: print("")
+                    print(f'Metavariable {var}/{key} differs between {f0.file} and {f1.file}')
+                    if not quiet: print("")
+                else:
+                    print('  %18s/%s: no diffs'%(var,key))
+        if var in ['LogicalLocations', 'Levels']:
+            #Compare raw data of these variables
+            val0 = np.array(f0.fid[var])
+            val1 = np.array(f1.fid[var])
+
+            #Sort val1 by otherBlockIdx
+            val1 = val1[otherBlockIdx]
+
+            #As integers, they should be identical
+            if np.any(val0 != val1):
+                no_meta_variables_diff = False
+                if not quiet: print("")
+                print(f'Metavariable {var} differs between {f0.file} and {f1.file}')
+                if not quiet: print("")
+            else:
+                print('  %20s: no diffs'%var)
+
+    if not no_meta_variables_diff:
+        return(ERROR_META_VARS_DIFF)
+    return(0)
+
+def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12, check_metadata=True):
+    """ compares two hdf files. Returns 0 if the files are equivalent.
+
+        Error codes:
+            1  : Can't open file 0
+            2  : Can't open file 1
+            3  : Total number of cells differ
+            4  : Variable data in files differ
+
+        Metadata Error codes:
+            10 : Times in hdf files differ
+            11 : Attribute names in Info of hdf files differ
+            12 : Values of attributes in Info of hdf files differ
+            13 : Attribute names in Params of hdf files differ
+            14 : Values of attributes in Params of hdf files differ
+            15 : Meta variables (Locations, VolumeLocations, LogicalLocations, Levels) differ
+    """
+
+    ERROR_NO_OPEN_F0 = 1
+    ERROR_NO_OPEN_F1 = 2
+    ERROR_CELLS_DIFFER = 3
+    ERROR_DATA_DIFFER = 4
 
     #**************
     # import Reader
@@ -80,6 +236,7 @@ def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
 
 
     # Load first file and print info
+    f0 = phdf(files[0])
     try:
         f0 = phdf(files[0])
         if not quiet: print(f0)
@@ -87,7 +244,7 @@ def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
         print("""
         *** ERROR: Unable to open %s as phdf file
         """%files[0])
-        return(1)
+        return(ERROR_NO_OPEN_F0)
 
     # Load second file and print info
     try:
@@ -97,7 +254,7 @@ def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
         print("""
         *** ERROR: Unable to open %s as phdf file
         """%files[1])
-        return(2)
+        return(ERROR_NO_OPEN_F1)
 
     # rudimentary checks
     if f0.TotalCellsReal != f1.TotalCellsReal:
@@ -108,7 +265,15 @@ def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
 
         Quitting...
         """)
-        return(3)
+        return(ERROR_CELLS_DIFFER)
+
+    if check_metadata:
+        if not quiet: print("Checking metadata")
+        metadata_status = compare_metadata(f0,f1)
+        if( metadata_status != 0):
+            return metadata_status
+    else:
+        if not quiet: print("Ignoring metadata")
 
     # Now go through all variables in first file
     # and hunt for them in second file.
@@ -136,9 +301,10 @@ def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
         otherLocations[idx] = f0.findIndexInOther(f1,idx)
     if not quiet: print(f0.TotalCells,'cells mapped')
 
-    for var in f0.Variables:
-        if var == 'Locations' or var == 'Info':
+    for var in set(f0.Variables+f1.Variables):
+        if var in ['Locations', 'VolumeLocations', 'LogicalLocations', 'Levels', 'Info', 'Params']:
             continue
+
         #initialize info values
         same = True
         errMax = -1.0
@@ -203,11 +369,11 @@ def compare(files, all=False, brief=True, quiet=False, one=False, tol=1.0e-12):
 
         if one and not same:
             break
-
+    
     if no_diffs:
       return(0)
     else:
-      return(4)
+      return(ERROR_DATA_DIFFER)
 
 if __name__ == "__main__":
     addPath()
@@ -218,6 +384,9 @@ if __name__ == "__main__":
     brief=input.b
     quiet=input.q
     one = input.o
+    ignore_metadata = input.i
+
+    check_metadata = not ignore_metadata
 
     # set all only if brief not set
     if brief or quiet:
@@ -236,5 +405,5 @@ if __name__ == "__main__":
         Usage()
         sys.exit(1)
 
-    ret = compare(files, all, brief, quiet, one, tol)
+    ret = compare(files, all, brief, quiet, one, tol, check_metadata)
     sys.exit(ret)

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -181,6 +181,13 @@ class Metadata {
     SetMultiple(bits);
   }
 
+  /// returns a metadata with bits and shape set
+  explicit Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
+                    const std::vector<std::string> component_labels)
+      : shape_(shape), sparse_id_(-1), component_labels_(component_labels) {
+    SetMultiple(bits);
+  }
+
   /// returns a metadata with bits and sparse id set
   explicit Metadata(const std::vector<MetadataFlag> &bits, const int sparse_id)
       : shape_({1}), sparse_id_(sparse_id) {
@@ -346,12 +353,18 @@ class Metadata {
   void Associate(const std::string &name) { associated_ = name; }
   const std::string &getAssociated() const { return associated_; }
 
+  const std::vector<std::string> getComponentLabels() const noexcept {
+    return component_labels_;
+  }
+
  private:
   /// the attribute flags that are set for the class
   std::vector<bool> bits_;
   std::vector<int> shape_;
   std::string associated_;
   int sparse_id_;
+
+  std::vector<std::string> component_labels_;
 
   /*--------------------------------------------------------*/
   // Setters for the different attributes of metadata

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <typeindex>
 #include <typeinfo>
+#include <utility>
 #include <vector>
 
 #include "utils/error_checking.hpp"
@@ -41,7 +42,7 @@ class Params {
   void Add(const std::string &key, T value) {
     PARTHENON_REQUIRE_THROWS(!(hasKey(key)), "Key " + key + " already exists");
     myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
-    myTypes_[key] = std::string(typeid(value).name());
+    myTypes_.emplace(make_pair(key, std::type_index(typeid(value))));
   }
 
   /// Updates existing object
@@ -49,7 +50,7 @@ class Params {
   template <typename T>
   void Update(const std::string &key, T value) {
     PARTHENON_REQUIRE_THROWS((hasKey(key)), "Key " + key + "missing.");
-    PARTHENON_REQUIRE_THROWS(!(myTypes_.at(key).compare(std::string(typeid(T).name()))),
+    PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
                              "WRONG TYPE FOR KEY '" + key + "'");
     myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
   }
@@ -63,7 +64,7 @@ class Params {
   const T &Get(const std::string &key) const {
     auto const it = myParams_.find(key);
     PARTHENON_REQUIRE_THROWS(it != myParams_.end(), "Key " + key + " doesn't exist");
-    PARTHENON_REQUIRE_THROWS(!(myTypes_.at(key).compare(std::string(typeid(T).name()))),
+    PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
                              "WRONG TYPE FOR KEY '" + key + "'");
     auto typed_ptr = dynamic_cast<Params::object_t<T> *>((it->second).get());
     return *typed_ptr->pValue;
@@ -83,12 +84,26 @@ class Params {
     return Get<T>(key);
   }
 
+  const std::type_index &GetType(const std::string &key) const {
+    auto const it = myTypes_.find(key);
+    PARTHENON_REQUIRE_THROWS(it != myTypes_.end(), "Key " + key + " doesn't exist");
+    return it->second;
+  }
+
+  std::vector<std::string> GetKeys() const {
+    std::vector<std::string> keys;
+    for (auto &x : myParams_) {
+      keys.push_back(x.first);
+    }
+    return keys;
+  }
+
   // void Params::
   void list() {
     std::cout << std::endl << "Items are:" << std::endl;
     for (auto &x : myParams_) {
       std::cout << "   " << x.first << ":" << x.second.get() << ":" << x.second->address()
-                << ":" << myTypes_[x.first] << std::endl;
+                << ":" << myTypes_.at(x.first).name() << std::endl;
     }
     std::cout << std::endl;
   }
@@ -109,7 +124,7 @@ class Params {
   };
 
   std::map<std::string, std::unique_ptr<Params::base_t>> myParams_;
-  std::map<std::string, std::string> myTypes_;
+  std::map<std::string, std::type_index> myTypes_;
 };
 
 } // namespace parthenon

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -66,11 +66,16 @@ class StateDescriptor {
   // Set (if not set) and get simultaneously.
   // infers type correctly.
   template <typename T>
-  const T &Param(const std::string &key, T value) {
-    params_.Get(key, value);
+  const T &Param(const std::string &key, T value) const {
+    return params_.Get(key, value);
+  }
+
+  const std::type_index &ParamType(const std::string &key) const {
+    return params_.GetType(key);
   }
 
   Params &AllParams() { return params_; }
+
   // retrieve label
   const std::string &label() const { return label_; }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -167,6 +167,7 @@ class Mesh {
   int GetMaxLevel() const noexcept { return max_level; }
   int GetCurrentLevel() const noexcept { return current_level; }
   std::vector<int> GetNbList() const noexcept { return nblist; }
+  std::vector<LogicalLocation> GetLocList() const noexcept { return loclist; }
 
   void OutputMeshStructure(const int dim, const bool dump_mesh_structure = true);
 

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -46,6 +46,7 @@ struct OutputParameters {
   std::string file_id;
   std::string variable;
   std::vector<std::string> variables;
+  std::vector<std::string> component_labels;
   std::string file_type;
   std::string data_format;
   Real next_time, dt;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -17,6 +17,8 @@
 
 // Only proceed if HDF5 output enabled
 
+#include <memory>
+
 #include "outputs/parthenon_hdf5.hpp"
 
 #include "mesh/meshblock.hpp"
@@ -214,6 +216,9 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
 
   auto nblist = pm->GetNbList();
 
+  auto ciX = MeshBlockDataIterator<Real>(pm->block_list.front()->meshblock_data.Get(),
+                                         output_params.variables);
+
   // set output size
   nx1 = out_ib.e - out_ib.s + 1; // SS first_block.block_size.nx1;
   nx2 = out_jb.e - out_jb.s + 1; // SS first_block.block_size.nx2;
@@ -274,45 +279,140 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
         H5Fcreate(filename.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, acc_file));
 
     // write timestep relevant attributes
-    {
+    { // START /Info
       // attributes written here:
       // All ranks write attributes
       H5S const localDSpace = H5S::FromHIDCheck(H5Screate(H5S_SCALAR));
-      H5D const myDSet = H5D::FromHIDCheck(H5Dcreate(
+      H5D const infoDSet = H5D::FromHIDCheck(H5Dcreate(
           file, "/Info", PREDINT32, localDSpace, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
 
       int max_level = pm->GetCurrentLevel() - pm->GetRootLevel();
       if (tm != nullptr) {
-        writeH5AI32("NCycle", &(tm->ncycle), localDSpace, myDSet);
-        writeH5AF64("Time", &(tm->time), localDSpace, myDSet);
+        writeH5AI32("NCycle", &(tm->ncycle), localDSpace, infoDSet);
+        writeH5AF64("Time", &(tm->time), localDSpace, infoDSet);
       }
-      writeH5AI32("NumDims", &pm->ndim, localDSpace, myDSet);
-      writeH5AI32("NumMeshBlocks", &pm->nbtotal, localDSpace, myDSet);
-      writeH5AI32("MaxLevel", &max_level, localDSpace, myDSet);
+      writeH5AI32("NumDims", &pm->ndim, localDSpace, infoDSet);
+      writeH5AI32("NumMeshBlocks", &pm->nbtotal, localDSpace, infoDSet);
+      writeH5AI32("MaxLevel", &max_level, localDSpace, infoDSet);
       // write whether we include ghost cells or not
       int iTmp = (output_params.include_ghost_zones ? 1 : 0);
-      writeH5AI32("IncludesGhost", &iTmp, localDSpace, myDSet);
+      writeH5AI32("IncludesGhost", &iTmp, localDSpace, infoDSet);
       // write number of ghost cells in simulation
       iTmp = Globals::nghost;
-      writeH5AI32("NGhost", &iTmp, localDSpace, myDSet);
+      writeH5AI32("NGhost", &iTmp, localDSpace, infoDSet);
       writeH5ASTRING("Coordinates", std::string(first_block.coords.Name()), localDSpace,
-                     myDSet);
+                     infoDSet);
 
       hsize_t nPE = Globals::nranks;
       writeH5AI32("BlocksPerPE", nblist.data(),
-                  H5S::FromHIDCheck(H5Screate_simple(1, &nPE, NULL)), myDSet);
+                  H5S::FromHIDCheck(H5Screate_simple(1, &nPE, NULL)), infoDSet);
 
       // open vector space
       // write mesh block size
-      int meshblock_size[3] = {nx1, nx2, nx3};
       const hsize_t xDims[1] = {3};
+      int meshblock_size[xDims[0]] = {nx1, nx2, nx3};
       writeH5AI32("MeshBlockSize", meshblock_size,
-                  H5S::FromHIDCheck(H5Screate_simple(1, xDims, NULL)), myDSet);
-    }
+                  H5S::FromHIDCheck(H5Screate_simple(1, xDims, NULL)), infoDSet);
+
+      // RootGridDomain - float[9] array with xyz mins, maxs, rats (dx(i)/dx(i-1))
+      const hsize_t rootGridDomain_size[1] = {9};
+      Real rootGridDomain[rootGridDomain_size[0]] = {
+          pm->mesh_size.x1min, pm->mesh_size.x1max, pm->mesh_size.x1rat,
+          pm->mesh_size.x2min, pm->mesh_size.x2max, pm->mesh_size.x2rat,
+          pm->mesh_size.x3min, pm->mesh_size.x3max, pm->mesh_size.x3rat};
+      writeH5AF64("RootGridDomain", rootGridDomain,
+                  H5S::FromHIDCheck(H5Screate_simple(1, rootGridDomain_size, NULL)),
+                  infoDSet);
+
+      // RootGridSize - int[3] number of cells on the root grid
+      const hsize_t rootGridSize_size[1] = {3};
+      int rootGridSize[rootGridSize_size[0]] = {pm->mesh_size.nx1, pm->mesh_size.nx2,
+                                                pm->mesh_size.nx3};
+      writeH5AI32("RootGridSize", rootGridSize,
+                  H5S::FromHIDCheck(H5Screate_simple(1, rootGridSize_size, NULL)),
+                  infoDSet);
+
+      // BoundaryConditions
+      const hsize_t boundaryConditions_size[1] = {BOUNDARY_NFACES};
+      std::vector<std::string> boundaryConditions;
+      boundaryConditions.reserve(boundaryConditions_size[0]);
+      for (int i = 0; i < BOUNDARY_NFACES; i++) {
+        boundaryConditions.push_back(GetBoundaryString(pm->mesh_bcs[i]));
+      }
+      writeH5ASTRINGS(
+          "BoundaryConditions", boundaryConditions,
+          H5S::FromHIDCheck(H5Screate_simple(1, boundaryConditions_size, NULL)),
+          infoDSet);
+
+      // DatasetNames - which datasets from the top level to read
+      const hsize_t datasetNames_size[1] = {output_params.variables.size()};
+      writeH5ASTRINGS("DatasetNames", output_params.variables,
+                      H5S::FromHIDCheck(H5Screate_simple(1, datasetNames_size, NULL)),
+                      infoDSet);
+
+      // NumVariables - number of variables within each dataset
+      std::vector<int> numVariables(output_params.variables.size());
+      // VariablesNames - Names of variables within each dataset
+      std::vector<std::string> variableNames;
+
+      for (int i = 0; i < ciX.vars.size(); i++) { // for every block
+        const std::vector<std::string> component_labels =
+            ciX.vars[i]->metadata().getComponentLabels();
+
+        if (component_labels.size() > 0) {
+          numVariables[i] = component_labels.size();
+          for (const auto &label : component_labels) {
+            variableNames.push_back(label);
+          }
+        } else {
+          numVariables[i] = 1;
+          variableNames.push_back(ciX.vars[i]->label());
+        }
+      }
+
+      writeH5AI32("NumVariables", numVariables.data(),
+                  H5S::FromHIDCheck(H5Screate_simple(1, datasetNames_size, NULL)),
+                  infoDSet);
+
+      const hsize_t variableNames_size[1] = {variableNames.size()};
+      writeH5ASTRINGS("VariableNames", variableNames,
+                      H5S::FromHIDCheck(H5Screate_simple(1, variableNames_size, NULL)),
+                      infoDSet);
+    } // END /Info
+
+    { // START /Params
+      // Params written here:
+      // All ranks write attributes
+      H5S const localDSpace = H5S::FromHIDCheck(H5Screate(H5S_SCALAR));
+      H5D const infoDSet =
+          H5D::FromHIDCheck(H5Dcreate(file, "/Params", PREDINT32, localDSpace,
+                                      H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
+
+      for (const auto &package : pm->packages.AllPackages()) {
+        std::shared_ptr<StateDescriptor> state = package.second;
+        // Write AllParams that can be written as HDF5 attributes
+        std::vector<std::string> paramKeys = state->AllParams().GetKeys();
+        for (const auto &paramKey : paramKeys) {
+          const std::type_index type = state->ParamType(paramKey);
+
+          std::stringstream ss;
+          ss << state->label() << "/" << paramKey;
+
+          if (type == typeid(int)) {
+            const int &param = state->Param<int>(paramKey);
+            writeH5AI32(ss.str().c_str(), &param, localDSpace, infoDSet);
+          } else if (type == typeid(double)) {
+            const double &param = state->Param<double>(paramKey);
+            writeH5AF64(ss.str().c_str(), &param, localDSpace, infoDSet);
+          } else if (type == typeid(std::string)) {
+            const std::string &param = state->Param<std::string>(paramKey);
+            writeH5ASTRING(ss.str().c_str(), param, localDSpace, infoDSet);
+          }
+        }
+      }
+    } // END /Params
 
     // allocate space for largest size variable
-    auto ciX = MeshBlockDataIterator<Real>(pm->block_list.front()->meshblock_data.Get(),
-                                           output_params.variables);
     size_t maxV = 1;
     hsize_t sumDim4AllVars = 0;
     for (auto &v : ciX.vars) {
@@ -372,14 +472,88 @@ void PHDF5Output::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       WRITEH5SLAB("z", tmpData.data(), gLocations, local_start, local_count, global_count,
                   property_list);
     }
+    {
+      // open locations tab
+      H5G const gVLocations = H5G::FromHIDCheck(
+          H5Gcreate(file, "/VolumeLocations", H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT));
+
+      // write X coordinates
+      local_count[0] = num_blocks_local;
+      global_count[0] = max_blocks_global;
+
+      // These macros are defined in parthenon_hdf5.hpp, which establishes relevant scope
+      LOADVARIABLEALL(tmpData, pm, pmb->coords.x1v, out_ib.s, out_ib.e, 0, 0, 0, 0);
+      local_count[1] = global_count[1] = nx1;
+      WRITEH5SLAB("x", tmpData.data(), gVLocations, local_start, local_count,
+                  global_count, property_list);
+
+      // write Y coordinates
+      LOADVARIABLEALL(tmpData, pm, pmb->coords.x2v, 0, 0, out_jb.s, out_jb.e, 0, 0);
+      local_count[1] = global_count[1] = nx2;
+      WRITEH5SLAB("y", tmpData.data(), gVLocations, local_start, local_count,
+                  global_count, property_list);
+
+      // write Z coordinates
+      LOADVARIABLEALL(tmpData, pm, pmb->coords.x3v, 0, 0, 0, 0, out_kb.s, out_kb.e);
+
+      local_count[1] = global_count[1] = nx3;
+      WRITEH5SLAB("z", tmpData.data(), gVLocations, local_start, local_count,
+                  global_count, property_list);
+    }
+
+    {
+      // Write Levels and Logical Locations with the level for each Meshblock
+      // loclist contains levels and logical locations for all meshblocks on
+      // all ranks
+      const auto &loclist = pm->GetLocList();
+
+      std::vector<std::int64_t> levels;
+      levels.reserve(pm->nbtotal);
+
+      std::vector<std::int64_t> logicalLocations;
+      logicalLocations.reserve(pm->nbtotal * 3);
+
+      for (const auto &loc : loclist) { // for every block
+        levels.push_back(loc.level - pm->GetRootLevel());
+        logicalLocations.push_back(loc.lx1);
+        logicalLocations.push_back(loc.lx2);
+        logicalLocations.push_back(loc.lx3);
+      }
+
+      // Only write levels on rank 0
+      local_count[0] = (Globals::my_rank == 0) ? pm->nbtotal : 0;
+
+      global_count[0] = max_blocks_global;
+
+      H5S const local_levelsSpace =
+          H5S::FromHIDCheck(H5Screate_simple(1, local_count, NULL));
+      H5S const global_levelsSpace =
+          H5S::FromHIDCheck(H5Screate_simple(1, global_count, NULL));
+
+      WRITEH5SLAB_X("Levels", levels.data(), file, local_start, local_count,
+                    local_levelsSpace, global_levelsSpace, property_list,
+                    H5T_NATIVE_INT32);
+
+      // Only write LogicalLocations on rank 0
+      local_count[0] = (Globals::my_rank == 0) ? pm->nbtotal : 0;
+      local_count[1] = 3;
+
+      global_count[0] = max_blocks_global;
+      global_count[1] = 3;
+
+      WRITEH5SLABI64("LogicalLocations", logicalLocations.data(), file, local_start,
+                     local_count, global_count, property_list);
+    }
 
     // write variables
     // create persistent spaces
+    local_count[0] = num_blocks_local;
     local_count[1] = nx3;
     local_count[2] = nx2;
     local_count[3] = nx1;
     local_count[4] = 1;
 
+    global_count[0] = max_blocks_global;
     global_count[1] = nx3;
     global_count[2] = nx2;
     global_count[3] = nx1;

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -20,6 +20,7 @@
 #include <hdf5.h>
 #endif
 
+#include <algorithm>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -256,6 +256,28 @@ static void writeH5ASTRING(const char *name, const std::string &pData,
   PARTHENON_HDF5_CHECK(H5Awrite(attribute, atype, pData.c_str()));
 }
 
+static void writeH5ASTRINGS(const char *name, const std::vector<std::string> &pData,
+                            const hid_t &dSpace, const hid_t &dSet) {
+  int max_name_length = 0;
+  for (const auto &s : pData) {
+    max_name_length = std::max(max_name_length, static_cast<int>(s.length()));
+  }
+
+  std::vector<const char *> c_strs;
+  c_strs.reserve(pData.size());
+  for (int i = 0; i < pData.size(); i++) {
+    // Copy pData[i] into c_strs[i], including a null terminator
+    c_strs.push_back(pData[i].c_str());
+  }
+
+  ::parthenon::H5T const atype = ::parthenon::H5T::FromHIDCheck(H5Tcopy(H5T_C_S1));
+  PARTHENON_HDF5_CHECK(H5Tset_size(atype, H5T_VARIABLE));
+
+  ::parthenon::H5A const attribute = ::parthenon::H5A::FromHIDCheck(
+      H5Acreate(dSet, name, atype, dSpace, H5P_DEFAULT, H5P_DEFAULT));
+  PARTHENON_HDF5_CHECK(H5Awrite(attribute, atype, c_strs.data()));
+}
+
 // Static functions to return HDF type
 static hid_t getHdfType(float *x) { return H5T_NATIVE_FLOAT; }
 static hid_t getHdfType(double *x) { return H5T_NATIVE_DOUBLE; }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Adds some meta data and AMR level information to the HDF5 outputs so that the python analysis library `yt` can read it. Development of the companion `yt` frontend is at https://github.com/forrestglines/yt/tree/athenapk-frontend

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] (@lanl.gov employees) Update copyright on changed files
