### PR TITLE
Remove shape duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[PR 482]](https://github.com/lanl/parthenon/pull/482) Add support for package enrolled history outputs.
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 517]](https://github.com/lanl/parthenon/pull/517) Remove optional `dims` argument from `MeshBlockData::Add` and use the shape from the `Metadata` instead
 - [[PR 492]](https://github.com/lanl/parthenon/pull/492) Modify advection example to have an arbitrary number of dense variables and to disable fill derived for profiling.
 - [[PR 486]](https://github.com/lanl/parthenon/pull/486) Unify HDF5 output and restart file writing,
     add HDF5 compression support, add support for sparse fields in HDF5 output/restart files, add and rename some metadata in HDF5 files.

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -182,14 +182,16 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     field_name = "one_minus_sqrt_one_minus_advected_sq";
     m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Sparse,
                   Metadata::Restart},
-                 12, // just picking a sparse_id out of a hat for demonstration
-                 std::vector<int>({num_vars}));
+                 std::vector<int>({num_vars}),
+                 12 // just picking a sparse_id out of a hat for demonstration
+    );
     pkg->AddField(field_name, m);
     // add another component
     m = Metadata({Metadata::Cell, Metadata::Derived, Metadata::OneCopy, Metadata::Sparse,
                   Metadata::Restart},
-                 37, // just picking a sparse_id out of a hat for demonstration
-                 std::vector<int>({num_vars}));
+                 std::vector<int>({num_vars}),
+                 37 // just picking a sparse_id out of a hat for demonstration
+    );
     pkg->AddField(field_name, m);
   }
 

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -25,15 +25,6 @@
 
 namespace parthenon {
 
-/// The new version of Add that takes the fourth dimension from
-/// the metadata structure
-template <typename T>
-void MeshBlockData<T>::Add(const std::string &label, const Metadata &metadata) {
-  // generate the vector and call Add
-  const std::vector<int> &dims = metadata.Shape();
-  Add(label, metadata, dims);
-}
-
 template <typename T>
 void MeshBlockData<T>::Add(const std::vector<std::string> &labelArray,
                            const Metadata &metadata) {
@@ -43,26 +34,15 @@ void MeshBlockData<T>::Add(const std::vector<std::string> &labelArray,
   }
 }
 
-template <typename T>
-void MeshBlockData<T>::Add(const std::vector<std::string> &labelArray,
-                           const Metadata &metadata, const std::vector<int> &dims) {
-  for (const auto &label : labelArray) {
-    Add(label, metadata, dims);
-  }
-}
-
 ///
 /// The internal routine for allocating an array.  This subroutine
 /// is topology aware and will allocate accordingly.
 ///
 /// @param label the name of the variable
-/// @param dims the size of each element
 /// @param metadata the metadata associated with the variable
 template <typename T>
-void MeshBlockData<T>::Add(const std::string &label, const Metadata &metadata,
-                           const std::vector<int> &dims) {
-  std::array<int, 6> arrDims;
-  calcArrDims_(arrDims, dims, metadata);
+void MeshBlockData<T>::Add(const std::string &label, const Metadata &metadata) {
+  auto arrDims = calcArrDims_(metadata);
 
   // branch on kind of variable
   if (metadata.IsSet(Metadata::Sparse)) {
@@ -855,10 +835,11 @@ void MeshBlockData<T>::Print() {
 }
 
 template <typename T>
-void MeshBlockData<T>::calcArrDims_(std::array<int, 6> &arrDims,
-                                    const std::vector<int> &dims,
-                                    const Metadata &metadata) {
-  const int N = dims.size();
+std::array<int, 6> MeshBlockData<T>::calcArrDims_(const Metadata &metadata) {
+  std::array<int, 6> arrDims;
+
+  const auto &shape = metadata.Shape();
+  const int N = shape.size();
 
   if (metadata.Where() == Metadata::Cell || metadata.Where() == Metadata::Face ||
       metadata.Where() == Metadata::Edge || metadata.Where() == Metadata::Node) {
@@ -866,14 +847,14 @@ void MeshBlockData<T>::calcArrDims_(std::array<int, 6> &arrDims,
     // classes add the +1's where needed.  They all expect
     // these dimensions to be the number of cells in each
     // direction, NOT the size of the arrays
-    assert(N >= 0 && N <= 3);
+    assert(N >= 1 && N <= 3);
     const IndexDomain entire = IndexDomain::entire;
     std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
     arrDims[0] = pmb->cellbounds.ncellsi(entire);
     arrDims[1] = pmb->cellbounds.ncellsj(entire);
     arrDims[2] = pmb->cellbounds.ncellsk(entire);
     for (int i = 0; i < N; i++)
-      arrDims[i + 3] = dims[i];
+      arrDims[i + 3] = shape[i];
     for (int i = N; i < 3; i++)
       arrDims[i + 3] = 1;
   } else {
@@ -882,10 +863,12 @@ void MeshBlockData<T>::calcArrDims_(std::array<int, 6> &arrDims,
     // size in each dimension
     assert(N >= 1 && N <= 6);
     for (int i = 0; i < N; i++)
-      arrDims[i] = dims[i];
+      arrDims[i] = shape[i];
     for (int i = N; i < 6; i++)
       arrDims[i] = 1;
   }
+
+  return arrDims;
 }
 
 template class MeshBlockData<double>;

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -163,36 +163,6 @@ class MeshBlockData {
   ///
   /// This function will eventually look at the metadata flags to
   /// identify the size of the first dimension based on the
-  /// topological location.
-  ///
-  /// @param label the name of the variable
-  /// @param metadata the metadata associated with the variable
-  /// @param dims the size of each element
-  ///
-  /// TODO(JMM): DO NOT make these strings const reference.
-  /// passing in C-style string literals misbehaves
-  void Add(const std::string &label, const Metadata &metadata,
-           const std::vector<int> &dims);
-
-  ///
-  /// Allocate and add a variable<T> to the container
-  ///
-  /// This function will eventually look at the metadata flags to
-  /// identify the size of the first dimension based on the
-  /// topological location.
-  ///
-  /// @param labelVector the array of names of variables
-  /// @param metadata the metadata associated with the variable
-  /// @param dims the size of each element
-  ///
-  void Add(const std::vector<std::string> &labelVector, const Metadata &metadata,
-           const std::vector<int> &dims);
-
-  ///
-  /// Allocate and add a variable<T> to the container
-  ///
-  /// This function will eventually look at the metadata flags to
-  /// identify the size of the first dimension based on the
   /// topological location.  Dimensions will be taken from the metadata.
   ///
   /// @param label the name of the variable
@@ -461,8 +431,7 @@ class MeshBlockData {
   MapToVariablePack<T> coarseVarPackMap_; // cache for varpacks over coarse arrays
   MapToVariableFluxPack<T> varFluxPackMap_;
 
-  void calcArrDims_(std::array<int, 6> &arrDims, const std::vector<int> &dims,
-                    const Metadata &metadata);
+  std::array<int, 6> calcArrDims_(const Metadata &metadata);
 
   // helper functions for VariablePack
   vpack_types::VarList<T> MakeList_(const std::vector<std::string> &names,

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -166,67 +166,65 @@ class Metadata {
   PARTHENON_INTERNAL_FOREACH_BUILTIN_FLAG
 #undef PARTHENON_INTERNAL_FOR_FLAG
 
-  /// Default constructor override
-  Metadata() : shape_({1}), sparse_id_(-1) {}
+  Metadata() = default;
 
-  /// returns a new Metadata instance with set bits,
-  /// set sparse_id, and fourth dimension
-  explicit Metadata(const std::vector<MetadataFlag> &bits) : shape_({1}), sparse_id_(-1) {
+  // There are 4 optional arguments: shape, sparse_id, component_labels, and associated,
+  // so we'll need 16 constructors to provide all possible variants
+
+  // 5 constructors, this is the general constructor called by all other constructors, so
+  // we do some sanity checks here
+  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {1},
+           int sparse_id = -1, const std::vector<std::string> component_labels = {},
+           const std::string &associated = "")
+      : shape_(shape), sparse_id_(sparse_id), component_labels_(component_labels),
+        associated_(associated) {
     SetMultiple(bits);
+    PARTHENON_REQUIRE_THROWS(IsSet(Sparse) == (sparse_id_ != -1),
+                             "Mismatch between sparse flag and sparse ID");
+    PARTHENON_REQUIRE_THROWS(shape_.size() > 0, "Shape must have at least rank 1");
+    if (IsMeshTied()) {
+      PARTHENON_REQUIRE_THROWS(
+          shape_.size() <= 3,
+          "Variables tied to mesh entities can only have a shape of rank <= 3");
+    }
   }
 
-  /// returns a metadata with bits and shape set
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape)
-      : shape_(shape), sparse_id_(-1) {
-    SetMultiple(bits);
-  }
+  // 1 constructor
+  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
+           int sparse_id, const std::string &associated)
+      : Metadata(bits, shape, sparse_id, {}, associated) {}
 
-  /// returns a metadata with bits and shape set
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
-                    const std::vector<std::string> component_labels)
-      : shape_(shape), sparse_id_(-1), component_labels_(component_labels) {
-    SetMultiple(bits);
-  }
+  // 2 constructors
+  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
+           const std::vector<std::string> component_labels,
+           const std::string &associated = "")
+      : Metadata(bits, shape, -1, component_labels, associated) {}
 
-  /// returns a metadata with bits and sparse id set
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const int sparse_id)
-      : shape_({1}), sparse_id_(sparse_id) {
-    SetMultiple(bits);
-    PARTHENON_REQUIRE_THROWS(IsSet(Sparse), "Sparse ID requires sparse metadata");
-  }
+  // 1 constructor
+  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
+           const std::string &associated)
+      : Metadata(bits, shape, -1, {}, associated) {}
 
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const std::string &associated)
-      : associated_(associated) {
-    SetMultiple(bits);
-  }
+  // 3 constructors
+  Metadata(const std::vector<MetadataFlag> &bits, int sparse_id,
+           const std::vector<std::string> component_labels = {},
+           const std::string &associated = "")
+      : Metadata(bits, {1}, sparse_id, component_labels, associated) {}
 
-  /// returns a metadata with bits, shape, and sparse ID set
-  explicit Metadata(const std::vector<MetadataFlag> &bits, int sparse_id,
-                    const std::vector<int> &shape)
-      : shape_(shape), sparse_id_(sparse_id) {
-    SetMultiple(bits);
-    PARTHENON_REQUIRE_THROWS(IsSet(Sparse), "Sparse ID requires sparse metadata");
-  }
+  // 1 constructor
+  Metadata(const std::vector<MetadataFlag> &bits, int sparse_id,
+           const std::string &associated)
+      : Metadata(bits, {1}, sparse_id, {}, associated) {}
 
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const int sparse_id,
-                    const std::string &associated)
-      : sparse_id_(sparse_id), associated_(associated) {
-    SetMultiple(bits);
-    PARTHENON_REQUIRE_THROWS(IsSet(Sparse), "Sparse ID requires sparse metadata");
-  }
+  // 2 constructors
+  Metadata(const std::vector<MetadataFlag> &bits,
+           const std::vector<std::string> component_labels,
+           const std::string &associated = "")
+      : Metadata(bits, {1}, -1, component_labels, associated) {}
 
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const std::string &associated,
-                    const std::vector<int> &shape)
-      : associated_(associated), shape_(shape) {
-    SetMultiple(bits);
-  }
-
-  explicit Metadata(const std::vector<MetadataFlag> &bits, const int sparse_id,
-                    const std::string &associated, const std::vector<int> &shape)
-      : sparse_id_(sparse_id), associated_(associated), shape_(shape) {
-    SetMultiple(bits);
-    PARTHENON_REQUIRE_THROWS(IsSet(Sparse), "Sparse ID requires sparse metadata");
-  }
+  // 1 constructor
+  Metadata(const std::vector<MetadataFlag> &bits, const std::string &associated)
+      : Metadata(bits, {1}, -1, {}, associated) {}
 
   // Static routines
   static MetadataFlag AllocateNewFlag(std::string &&name);
@@ -251,6 +249,8 @@ class Metadata {
     /// by default return Metadata::None
     return None;
   }
+
+  bool IsMeshTied() const { return Where() != None; }
 
   /// returns the type of the variable
   MetadataFlag Type() const {
@@ -345,6 +345,7 @@ class Metadata {
   }
 
   bool operator==(const Metadata &b) const {
+    // TODO(JL) What about component_labels_ and associated_?
     return (SparseEqual(b) && (sparse_id_ == b.sparse_id_));
   }
 
@@ -360,11 +361,10 @@ class Metadata {
  private:
   /// the attribute flags that are set for the class
   std::vector<bool> bits_;
-  std::vector<int> shape_;
-  std::string associated_;
-  int sparse_id_;
-
-  std::vector<std::string> component_labels_;
+  std::vector<int> shape_ = {1};
+  int sparse_id_ = -1;
+  std::vector<std::string> component_labels_ = {};
+  std::string associated_ = "";
 
   /*--------------------------------------------------------*/
   // Setters for the different attributes of metadata

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -174,7 +174,7 @@ class Metadata {
   // 5 constructors, this is the general constructor called by all other constructors, so
   // we do some sanity checks here
   Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {1},
-           int sparse_id = -1, const std::vector<std::string> component_labels = {},
+           int sparse_id = -1, const std::vector<std::string> &component_labels = {},
            const std::string &associated = "")
       : shape_(shape), sparse_id_(sparse_id), component_labels_(component_labels),
         associated_(associated) {

--- a/tst/performance/test_meshblock_data_iterator.cpp
+++ b/tst/performance/test_meshblock_data_iterator.cpp
@@ -75,18 +75,19 @@ void performance_test_wrapper(const std::string &test_name, InitFunc init_func,
 static MeshBlockData<Real> createTestContainer() {
   // Make a container for testing performance
   MeshBlockData<Real> container;
-  Metadata m_in({Metadata::Independent});
-  Metadata m_out;
-  std::vector<int> scalar_block_size{N, N, N};
-  std::vector<int> vector_block_size{N, N, N, 3};
+  std::vector<int> scalar_shape{N, N, N};
+  std::vector<int> vector_shape{N, N, N, 3};
+
+  Metadata m_in({Metadata::Independent}, scalar_shape);
+  Metadata m_in_vec({Metadata::Independent}, vector_shape);
 
   // make some variables - 5 in all, 2 3-vectors, total 10 fields
-  container.Add("v0", m_in, scalar_block_size);
-  container.Add("v1", m_in, scalar_block_size);
-  container.Add("v2", m_in, vector_block_size);
-  container.Add("v3", m_in, scalar_block_size);
-  container.Add("v4", m_in, vector_block_size);
-  container.Add("v5", m_in, scalar_block_size);
+  container.Add("v0", m_in);
+  container.Add("v1", m_in);
+  container.Add("v2", m_in_vec);
+  container.Add("v3", m_in);
+  container.Add("v4", m_in_vec);
+  container.Add("v5", m_in);
   return container;
 }
 

--- a/tst/unit/test_data_collection.cpp
+++ b/tst/unit/test_data_collection.cpp
@@ -43,11 +43,11 @@ TEST_CASE("Adding MeshBlockData objects to a DataCollection", "[DataCollection]"
     auto &mbd = d.Get();
     mbd->SetBlockPointer(pmb);
     std::vector<int> size(6, 1);
-    Metadata m_ind({Metadata::Independent});
-    Metadata m_one({Metadata::OneCopy});
-    mbd->Add("var1", m_ind, size);
-    mbd->Add("var2", m_one, size);
-    mbd->Add("var3", m_ind, size);
+    Metadata m_ind({Metadata::Independent}, size);
+    Metadata m_one({Metadata::OneCopy}, size);
+    mbd->Add("var1", m_ind);
+    mbd->Add("var2", m_one);
+    mbd->Add("var3", m_ind);
     auto &v1 = mbd->Get("var1").data;
     auto &v2 = mbd->Get("var2").data;
     auto &v3 = mbd->Get("var3").data;

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -70,18 +70,22 @@ TEST_CASE("Can pull variables from containers based on Metadata",
           "[MeshBlockDataIterator]") {
   GIVEN("A Container with a set of variables initialized to zero") {
     MeshBlockData<Real> rc;
-    Metadata m_in({Metadata::Independent, Metadata::FillGhost});
-    Metadata m_in_vector({Metadata::Independent, Metadata::FillGhost, Metadata::Vector});
-    Metadata m_out;
-    std::vector<int> scalar_block_size{16, 16, 16};
-    std::vector<int> vector_block_size{16, 16, 16, 3};
+    std::vector<int> scalar_shape{16, 16, 16};
+    std::vector<int> vector_shape{16, 16, 16, 3};
+
+    Metadata m_in({Metadata::Independent, Metadata::FillGhost}, scalar_shape);
+    Metadata m_in_vector({Metadata::Independent, Metadata::FillGhost, Metadata::Vector},
+                         vector_shape);
+    Metadata m_out({}, scalar_shape);
+    Metadata m_out_vector({}, vector_shape);
+
     // Make some variables
-    rc.Add("v1", m_in, scalar_block_size);
-    rc.Add("v2", m_out, scalar_block_size);
-    rc.Add("v3", m_in_vector, vector_block_size);
-    rc.Add("v4", m_out, vector_block_size);
-    rc.Add("v5", m_in, scalar_block_size);
-    rc.Add("v6", m_out, scalar_block_size);
+    rc.Add("v1", m_in);
+    rc.Add("v2", m_out);
+    rc.Add("v3", m_in_vector);
+    rc.Add("v4", m_out_vector);
+    rc.Add("v5", m_in);
+    rc.Add("v6", m_out);
 
     WHEN("We extract a subcontainer") {
       auto subcontainer = MeshBlockData<Real>(rc, {"v1", "v3", "v5"});
@@ -286,12 +290,12 @@ TEST_CASE("Can pull variables from containers based on Metadata",
 
     WHEN("we add sparse fields") {
       Metadata m_sparse;
-      m_sparse = Metadata({Metadata::Sparse}, 1);
-      rc.Add("vsparse", m_sparse, scalar_block_size);
+      m_sparse = Metadata({Metadata::Sparse}, scalar_shape, 1);
+      rc.Add("vsparse", m_sparse);
       m_sparse = Metadata({Metadata::Sparse}, 13);
-      rc.Add("vsparse", m_sparse, scalar_block_size);
+      rc.Add("vsparse", m_sparse);
       m_sparse = Metadata({Metadata::Sparse}, 42);
-      rc.Add("vsparse", m_sparse, scalar_block_size);
+      rc.Add("vsparse", m_sparse);
       THEN("the low and high index bounds are correct as returned by PackVariables") {
         PackIndexMap imap;
         auto v = rc.PackVariables({"v3", "v6", "vsparse"}, imap);
@@ -358,8 +362,9 @@ TEST_CASE("Can pull variables from containers based on Metadata",
     }
 
     WHEN("we add a 2d variable") {
-      std::vector<int> twod_block_size{16, 16, 1};
-      rc.Add("v2d", m_in, twod_block_size);
+      std::vector<int> shape_2D{16, 16, 1};
+      Metadata m_in_2D({Metadata::Independent, Metadata::FillGhost}, shape_2D);
+      rc.Add("v2d", m_in_2D);
       auto packw2d = rc.PackVariablesAndFluxes({"v2d"}, {"v2d"});
       THEN("The pack knows it is 2d") { REQUIRE(packw2d.GetNdim() == 2); }
     }
@@ -383,10 +388,10 @@ TEST_CASE("Coarse variable from meshblock_data for cell variable",
     auto c_cellbounds = IndexShape(nside / 2, nside / 2, nside / 2, nghost);
 
     MeshBlockData<Real> rc;
-    Metadata m({Metadata::Independent});
     std::vector<int> block_size{nside + 2 * nghost, nside + 2 * nghost,
                                 nside + 2 * nghost};
-    rc.Add("var", m, block_size);
+    Metadata m({Metadata::Independent}, block_size);
+    rc.Add("var", m);
     auto &var = rc.Get("var");
 
     auto coarse_s =


### PR DESCRIPTION
Remove optional dims argument when adding variable to `MeshBlockData` and use the shape from `Metadata` instead.

This way, the variable shape only exists in one place and it can't become inconsistent with the shape stored in `Metadata`.

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
