### PR TITLE
Jmm/one buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 493]](https://github.com/lanl/parthenon/pull/493) Use subviews of a single view for comm buffers
 - [[PR 490]](https://github.com/lanl/parthenon/pull/490) Adjust block size in OverlappingSpace instance tests to remain within Cuda/HIP limits
 - [[PR 488]](https://github.com/lanl/parthenon/pull/488) Update GitLab Dockerfile to use HDF5 version 1.10.7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 494]](https://github.com/lanl/parthenon/pull/494) Use subviews of a single view for fluxes and coarse cells
 - [[PR 493]](https://github.com/lanl/parthenon/pull/493) Use subviews of a single view for comm buffers
 - [[PR 490]](https://github.com/lanl/parthenon/pull/490) Adjust block size in OverlappingSpace instance tests to remain within Cuda/HIP limits
 - [[PR 488]](https://github.com/lanl/parthenon/pull/488) Update GitLab Dockerfile to use HDF5 version 1.10.7

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -164,6 +164,7 @@ struct BoundaryData { // aggregate and POD (even when MPI_PARALLEL is defined)
   // currently, sflag[] is only used by Multgrid (send buffers are reused each stage in
   // red-black comm. pattern; need to check if they are available)
   BoundaryStatus flag[kMaxNeighbor], sflag[kMaxNeighbor];
+  BufArray1D<Real> buffers;
   BufArray1D<Real> send[kMaxNeighbor], recv[kMaxNeighbor];
 #ifdef MPI_PARALLEL
   MPI_Request req_send[kMaxNeighbor], req_recv[kMaxNeighbor];

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 202-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/bvals/bvals_var.cpp
+++ b/src/bvals/bvals_var.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/bvals/bvals_var.cpp
+++ b/src/bvals/bvals_var.cpp
@@ -18,7 +18,6 @@
 //  \brief constructor/destructor and default implementations for some functions in the
 //         abstract BoundaryVariable class
 
-#include "Kokkos_View.hpp"
 #include "bvals/bvals_interfaces.hpp"
 
 #include <cstring>
@@ -63,7 +62,7 @@ void BoundaryVariable::InitBoundaryData(BoundaryData<> &bd, BoundaryQuantity typ
   }
   auto total_size = 0;
   std::vector<size_t> offsets;
-  offsets.reserve(bd.nbmax+1);
+  offsets.reserve(bd.nbmax + 1);
 
   for (int n = 0; n < bd.nbmax; n++) {
     // Clear flags and requests

--- a/src/bvals/bvals_var.cpp
+++ b/src/bvals/bvals_var.cpp
@@ -18,6 +18,7 @@
 //  \brief constructor/destructor and default implementations for some functions in the
 //         abstract BoundaryVariable class
 
+#include "Kokkos_View.hpp"
 #include "bvals/bvals_interfaces.hpp"
 
 #include <cstring>
@@ -60,6 +61,10 @@ void BoundaryVariable::InitBoundaryData(BoundaryData<> &bd, BoundaryQuantity typ
     for (; pmb->pbval->ni[bd.nbmax].type == NeighborConnect::edge; bd.nbmax++) {
     }
   }
+  auto total_size = 0;
+  std::vector<size_t> offsets;
+  offsets.reserve(bd.nbmax+1);
+
   for (int n = 0; n < bd.nbmax; n++) {
     // Clear flags and requests
     bd.flag[n] = BoundaryStatus::waiting;
@@ -79,8 +84,20 @@ void BoundaryVariable::InitBoundaryData(BoundaryData<> &bd, BoundaryQuantity typ
           << "Invalid boundary type is specified." << std::endl;
       PARTHENON_FAIL(msg);
     }
-    bd.send[n] = BufArray1D<Real>("send buf " + std::to_string(n), size);
-    bd.recv[n] = BufArray1D<Real>("recv buf " + std::to_string(n), size);
+    offsets.push_back(total_size);
+    total_size += size;
+  }
+  bd.buffers = BufArray1D<Real>("comm buffers", 2 * total_size);
+  offsets.push_back(total_size);
+  for (int n = 0; n < bd.nbmax; n++) {
+    if (offsets.at(n) == offsets.at(n + 1)) {
+      continue;
+    }
+    bd.send[n] =
+        BufArray1D<Real>(bd.buffers, std::make_pair(offsets.at(n), offsets.at(n + 1)));
+    bd.recv[n] =
+        BufArray1D<Real>(bd.buffers, std::make_pair(offsets.at(n) + total_size,
+                                                    offsets.at(n + 1) + total_size));
   }
 }
 

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -14,6 +14,7 @@
 #include "interface/variable.hpp"
 
 #include <iostream>
+#include <utility>
 
 #include "bvals/cc/bvals_cc.hpp"
 #include "mesh/mesh.hpp"
@@ -69,12 +70,12 @@ CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wp
       // Note that vbvar->var_cc will be set when stage is selected
       cv->vbvar = vbvar;
 
-      // fluxes, etc are always a copy
+      // fluxes, coarse buffers, etc., are always a copy
+      // Rely on reference counting and shallow copy of kokkos views
+      cv->comm_data_ = comm_data_; // views are reference counted
       for (int i = 1; i <= 3; i++) {
         cv->flux[i] = flux[i];
       }
-
-      // These members are pointers,      // point at same memory as src
       cv->coarse_s = coarse_s;
     }
   }
@@ -85,28 +86,42 @@ CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wp
 /// Initialize a 6D variable
 template <typename T>
 void CellVariable<T>::allocateComms(std::weak_ptr<MeshBlock> wpmb) {
-  // set up fluxes
+  if (wpmb.expired()) return;
+  std::shared_ptr<MeshBlock> pmb = wpmb.lock();
   std::string base_name = label();
+
+  // TODO(JMM): Note that this approach assumes LayoutRight. Otherwise
+  // the stride will mess up the types.
+
+  // Compute size of unified comm_data object and create it. A unified
+  // comm_data_ object reduces the number of memory allocations per
+  // variable per meshblock from 5 to 2.
+  int n_outer = 0;
   if (IsSet(Metadata::Independent)) {
-    flux[X1DIR] = ParArrayND<T>(base_name + ".fluxX1", GetDim(6), GetDim(5), GetDim(4),
-                                GetDim(3), GetDim(2), GetDim(1));
-    if (GetDim(2) > 1)
-      flux[X2DIR] = ParArrayND<T>(base_name + ".fluxX2", GetDim(6), GetDim(5), GetDim(4),
-                                  GetDim(3), GetDim(2), GetDim(1));
-    if (GetDim(3) > 1)
-      flux[X3DIR] = ParArrayND<T>(base_name + ".fluxX3", GetDim(6), GetDim(5), GetDim(4),
-                                  GetDim(3), GetDim(2), GetDim(1));
+    n_outer += (GetDim(1) > 1) + (GetDim(2) > 1) + (GetDim(3) > 1);
+  }
+  n_outer += (pmb->pmy_mesh->multilevel);
+  comm_data_ = ParArray7D<T>(base_name + ".comm_data", n_outer, GetDim(6), GetDim(5),
+                             GetDim(4), GetDim(3), GetDim(2), GetDim(1));
+
+  // set up fluxes
+  int offset = 0;
+  if (IsSet(Metadata::Independent)) {
+    for (int d = X1DIR; d <= X3DIR; ++d) {
+      if (GetDim(d) > 1) {
+        flux[d] = ParArrayND<T>(
+            Kokkos::subview(comm_data_, offset++, Kokkos::ALL(), Kokkos::ALL(),
+                            Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL()));
+      }
+    }
   }
 
-  if (wpmb.expired()) return;
-
-  std::shared_ptr<MeshBlock> pmb = wpmb.lock();
-
-  if (pmb->pmy_mesh->multilevel)
-    coarse_s = ParArrayND<T>(base_name + ".coarse", GetDim(6), GetDim(5), GetDim(4),
-                             pmb->c_cellbounds.ncellsk(IndexDomain::entire),
-                             pmb->c_cellbounds.ncellsj(IndexDomain::entire),
-                             pmb->c_cellbounds.ncellsi(IndexDomain::entire));
+  if (pmb->pmy_mesh->multilevel) {
+    // This wastes about 1/2 a meshblock in memory
+    coarse_s = ParArrayND<T>(Kokkos::subview(comm_data_, offset++, Kokkos::ALL(),
+                                             Kokkos::ALL(), Kokkos::ALL(), Kokkos::ALL(),
+                                             Kokkos::ALL(), Kokkos::ALL()));
+  }
 
   // Create the boundary object
   vbvar = std::make_shared<CellCenteredBoundaryVariable>(pmb, data, coarse_s, flux);

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -99,6 +99,7 @@ class CellVariable {
  private:
   Metadata m_;
   std::string label_;
+  ParArray7D<T> comm_data_; // unified par array for the fluxes and coarse buffer
 };
 
 ///

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -67,6 +67,8 @@ template <typename T>
 using ParArray5D = Kokkos::View<T *****, LayoutWrapper, DevMemSpace>;
 template <typename T>
 using ParArray6D = Kokkos::View<T ******, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray7D = Kokkos::View<T *******, LayoutWrapper, DevMemSpace>;
 
 using team_policy = Kokkos::TeamPolicy<>;
 using team_mbr_t = Kokkos::TeamPolicy<>::member_type;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Built on the discussions in the hackathon and on @pgrete 's unification of communication buffers in #493 . This combines the flux and coarse cell buffers into a single kokkos view. A couple of things to note:
- This reduces the number of allocations per variable per meshblock by 3.
- This relies on `LayoutRight` in our kokkos views.
- This is wasteful of some memory because the coarse buffer is now the same size as the dense buffer.
- This is built on #493 and should go in after it.

I haven't done any profiling yet.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] (@lanl.gov employees) Update copyright on changed files
