### PR TITLE
Hotfix: Adjust block size in OverlappingSpace instance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 490]](https://github.com/lanl/parthenon/pull/490) Adjust block size in OverlappingSpace instance tests to remain within Cuda/HIP limits
 - [[PR 488]](https://github.com/lanl/parthenon/pull/488) Update GitLab Dockerfile to use HDF5 version 1.10.7
 
 ### Removed (removing behavior/API/varaibles/...)

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -631,7 +631,7 @@ template <class BufferPack>
 void test_wrapper_buffer_pack_overlapping_space_instances(const std::string &test_name) {
   auto default_exec_space = DevExecSpace();
 
-  const int N = 32;      // ~meshblock size
+  const int N = 24;      // ~meshblock size
   const int M = 5;       // ~nhydro
   const int nspaces = 8; // number of streams
   const int nghost = 2;  // number of ghost zones


### PR DESCRIPTION


<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The unit test resulted in using an MDRange tiling with more than 1024 threads per block, which violate CUDA and HIP limits, see https://github.com/kokkos/kokkos/blob/1fb0c284d458c75370094921d9f202c287502325/core/src/KokkosExp_MDRangePolicy.hpp#L427

The slightly smaller block size ensure that we stay below the limit (on all available hardware).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] (@lanl.gov employees) Update copyright on changed files
