### PR TITLE
Add elapsed wall time to output files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Current develop
 
+### Added (Timing information availaibility outside of Driver class)
+- [[PR 509]](https://github.com/lanl/parthenon/pull/509) Add `elapsed_main`, `elapsed_cycle`, and `elapsed_LBandAMR` functions to `Driver` as static functions to enable access to timing information in Visualization and Restart files.
+
 ### Added (new features/APIs/variables/...)
 - [[PR 479]](https://github.com/lanl/parthenon/pull/479) Add `Update` function to `Params` to update the value of an existing key.
 - [[PR 482]](https://github.com/lanl/parthenon/pull/482) Add support for package enrolled history outputs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,8 @@
 
 ## Current develop
 
-### Added (Timing information availaibility outside of Driver class)
-- [[PR 509]](https://github.com/lanl/parthenon/pull/509) Add `elapsed_main`, `elapsed_cycle`, and `elapsed_LBandAMR` functions to `Driver` as static functions to enable access to timing information in Visualization and Restart files.
-
 ### Added (new features/APIs/variables/...)
+- [[PR 509]](https://github.com/lanl/parthenon/pull/509) Add `elapsed_main`, `elapsed_cycle`, and `elapsed_LBandAMR` functions to `Driver` as static functions to enable access to timing information in output and restart files.
 - [[PR 479]](https://github.com/lanl/parthenon/pull/479) Add `Update` function to `Params` to update the value of an existing key.
 - [[PR 482]](https://github.com/lanl/parthenon/pull/482) Add support for package enrolled history outputs.
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -152,8 +152,8 @@ def compare_metadata(f0, f1, quiet=False, one=False, tol=1.0e-12):
         if one: return ret_code
 
     #Compare the names of attributes in /Info, except "Time"
-    f0_Info = { key:value for key,value in f0.Info.items() if key != "Time" and key != "BlocksPerPE" }
-    f1_Info = { key:value for key,value in f1.Info.items() if key != "Time" and key != "BlocksPerPE" }
+    f0_Info = { key:value for key,value in f0.Info.items() if key != "Time" and key != "BlocksPerPE" and key != "WallTime" }
+    f1_Info = { key:value for key,value in f1.Info.items() if key != "Time" and key != "BlocksPerPE" and key != "WallTime" }
     if sorted(f0_Info.keys()) != sorted(f1_Info.keys()):
         print("Names of attributes in '/Info' of differ")
         ret_code = ERROR_INFO_ATTRS_DIFF

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -187,8 +187,7 @@ void EvolutionDriver::OutputCycleDiagnostics() {
                 << std::setprecision(dt_precision) << " time=" << tm.time
                 << " dt=" << tm.dt << std::setprecision(2) << " zone-cycles/wsec_step="
                 << static_cast<double>(zonecycles) / time_cycle_step
-                << " wsec_total=" << wtime
-                << " wsec_step=" << time_cycle_step;
+                << " wsec_total=" << wtime << " wsec_step=" << time_cycle_step;
 
       // In principle load balancing based on a cost list can happens for non-AMR runs.
       // TODO(future me) fix this when this becomes important.

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -26,6 +26,10 @@
 #include "utils/utils.hpp"
 
 namespace parthenon {
+// Declare class static variables
+Kokkos::Timer Driver::timer_main;
+Kokkos::Timer Driver::timer_cycle;
+Kokkos::Timer Driver::timer_LBandAMR;
 
 void Driver::PreExecute() {
   if (Globals::my_rank == 0) {

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -182,10 +182,12 @@ void EvolutionDriver::OutputCycleDiagnostics() {
           static_cast<std::uint64_t>(pmesh->GetNumberOfMeshBlockCells());
       const auto time_cycle_all = timer_cycle.seconds();
       const auto time_cycle_step = time_cycle_all - time_LBandAMR;
+      const auto wtime = timer_main.seconds();
       std::cout << "cycle=" << tm.ncycle << std::scientific
                 << std::setprecision(dt_precision) << " time=" << tm.time
                 << " dt=" << tm.dt << std::setprecision(2) << " zone-cycles/wsec_step="
                 << static_cast<double>(zonecycles) / time_cycle_step
+                << " wsec_total=" << wtime
                 << " wsec_step=" << time_cycle_step;
 
       // In principle load balancing based on a cost list can happens for non-AMR runs.

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -46,9 +46,12 @@ class Driver {
   ApplicationInput *app_input;
   Mesh *pmesh;
   std::unique_ptr<Outputs> pouts;
+  static double elapsed_main() { return timer_main.seconds(); }
+  static double elapsed_cycle() { return timer_cycle.seconds(); }
+  static double elapsed_LBandAMR() { return timer_LBandAMR.seconds(); }
 
  protected:
-  Kokkos::Timer timer_cycle, timer_main, timer_LBandAMR;
+  static Kokkos::Timer timer_cycle, timer_main, timer_LBandAMR;
   double time_LBandAMR;
   std::uint64_t mbcnt_prev;
   virtual void PreExecute();

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -28,6 +28,7 @@
 #include <type_traits>
 #include <unordered_map>
 
+#include "driver/driver.hpp"
 #include "interface/meshblock_data_iterator.hpp"
 #include "interface/metadata.hpp"
 #include "mesh/mesh.hpp"
@@ -439,7 +440,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   // -------------------------------------------------------------------------------- //
   //   WRITING ATTRIBUTES                                                             //
   // -------------------------------------------------------------------------------- //
-
   {
     // write input key-value pairs
     std::ostringstream oss;
@@ -459,6 +459,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       HDF5WriteAttribute("Time", tm->time, info_group);
       HDF5WriteAttribute("dt", tm->dt, info_group);
     }
+
+    HDF5WriteAttribute("WallTime", Driver::elapsed_main(), info_group);
     HDF5WriteAttribute("NumDims", pm->ndim, info_group);
     HDF5WriteAttribute("NumMeshBlocks", pm->nbtotal, info_group);
     HDF5WriteAttribute("MaxLevel", max_level, info_group);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
The HDF output files for visualization and restart do not include elapsed wall clock time, which is useful for doing macro scale comparisons after the fact.  This PR adds static functions to the Driver class to access the main, cycle, and LBandAMR timers and adds them to the viz and restart files as attribute /Info/WallTime


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [N/A] New features are documented.
- [N/A] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] (@lanl.gov employees) Update copyright on changed files
