### PR TITLE
Add default tiling matching  index range to MDRange loop pattern.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.
 
 ### Infrastructure (changes irrelevant to downstream codes)
 

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -179,12 +179,12 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
              const Function &function, Args &&... args) {
   using namespace dispatch_impl;
   typename DispatchType<Args...>::type tag;
-  kokkos_dispatch(
-      tag, name,
-      Kokkos::Experimental::require(
-          Kokkos::MDRangePolicy<Kokkos::Rank<2>>(exec_space, {jl, il}, {ju + 1, iu + 1}, {1, iu + 1 - il}),
-          Kokkos::Experimental::WorkItemProperty::HintLightWeight),
-      function, std::forward<Args>(args)...);
+  kokkos_dispatch(tag, name,
+                  Kokkos::Experimental::require(
+                      Kokkos::MDRangePolicy<Kokkos::Rank<2>>(
+                          exec_space, {jl, il}, {ju + 1, iu + 1}, {1, iu + 1 - il}),
+                      Kokkos::Experimental::WorkItemProperty::HintLightWeight),
+                  function, std::forward<Args>(args)...);
 }
 
 // 3D loop using Kokkos 1D Range
@@ -225,7 +225,8 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
   kokkos_dispatch(tag, name,
                   Kokkos::Experimental::require(
                       Kokkos::MDRangePolicy<Kokkos::Rank<3>>(exec_space, {kl, jl, il},
-                                                             {ku + 1, ju + 1, iu + 1}, {1,1,iu + 1 - il}),
+                                                             {ku + 1, ju + 1, iu + 1},
+                                                             {1, 1, iu + 1 - il}),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   function, std::forward<Args>(args)...);
 }
@@ -347,7 +348,8 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
   kokkos_dispatch(tag, name,
                   Kokkos::Experimental::require(
                       Kokkos::MDRangePolicy<Kokkos::Rank<4>>(
-                          exec_space, {nl, kl, jl, il}, {nu + 1, ku + 1, ju + 1, iu + 1}, {1,1,1,iu+1-il}),
+                          exec_space, {nl, kl, jl, il}, {nu + 1, ku + 1, ju + 1, iu + 1},
+                          {1, 1, 1, iu + 1 - il}),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   function, std::forward<Args>(args)...);
 }
@@ -451,8 +453,9 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
   kokkos_dispatch(
       tag, name,
       Kokkos::Experimental::require(
-          Kokkos::MDRangePolicy<Kokkos::Rank<5>>(
-              exec_space, {ml, nl, kl, jl, il}, {mu + 1, nu + 1, ku + 1, ju + 1, iu + 1}, {1,1,1,1,iu + 1 - il}),
+          Kokkos::MDRangePolicy<Kokkos::Rank<5>>(exec_space, {ml, nl, kl, jl, il},
+                                                 {mu + 1, nu + 1, ku + 1, ju + 1, iu + 1},
+                                                 {1, 1, 1, 1, iu + 1 - il}),
           Kokkos::Experimental::WorkItemProperty::HintLightWeight),
       function, std::forward<Args>(args)...);
 }

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -182,7 +182,7 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
   kokkos_dispatch(
       tag, name,
       Kokkos::Experimental::require(
-          Kokkos::MDRangePolicy<Kokkos::Rank<2>>(exec_space, {jl, il}, {ju + 1, iu + 1}),
+          Kokkos::MDRangePolicy<Kokkos::Rank<2>>(exec_space, {jl, il}, {ju + 1, iu + 1}, {1, iu + 1 - il}),
           Kokkos::Experimental::WorkItemProperty::HintLightWeight),
       function, std::forward<Args>(args)...);
 }
@@ -225,7 +225,7 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
   kokkos_dispatch(tag, name,
                   Kokkos::Experimental::require(
                       Kokkos::MDRangePolicy<Kokkos::Rank<3>>(exec_space, {kl, jl, il},
-                                                             {ku + 1, ju + 1, iu + 1}),
+                                                             {ku + 1, ju + 1, iu + 1}, {1,1,iu + 1 - il}),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   function, std::forward<Args>(args)...);
 }
@@ -347,7 +347,7 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
   kokkos_dispatch(tag, name,
                   Kokkos::Experimental::require(
                       Kokkos::MDRangePolicy<Kokkos::Rank<4>>(
-                          exec_space, {nl, kl, jl, il}, {nu + 1, ku + 1, ju + 1, iu + 1}),
+                          exec_space, {nl, kl, jl, il}, {nu + 1, ku + 1, ju + 1, iu + 1}, {1,1,1,iu+1-il}),
                       Kokkos::Experimental::WorkItemProperty::HintLightWeight),
                   function, std::forward<Args>(args)...);
 }
@@ -452,7 +452,7 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
       tag, name,
       Kokkos::Experimental::require(
           Kokkos::MDRangePolicy<Kokkos::Rank<5>>(
-              exec_space, {ml, nl, kl, jl, il}, {mu + 1, nu + 1, ku + 1, ju + 1, iu + 1}),
+              exec_space, {ml, nl, kl, jl, il}, {mu + 1, nu + 1, ku + 1, ju + 1, iu + 1}, {1,1,1,1,iu + 1 - il}),
           Kokkos::Experimental::WorkItemProperty::HintLightWeight),
       function, std::forward<Args>(args)...);
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Addresses performance issue observed by @jdolence when using `par_reduce`.
The latter uses an `MDRangePolicy`, which, by default, does not come with tiling information.
That results in poor performance on devices as observed before, see, e.g.,  https://gitlab.com/pgrete/kathena/-/merge_requests/58
The current default may not be perfect for all situations and `MeshBlock` sizes but it's for sure a much better default choice than "no tiling".
Partially addresses #466 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] (@lanl.gov employees) Update copyright on changed files
