### PR TITLE
Enforce Metadata constraints, add `Metadata::WithFluxes`, fix Metadata checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[PR 482]](https://github.com/lanl/parthenon/pull/482) Add support for package enrolled history outputs.
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 524]](https://github.com/lanl/parthenon/pull/524) Enforce `Metadata` flags constraints and add new `Metadata::WithFluxes` flag. Note: `Metadata::Independent` will be set automatically unless `Metadata::Derived` is set
 - [[PR 517]](https://github.com/lanl/parthenon/pull/517) Remove optional `dims` argument from `MeshBlockData::Add` and use the shape from the `Metadata` instead
 - [[PR 492]](https://github.com/lanl/parthenon/pull/492) Modify advection example to have an arbitrary number of dense variables and to disable fill derived for profiling.
 - [[PR 486]](https://github.com/lanl/parthenon/pull/486) Unify HDF5 output and restart file writing,

--- a/docs/interface/Metadata.md
+++ b/docs/interface/Metadata.md
@@ -75,7 +75,7 @@ enable output properties.
 For multidimensional variables, these flags specify how to treat the
 individual components at boundaries. For concreteness, we will discuss
 reflecting boundaries. But this may apply more broadly. A variable
-with no flag set is assumed to be a *Scalar*. Scalars obey 
+with no flag set is assumed to be a *Scalar*. Scalars obey
 [Dirichlet boundary conditions](https://en.wikipedia.org/wiki/Dirichlet_boundary_condition)
 at reflecting boundaries and are set to a constant value.
 The following flags are mutually exclusive.
@@ -125,10 +125,10 @@ classes may be allocated. The behaviours are the following:
   shared between all instances of a variable in all `Containers` in a
   `DataCollection`.
 
-- If, in addition to `Metadata::FillGhosts`, `Metadata::Independent`
-  is set, the flux vector for the variable is allocated. In the
-  current design, the flux is fundamental to communication, since flux
-  corrections accross meshblocks utilize the flux buffer.
+- If `Metadata::WithFluxes` is set, the flux vector for the variable
+  is allocated. Note that it is necessary to set both
+  `Metadata::WithFluxes` and `Metadata::FillGhosts` to send flux
+  corrections across meshblocks.
 
 ### Application Metadata Flags
 

--- a/docs/interface/Metadata.md
+++ b/docs/interface/Metadata.md
@@ -112,8 +112,6 @@ variables are copied or not in multiple stages.
   always required. `OneCopy` variables, for example, may not need
   this.
 
-- `Metadata::SharedComms` TODO(JMM): not sure this variable is used
-
 ### Ghost Zones, Communication, and Fluxes
 
 Depending on a combination of flags, extra communication buffers and

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -163,7 +163,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     } else {
       field_name = field_name_base + "_" + std::to_string(var);
     }
-    m = Metadata({Metadata::Cell, Metadata::Independent, Metadata::WithFluxes, Metadata::FillGhost},
+    m = Metadata({Metadata::Cell, Metadata::Independent, Metadata::WithFluxes,
+                  Metadata::FillGhost},
                  std::vector<int>({vec_size}), advected_labels);
     pkg->AddField(field_name, m);
   }

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     } else {
       field_name = field_name_base + "_" + std::to_string(var);
     }
-    m = Metadata({Metadata::Cell, Metadata::Independent, Metadata::FillGhost},
+    m = Metadata({Metadata::Cell, Metadata::Independent, Metadata::WithFluxes, Metadata::FillGhost},
                  std::vector<int>({vec_size}), advected_labels);
     pkg->AddField(field_name, m);
   }
@@ -427,7 +427,7 @@ TaskStatus CalculateFluxes(std::shared_ptr<MeshBlockData<Real>> &rc) {
   const auto &vy = pkg->Param<Real>("vy");
   const auto &vz = pkg->Param<Real>("vz");
 
-  auto v = rc->PackVariablesAndFluxes(std::vector<MetadataFlag>{Metadata::Independent});
+  auto v = rc->PackVariablesAndFluxes(std::vector<MetadataFlag>{Metadata::WithFluxes});
 
   const int scratch_level = 1; // 0 is actual scratch (tiny); 1 is HBM
   const int nx1 = pmb->cellbounds.ncellsi(IndexDomain::entire);

--- a/example/kokkos_pi/kokkos_pi.cpp
+++ b/example/kokkos_pi/kokkos_pi.cpp
@@ -161,7 +161,7 @@ static BlockList_t setupMesh(const int &n_block, const int &n_mesh, const double
   auto h_xyz = Kokkos::create_mirror_view(xyz);
 
   // Set up our mesh.
-  Metadata myMetadata({Metadata::Independent, Metadata::Cell});
+  Metadata myMetadata({Metadata::Independent, Metadata::WithFluxes, Metadata::Cell});
   BlockList_t block_list;
   block_list.reserve(n_mesh * n_mesh * n_mesh);
 

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -70,7 +70,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   pkg->AddSwarmValue("weight", swarm_name, real_swarmvalue_metadata);
 
   std::string field_name = "particle_deposition";
-  Metadata m({Metadata::Cell, Metadata::Independent});
+  Metadata m({Metadata::Cell, Metadata::Independent, Metadata::WithFluxes});
   pkg->AddField(field_name, m);
 
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;

--- a/example/stochastic_subgrid/stochastic_subgrid_package.cpp
+++ b/example/stochastic_subgrid/stochastic_subgrid_package.cpp
@@ -190,7 +190,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     const auto num_vars = pin->GetOrAddInteger("Advection", "num_vars", 1);
 
     std::string field_name = "advected";
-    Metadata m({Metadata::Cell, Metadata::Independent, Metadata::FillGhost},
+    Metadata m({Metadata::Cell, Metadata::Independent, Metadata::WithFluxes,
+                Metadata::FillGhost},
                std::vector<int>({num_vars}));
     pkg->AddField(field_name, m);
 

--- a/src/bvals/cc/bvals_cc_in_one.cpp
+++ b/src/bvals/cc/bvals_cc_in_one.cpp
@@ -247,7 +247,7 @@ size_t ResetAndRestrictSendBuffers(MeshData<Real> *md, bool cache_is_valid) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->IsSet(parthenon::Metadata::FillGhost)) {
+      if (v->HasBoundaryVars()) {
         v->resetBoundary();
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
@@ -300,7 +300,7 @@ void ResetSendBufferBoundaryInfo(MeshData<Real> *md, size_t buffers_used) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->IsSet(parthenon::Metadata::FillGhost)) {
+      if (v->HasBoundaryVars()) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
           auto *pbd_var_ = v->vbvar->GetPBdVar();
@@ -376,7 +376,7 @@ void SendAndNotify(MeshData<Real> *md) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->IsSet(parthenon::Metadata::FillGhost)) {
+      if (v->HasBoundaryVars()) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
           auto *pbd_var_ = v->vbvar->GetPBdVar();
@@ -511,7 +511,7 @@ void ResetSetFromBufferBoundaryInfo(MeshData<Real> *md) {
     auto &rc = md->GetBlockData(block);
     auto pmb = rc->GetBlockPointer();
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->IsSet(parthenon::Metadata::FillGhost)) {
+      if (v->HasBoundaryVars()) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           buffers_used += 1;
         }
@@ -529,7 +529,7 @@ void ResetSetFromBufferBoundaryInfo(MeshData<Real> *md) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->IsSet(parthenon::Metadata::FillGhost)) {
+      if (v->HasBoundaryVars()) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
           auto *pbd_var_ = v->vbvar->GetPBdVar();

--- a/src/bvals/cc/bvals_cc_in_one.cpp
+++ b/src/bvals/cc/bvals_cc_in_one.cpp
@@ -247,7 +247,7 @@ size_t ResetAndRestrictSendBuffers(MeshData<Real> *md, bool cache_is_valid) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->HasBoundaryVars()) {
+      if (v->IsSet(Metadata::FillGhost)) {
         v->resetBoundary();
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
@@ -300,7 +300,7 @@ void ResetSendBufferBoundaryInfo(MeshData<Real> *md, size_t buffers_used) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->HasBoundaryVars()) {
+      if (v->IsSet(Metadata::FillGhost)) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
           auto *pbd_var_ = v->vbvar->GetPBdVar();
@@ -376,7 +376,7 @@ void SendAndNotify(MeshData<Real> *md) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->HasBoundaryVars()) {
+      if (v->IsSet(Metadata::FillGhost)) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
           auto *pbd_var_ = v->vbvar->GetPBdVar();
@@ -511,7 +511,7 @@ void ResetSetFromBufferBoundaryInfo(MeshData<Real> *md) {
     auto &rc = md->GetBlockData(block);
     auto pmb = rc->GetBlockPointer();
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->HasBoundaryVars()) {
+      if (v->IsSet(Metadata::FillGhost)) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           buffers_used += 1;
         }
@@ -529,7 +529,7 @@ void ResetSetFromBufferBoundaryInfo(MeshData<Real> *md) {
 
     int mylevel = pmb->loc.level;
     for (auto &v : rc->GetCellVariableVector()) {
-      if (v->HasBoundaryVars()) {
+      if (v->IsSet(Metadata::FillGhost)) {
         for (int n = 0; n < pmb->pbval->nneighbor; n++) {
           parthenon::NeighborBlock &nb = pmb->pbval->neighbor[n];
           auto *pbd_var_ = v->vbvar->GetPBdVar();

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -54,7 +54,7 @@ void MeshBlockData<T>::Add(const std::string &label, const Metadata &metadata) {
     int varIndex = metadata.GetSparseId();
     sparseMap_[label]->Add(varIndex, arrDims);
     auto &v = sparseMap_[label]->Get(varIndex);
-    v->allocateComms(pmy_block);
+    v->AllocateFluxesAndBdryVar(pmy_block);
   } else if (metadata.Where() == Metadata::Edge) {
     // add an edge variable
     std::cerr << "Accessing unliving edge array in stage" << std::endl;
@@ -77,7 +77,7 @@ void MeshBlockData<T>::Add(const std::string &label, const Metadata &metadata) {
   } else {
     auto sv = std::make_shared<CellVariable<T>>(label, arrDims, metadata);
     Add(sv);
-    sv->allocateComms(pmy_block);
+    sv->AllocateFluxesAndBdryVar(pmy_block);
   }
 }
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -37,35 +37,35 @@
   /**  bit 0 is ignored */                                                               \
   PARTHENON_INTERNAL_FOR_FLAG(Ignore)                                                    \
   /************************************************/                                     \
-  /**  TOPOLOGY: Exactly one must be specified (default is None) */                      \
-  /**  no topology specified */                                                          \
+  /** TOPOLOGY: Exactly one must be specified (default is None) */                      \
+  /** no topology specified */                                                          \
   PARTHENON_INTERNAL_FOR_FLAG(None)                                                      \
-  /**  cell variable */                                                                  \
+  /** cell variable */                                                                  \
   PARTHENON_INTERNAL_FOR_FLAG(Cell)                                                      \
-  /**  face variable */                                                                  \
+  /** face variable */                                                                  \
   PARTHENON_INTERNAL_FOR_FLAG(Face)                                                      \
-  /**  edge variable */                                                                  \
+  /** edge variable */                                                                  \
   PARTHENON_INTERNAL_FOR_FLAG(Edge)                                                      \
-  /**  node variable */                                                                  \
+  /** node variable */                                                                  \
   PARTHENON_INTERNAL_FOR_FLAG(Node)                                                      \
   /************************************************/                                     \
-  /**  ROLE: Exactly one must be specified (default is Provides) */                      \
-  /**  Private to a package */                                                           \
+  /** ROLE: Exactly one must be specified (default is Provides) */                      \
+  /** Private to a package */                                                           \
   PARTHENON_INTERNAL_FOR_FLAG(Private)                                                   \
-  /**  Provided by a package */                                                          \
+  /** Provided by a package */                                                          \
   PARTHENON_INTERNAL_FOR_FLAG(Provides)                                                  \
-  /**  Not created by a package, assumes available from another package */               \
+  /** Not created by a package, assumes available from another package */               \
   PARTHENON_INTERNAL_FOR_FLAG(Requires)                                                  \
-  /**  does nothing if another package provides the variable */                          \
+  /** does nothing if another package provides the variable */                          \
   PARTHENON_INTERNAL_FOR_FLAG(Overridable)                                               \
   /************************************************/                                     \
-  /**  SHAPE: Neither or one (but not both) can be specified */                          \
-  /**  a vector quantity, i.e. a rank 1 contravariant tensor */                          \
+  /** SHAPE: Neither or one (but not both) can be specified */                          \
+  /** a vector quantity, i.e. a rank 1 contravariant tensor */                          \
   PARTHENON_INTERNAL_FOR_FLAG(Vector)                                                    \
-  /**  a rank-2 tensor */                                                                \
+  /** a rank-2 tensor */                                                                \
   PARTHENON_INTERNAL_FOR_FLAG(Tensor)                                                    \
   /************************************************/                                     \
-  /**  DATATYPE: Exactly one must be specified (default is Real) */                      \
+  /** DATATYPE: Exactly one must be specified (default is Real) */                      \
   /** Boolean-valued quantity */                                                         \
   PARTHENON_INTERNAL_FOR_FLAG(Boolean)                                                   \
   /** Integer-valued quantity */                                                         \
@@ -73,22 +73,16 @@
   /** Real-valued quantity */                                                            \
   PARTHENON_INTERNAL_FOR_FLAG(Real)                                                      \
   /************************************************/                                     \
-  /**  INDEPENDENT: Exactly one must be specified (default is Independent) */            \
+  /** INDEPENDENT: Exactly one must be specified (default is Independent) */            \
   /** is an independent, evolved variable */                                             \
   PARTHENON_INTERNAL_FOR_FLAG(Independent)                                               \
   /** is a derived quantity (ignored) */                                                 \
   PARTHENON_INTERNAL_FOR_FLAG(Derived)                                                   \
   /************************************************/                                     \
-  /**  COMMUNICATION: SharedComms can only be set if FillGhost is set */                 \
-  /** Do boundary communication */                                                       \
-  PARTHENON_INTERNAL_FOR_FLAG(FillGhost)                                                 \
-  /** Communication arrays are a copy: hint to destructor */                             \
-  PARTHENON_INTERNAL_FOR_FLAG(SharedComms)                                               \
-  /************************************************/                                     \
-  /**  OTHER: All the following flags can be turned on or off independently */           \
-  /**  advected variable */                                                              \
+  /** OTHER: All the following flags can be turned on or off independently */           \
+  /** advected variable */                                                              \
   PARTHENON_INTERNAL_FOR_FLAG(Advected)                                                  \
-  /**  conserved variable */                                                             \
+  /** conserved variable */                                                             \
   PARTHENON_INTERNAL_FOR_FLAG(Conserved)                                                 \
   /** intensive variable */                                                              \
   PARTHENON_INTERNAL_FOR_FLAG(Intensive)                                                 \
@@ -98,6 +92,8 @@
   PARTHENON_INTERNAL_FOR_FLAG(Sparse)                                                    \
   /** only one copy even if multiple stages */                                           \
   PARTHENON_INTERNAL_FOR_FLAG(OneCopy)                                                   \
+  /** Do boundary communication */                                                       \
+  PARTHENON_INTERNAL_FOR_FLAG(FillGhost)                                                 \
   /** does variable have fluxes */                                                       \
   PARTHENON_INTERNAL_FOR_FLAG(WithFluxes)
 
@@ -314,14 +310,6 @@ class Metadata {
       valid = false;
       if (throw_on_fail) {
         PARTHENON_THROW("Either the Independent or Derived flag must be set");
-      }
-    }
-
-    // Communication
-    if (IsSet(SharedComms) && !IsSet(FillGhost)) {
-      valid = false;
-      if (throw_on_fail) {
-        PARTHENON_THROW("FillGhost must be set if SharedComms is set");
       }
     }
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -37,35 +37,35 @@
   /**  bit 0 is ignored */                                                               \
   PARTHENON_INTERNAL_FOR_FLAG(Ignore)                                                    \
   /************************************************/                                     \
-  /** TOPOLOGY: Exactly one must be specified (default is None) */                      \
-  /** no topology specified */                                                          \
+  /** TOPOLOGY: Exactly one must be specified (default is None) */                       \
+  /** no topology specified */                                                           \
   PARTHENON_INTERNAL_FOR_FLAG(None)                                                      \
-  /** cell variable */                                                                  \
+  /** cell variable */                                                                   \
   PARTHENON_INTERNAL_FOR_FLAG(Cell)                                                      \
-  /** face variable */                                                                  \
+  /** face variable */                                                                   \
   PARTHENON_INTERNAL_FOR_FLAG(Face)                                                      \
-  /** edge variable */                                                                  \
+  /** edge variable */                                                                   \
   PARTHENON_INTERNAL_FOR_FLAG(Edge)                                                      \
-  /** node variable */                                                                  \
+  /** node variable */                                                                   \
   PARTHENON_INTERNAL_FOR_FLAG(Node)                                                      \
   /************************************************/                                     \
-  /** ROLE: Exactly one must be specified (default is Provides) */                      \
-  /** Private to a package */                                                           \
+  /** ROLE: Exactly one must be specified (default is Provides) */                       \
+  /** Private to a package */                                                            \
   PARTHENON_INTERNAL_FOR_FLAG(Private)                                                   \
-  /** Provided by a package */                                                          \
+  /** Provided by a package */                                                           \
   PARTHENON_INTERNAL_FOR_FLAG(Provides)                                                  \
-  /** Not created by a package, assumes available from another package */               \
+  /** Not created by a package, assumes available from another package */                \
   PARTHENON_INTERNAL_FOR_FLAG(Requires)                                                  \
-  /** does nothing if another package provides the variable */                          \
+  /** does nothing if another package provides the variable */                           \
   PARTHENON_INTERNAL_FOR_FLAG(Overridable)                                               \
   /************************************************/                                     \
-  /** SHAPE: Neither or one (but not both) can be specified */                          \
-  /** a vector quantity, i.e. a rank 1 contravariant tensor */                          \
+  /** SHAPE: Neither or one (but not both) can be specified */                           \
+  /** a vector quantity, i.e. a rank 1 contravariant tensor */                           \
   PARTHENON_INTERNAL_FOR_FLAG(Vector)                                                    \
-  /** a rank-2 tensor */                                                                \
+  /** a rank-2 tensor */                                                                 \
   PARTHENON_INTERNAL_FOR_FLAG(Tensor)                                                    \
   /************************************************/                                     \
-  /** DATATYPE: Exactly one must be specified (default is Real) */                      \
+  /** DATATYPE: Exactly one must be specified (default is Real) */                       \
   /** Boolean-valued quantity */                                                         \
   PARTHENON_INTERNAL_FOR_FLAG(Boolean)                                                   \
   /** Integer-valued quantity */                                                         \
@@ -73,16 +73,16 @@
   /** Real-valued quantity */                                                            \
   PARTHENON_INTERNAL_FOR_FLAG(Real)                                                      \
   /************************************************/                                     \
-  /** INDEPENDENT: Exactly one must be specified (default is Independent) */            \
+  /** INDEPENDENT: Exactly one must be specified (default is Independent) */             \
   /** is an independent, evolved variable */                                             \
   PARTHENON_INTERNAL_FOR_FLAG(Independent)                                               \
   /** is a derived quantity (ignored) */                                                 \
   PARTHENON_INTERNAL_FOR_FLAG(Derived)                                                   \
   /************************************************/                                     \
-  /** OTHER: All the following flags can be turned on or off independently */           \
-  /** advected variable */                                                              \
+  /** OTHER: All the following flags can be turned on or off independently */            \
+  /** advected variable */                                                               \
   PARTHENON_INTERNAL_FOR_FLAG(Advected)                                                  \
-  /** conserved variable */                                                             \
+  /** conserved variable */                                                              \
   PARTHENON_INTERNAL_FOR_FLAG(Conserved)                                                 \
   /** intensive variable */                                                              \
   PARTHENON_INTERNAL_FOR_FLAG(Intensive)                                                 \

--- a/src/interface/sparse_variable.hpp
+++ b/src/interface/sparse_variable.hpp
@@ -99,9 +99,6 @@ class SparseVariable {
 
   bool IsSet(const MetadataFlag flag) { return metadata_.IsSet(flag); }
 
-  inline bool HasFluxes() const { return metadata_.IsSet(Metadata::WithFluxes); }
-  inline bool HasBoundaryVars() const { return metadata_.IsSet(Metadata::FillGhost); }
-
   /// return information string
   std::string info() {
     std::string s = "info not yet implemented for sparse variables";

--- a/src/interface/sparse_variable.hpp
+++ b/src/interface/sparse_variable.hpp
@@ -99,6 +99,9 @@ class SparseVariable {
 
   bool IsSet(const MetadataFlag flag) { return metadata_.IsSet(flag); }
 
+  inline bool HasFluxes() const { return metadata_.IsSet(Metadata::WithFluxes); }
+  inline bool HasBoundaryVars() const { return metadata_.IsSet(Metadata::FillGhost); }
+
   /// return information string
   std::string info() {
     std::string s = "info not yet implemented for sparse variables";

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -275,15 +275,6 @@ bool StateDescriptor::FlagsPresent(std::vector<MetadataFlag> const &flags,
   return false;
 }
 
-void StateDescriptor::ValidateMetadata() {
-  MetadataLoop_([&](Metadata &m) {
-    auto dependency = m.Role();
-    if (dependency == Metadata::None) {
-      m.Set(Metadata::Provides);
-    }
-  });
-}
-
 std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd) {
   os << "# Package: " << sd.label() << "\n"
      << "# ---------------------------------------------------\n"
@@ -346,7 +337,6 @@ std::shared_ptr<StateDescriptor> ResolvePackages(Packages_t &packages) {
   for (auto &pair : packages.AllPackages()) {
     auto &name = pair.first;
     auto &package = pair.second;
-    package->ValidateMetadata(); // set unset flags
     // sort
     var_tracker.CategorizeCollection(name, package->AllFields(), &cvar_provider);
     for (auto &p2 : package->AllSparseFields()) { // sparse

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -98,10 +98,6 @@ class StateDescriptor {
   // retrieve number of fields
   int size() const { return metadataMap_.size(); }
 
-  // Ensure all required bits are present
-  // projective and can be called multiple times with no harm
-  void ValidateMetadata();
-
   // retrieve all field names
   std::vector<std::string> Fields() {
     std::vector<std::string> names;
@@ -232,21 +228,6 @@ class StateDescriptor {
   friend std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd);
 
  private:
-  template <typename F>
-  void MetadataLoop_(F func) {
-    for (auto &pair : metadataMap_) {
-      func(pair.second);
-    }
-    for (auto &p1 : sparseMetadataMap_) {
-      for (auto &p2 : p1.second) {
-        func(p2.second);
-      }
-    }
-    for (auto &pair : swarmMetadataMap_) {
-      func(pair.second);
-    }
-  }
-
   Params params_;
   const std::string label_;
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -54,7 +54,8 @@ void Swarm::Add(const std::vector<std::string> &labelArray, const Metadata &meta
   }
 }
 
-std::shared_ptr<Swarm> Swarm::AllocateCopy(const bool allocComms, MeshBlock *pmb) {
+std::shared_ptr<Swarm> Swarm::AllocateCopy(const bool /*alloc_separate_fluxes_and_bvar*/,
+                                           MeshBlock * /*pmb*/) {
   Metadata m = m_;
 
   auto swarm = std::make_shared<Swarm>(label(), m, nmax_pool_);

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -77,7 +77,7 @@ class Swarm {
   void SetBlockPointer(std::weak_ptr<MeshBlock> pmb) { pmy_block = pmb; }
 
   /// Make a new Swarm based on an existing one
-  std::shared_ptr<Swarm> AllocateCopy(const bool allocComms = false,
+  std::shared_ptr<Swarm> AllocateCopy(const bool alloc_separate_fluxes_and_bvar = false,
                                       MeshBlock *pmb = nullptr);
 
   /// Add variable to swarm

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -54,8 +54,8 @@ TaskStatus FluxDivergence(MeshBlockData<Real> *in, MeshBlockData<Real> *dudt_con
   const IndexRange jb = in->GetBoundsJ(interior);
   const IndexRange kb = in->GetBoundsK(interior);
 
-  const auto &vin = in->PackVariablesAndFluxes({Metadata::Independent});
-  auto dudt = dudt_cont->PackVariables({Metadata::Independent});
+  const auto &vin = in->PackVariablesAndFluxes({Metadata::WithFluxes});
+  auto dudt = dudt_cont->PackVariables({Metadata::WithFluxes});
 
   const auto &coords = pmb->coords;
   const int ndim = pmb->pmy_mesh->ndim;
@@ -72,7 +72,7 @@ template <>
 TaskStatus FluxDivergence(MeshData<Real> *in_obj, MeshData<Real> *dudt_obj) {
   const IndexDomain interior = IndexDomain::interior;
 
-  std::vector<MetadataFlag> flags({Metadata::Independent});
+  std::vector<MetadataFlag> flags({Metadata::WithFluxes});
   const auto &vin = in_obj->PackVariablesAndFluxes(flags);
   auto dudt = dudt_obj->PackVariables(flags);
   const IndexRange ib = in_obj->GetBoundsI(interior);
@@ -102,8 +102,8 @@ TaskStatus UpdateWithFluxDivergence(MeshBlockData<Real> *u0_data,
   const IndexRange jb = u0_data->GetBoundsJ(interior);
   const IndexRange kb = u0_data->GetBoundsK(interior);
 
-  auto u0 = u0_data->PackVariablesAndFluxes({Metadata::Independent});
-  const auto &u1 = u1_data->PackVariables({Metadata::Independent});
+  auto u0 = u0_data->PackVariablesAndFluxes({Metadata::WithFluxes});
+  const auto &u1 = u1_data->PackVariables({Metadata::WithFluxes});
 
   const auto &coords = pmb->coords;
   const int ndim = pmb->pmy_mesh->ndim;
@@ -123,7 +123,7 @@ TaskStatus UpdateWithFluxDivergence(MeshData<Real> *u0_data, MeshData<Real> *u1_
                                     const Real beta_dt) {
   const IndexDomain interior = IndexDomain::interior;
 
-  std::vector<MetadataFlag> flags({Metadata::Independent});
+  std::vector<MetadataFlag> flags({Metadata::WithFluxes});
   auto u0_pack = u0_data->PackVariablesAndFluxes(flags);
   const auto &u1_pack = u1_data->PackVariables(flags);
   const IndexRange ib = u0_data->GetBoundsI(interior);

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -108,7 +108,6 @@ void CellVariable<T>::AllocateFluxesAndBdryVar(std::weak_ptr<MeshBlock> wpmb) {
   // Create the boundary object
   if (IsSet(Metadata::FillGhost)) {
     if (wpmb.expired()) return;
-
     std::shared_ptr<MeshBlock> pmb = wpmb.lock();
 
     if (pmb->pmy_mesh != nullptr && pmb->pmy_mesh->multilevel) {
@@ -116,19 +115,19 @@ void CellVariable<T>::AllocateFluxesAndBdryVar(std::weak_ptr<MeshBlock> wpmb) {
                                pmb->c_cellbounds.ncellsk(IndexDomain::entire),
                                pmb->c_cellbounds.ncellsj(IndexDomain::entire),
                                pmb->c_cellbounds.ncellsi(IndexDomain::entire));
-
-      vbvar = std::make_shared<CellCenteredBoundaryVariable>(pmb, data, coarse_s, flux);
-
-      // enroll CellCenteredBoundaryVariable object
-      vbvar->bvar_index = pmb->pbval->bvars.size();
-      // TODO(JMM): This means RestrictBoundaries()
-      // is called on EVERY stage, regardless of what
-      // stage needs it.
-      // The fix is to refactor BoundaryValues
-      // to expose calls at either the `Variable`
-      // or `MeshBlockData` and `MeshData` level.
-      pmb->pbval->bvars.push_back(vbvar);
     }
+
+    vbvar = std::make_shared<CellCenteredBoundaryVariable>(pmb, data, coarse_s, flux);
+
+    // enroll CellCenteredBoundaryVariable object
+    vbvar->bvar_index = pmb->pbval->bvars.size();
+    // TODO(JMM): This means RestrictBoundaries()
+    // is called on EVERY stage, regardless of what
+    // stage needs it.
+    // The fix is to refactor BoundaryValues
+    // to expose calls at either the `Variable`
+    // or `MeshBlockData` and `MeshData` level.
+    pmb->pbval->bvars.push_back(vbvar);
   }
 
   mpiStatus = false;

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -53,11 +53,8 @@ CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wp
   std::array<int, 6> dims = {GetDim(1), GetDim(2), GetDim(3),
                              GetDim(4), GetDim(5), GetDim(6)};
 
-  // copy the Metadata and set the SharedComms flag if appropriate
+  // copy the Metadata
   Metadata m = m_;
-  if (IsSet(Metadata::FillGhost) && !allocComms) {
-    m.Set(Metadata::SharedComms);
-  }
 
   // make the new CellVariable
   auto cv = std::make_shared<CellVariable<T>>(label(), dims, m);

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -91,7 +91,7 @@ void CellVariable<T>::allocateComms(std::weak_ptr<MeshBlock> wpmb) {
   // TODO(JMM): Note that this approach assumes LayoutRight. Otherwise
   // the stride will mess up the types.
 
-  if (HasFluxes()) {
+  if (IsSet(Metadata::WithFluxes)) {
     // Compute size of unified flux_data object and create it. A unified
     // flux_data_ object reduces the number of memory allocations per
     // variable per meshblock from 5 to 3.
@@ -108,7 +108,7 @@ void CellVariable<T>::allocateComms(std::weak_ptr<MeshBlock> wpmb) {
   }
 
   // Create the boundary object
-  if (HasBoundaryVars()) {
+  if (IsSet(Metadata::FillGhost)) {
     if (wpmb.expired()) return;
 
     std::shared_ptr<MeshBlock> pmb = wpmb.lock();

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -49,7 +49,8 @@ std::string CellVariable<T>::info() {
 // copy constructor
 template <typename T>
 std::shared_ptr<CellVariable<T>>
-CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wpmb) {
+CellVariable<T>::AllocateCopy(const bool alloc_separate_fluxes_and_bvar,
+                              std::weak_ptr<MeshBlock> wpmb) {
   std::array<int, 6> dims = {GetDim(1), GetDim(2), GetDim(3),
                              GetDim(4), GetDim(5), GetDim(6)};
 
@@ -60,8 +61,8 @@ CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wp
   auto cv = std::make_shared<CellVariable<T>>(label(), dims, m);
 
   if (IsSet(Metadata::FillGhost)) {
-    if (allocComms) {
-      cv->allocateComms(wpmb);
+    if (alloc_separate_fluxes_and_bvar) {
+      cv->AllocateFluxesAndBdryVar(wpmb);
     } else {
       // set data pointer for the boundary communication
       // Note that vbvar->var_cc will be set when stage is selected
@@ -82,7 +83,7 @@ CellVariable<T>::AllocateCopy(const bool allocComms, std::weak_ptr<MeshBlock> wp
 /// allocate communication space based on info in MeshBlock
 /// Initialize a 6D variable
 template <typename T>
-void CellVariable<T>::allocateComms(std::weak_ptr<MeshBlock> wpmb) {
+void CellVariable<T>::AllocateFluxesAndBdryVar(std::weak_ptr<MeshBlock> wpmb) {
   std::string base_name = label();
 
   // TODO(JMM): Note that this approach assumes LayoutRight. Otherwise

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -38,6 +38,7 @@
 #include "defs.hpp"
 #include "interface/metadata.hpp"
 #include "parthenon_arrays.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 
@@ -53,6 +54,9 @@ class CellVariable {
         mpiStatus(false), m_(metadata),
         label_(label + (sparse_id >= 0 ? "_" + std::to_string(sparse_id) : "")),
         sparse_id_(sparse_id) {
+    PARTHENON_REQUIRE_THROWS(
+        m_.IsSet(Metadata::Real),
+        "Only Real data type is currently supported for CellVariable");
     if (m_.getAssociated() == "") {
       m_.Associate(label);
     }
@@ -63,7 +67,6 @@ class CellVariable {
                                                 std::weak_ptr<MeshBlock> wpmb = {});
 
   // accessors
-
   template <class... Args>
   KOKKOS_FORCEINLINE_FUNCTION auto &operator()(Args... args) {
     return data(std::forward<Args>(args)...);
@@ -77,9 +80,6 @@ class CellVariable {
 
   ///< retrieve metadata for variable
   inline Metadata metadata() const { return m_; }
-
-  inline bool HasFluxes() const { return m_.IsSet(Metadata::WithFluxes); }
-  inline bool HasBoundaryVars() const { return m_.IsSet(Metadata::FillGhost); }
 
   /// Get Sparse ID (-1 if not sparse)
   inline int GetSparseID() const { return sparse_id_; }

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -63,8 +63,9 @@ class CellVariable {
   }
 
   // make a new CellVariable based on an existing one
-  std::shared_ptr<CellVariable<T>> AllocateCopy(const bool allocComms = false,
-                                                std::weak_ptr<MeshBlock> wpmb = {});
+  std::shared_ptr<CellVariable<T>>
+  AllocateCopy(const bool alloc_separate_fluxes_and_bvar = false,
+               std::weak_ptr<MeshBlock> wpmb = {});
 
   // accessors
   template <class... Args>
@@ -91,8 +92,9 @@ class CellVariable {
   /// return information string
   std::string info();
 
-  /// allocate communication space based on info in MeshBlock
-  void allocateComms(std::weak_ptr<MeshBlock> wpmb);
+  /// allocate fluxes (if Metadata::WithFluxes is set) and boundary variable if
+  /// (Metadata::FillGhost is set)
+  void AllocateFluxesAndBdryVar(std::weak_ptr<MeshBlock> wpmb);
 
   /// Repoint vbvar's var_cc array at the current variable
   inline void resetBoundary() { vbvar->var_cc = data; }

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -78,6 +78,9 @@ class CellVariable {
   ///< retrieve metadata for variable
   inline Metadata metadata() const { return m_; }
 
+  inline bool HasFluxes() const { return m_.IsSet(Metadata::WithFluxes); }
+  inline bool HasBoundaryVars() const { return m_.IsSet(Metadata::FillGhost); }
+
   /// Get Sparse ID (-1 if not sparse)
   inline int GetSparseID() const { return sparse_id_; }
 

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -73,11 +73,13 @@ TEST_CASE("Can pull variables from containers based on Metadata",
     std::vector<int> scalar_shape{16, 16, 16};
     std::vector<int> vector_shape{16, 16, 16, 3};
 
-    Metadata m_in({Metadata::Independent, Metadata::FillGhost}, scalar_shape);
-    Metadata m_in_vector({Metadata::Independent, Metadata::FillGhost, Metadata::Vector},
+    Metadata m_in({Metadata::Independent, Metadata::WithFluxes, Metadata::FillGhost},
+                  scalar_shape);
+    Metadata m_in_vector({Metadata::Independent, Metadata::WithFluxes,
+                          Metadata::FillGhost, Metadata::Vector},
                          vector_shape);
-    Metadata m_out({}, scalar_shape);
-    Metadata m_out_vector({}, vector_shape);
+    Metadata m_out({Metadata::Derived}, scalar_shape);
+    Metadata m_out_vector({Metadata::Derived}, vector_shape);
 
     // Make some variables
     rc.Add("v1", m_in);
@@ -253,7 +255,8 @@ TEST_CASE("Can pull variables from containers based on Metadata",
     }
 
     WHEN("we set fluxes of independent variables") {
-      auto vf = rc.PackVariablesAndFluxes({Metadata::Independent, Metadata::FillGhost});
+      auto vf = rc.PackVariablesAndFluxes(
+          {Metadata::Independent, Metadata::WithFluxes, Metadata::FillGhost});
       par_for(
           DEFAULT_LOOP_PATTERN, "Set fluxes", DevExecSpace(), 0, vf.GetDim(4) - 1, 0,
           vf.GetDim(3) - 1, 0, vf.GetDim(2) - 1, 0, vf.GetDim(1) - 1,
@@ -290,11 +293,11 @@ TEST_CASE("Can pull variables from containers based on Metadata",
 
     WHEN("we add sparse fields") {
       Metadata m_sparse;
-      m_sparse = Metadata({Metadata::Sparse}, scalar_shape, 1);
+      m_sparse = Metadata({Metadata::Derived, Metadata::Sparse}, scalar_shape, 1);
       rc.Add("vsparse", m_sparse);
-      m_sparse = Metadata({Metadata::Sparse}, 13);
+      m_sparse = Metadata({Metadata::Derived, Metadata::Sparse}, 13);
       rc.Add("vsparse", m_sparse);
-      m_sparse = Metadata({Metadata::Sparse}, 42);
+      m_sparse = Metadata({Metadata::Derived, Metadata::Sparse}, 42);
       rc.Add("vsparse", m_sparse);
       THEN("the low and high index bounds are correct as returned by PackVariables") {
         PackIndexMap imap;
@@ -363,7 +366,8 @@ TEST_CASE("Can pull variables from containers based on Metadata",
 
     WHEN("we add a 2d variable") {
       std::vector<int> shape_2D{16, 16, 1};
-      Metadata m_in_2D({Metadata::Independent, Metadata::FillGhost}, shape_2D);
+      Metadata m_in_2D({Metadata::Independent, Metadata::WithFluxes, Metadata::FillGhost},
+                       shape_2D);
       rc.Add("v2d", m_in_2D);
       auto packw2d = rc.PackVariablesAndFluxes({"v2d"}, {"v2d"});
       THEN("The pack knows it is 2d") { REQUIRE(packw2d.GetNdim() == 2); }
@@ -390,7 +394,7 @@ TEST_CASE("Coarse variable from meshblock_data for cell variable",
     MeshBlockData<Real> rc;
     std::vector<int> block_size{nside + 2 * nghost, nside + 2 * nghost,
                                 nside + 2 * nghost};
-    Metadata m({Metadata::Independent}, block_size);
+    Metadata m({Metadata::Independent, Metadata::WithFluxes}, block_size);
     rc.Add("var", m);
     auto &var = rc.Get("var");
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Adds a `Metadata::WithFluxes` flag. Documents and enforces some constraints on Metadata flags, and fixes a potential issue where the boundary variable is accessed without checking that it exists.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
