### PR TITLE
WIP: Add AMR performance test

### DIFF
--- a/.gitlab-ci-ias.yml
+++ b/.gitlab-ci-ias.yml
@@ -10,7 +10,6 @@ before_script:
     - git submodule update
     - export OMP_NUM_THREADS=1
     - export OMP_PROC_BIND=1
-    - export OMP_NESTED=True
     - export CTEST_OUTPUT_ON_FAILURE=1
     - export J=4 && echo Using ${J} cores during build
     - export PATH=${PWD}/opt/cmake-${CMAKE_VER}-Linux-x86_64/bin:$PATH
@@ -80,6 +79,15 @@ prep-cuda:
       wget -qO- http://www.cmake.org/files/v${CMAKE_VER:0:4}/cmake-${CMAKE_VER}-Linux-x86_64.tar.gz | tar -xz;
       cd ..;
       fi
+    - if [ ! -d opt/kokkos-tools ]; then
+      cd opt;
+      git clone https://github.com/kokkos/kokkos-tools.git;
+      cd kokkos-tools;
+      git checkout develop;
+      cd profiling/space-time-stack;
+      make;
+      cd ../../../..;
+      fi
     # create our own python env as the default python3 one is incorrectly linked
     # (missing libopenblasp-r0-39a31c03.2.18.so in numpy module)
     - if [ ! -d opt/pyenv ]; then
@@ -102,20 +110,24 @@ parthenon-build-cuda:
     - mkdir build-cuda
     - cd build-cuda
     - cmake -DCMAKE_BUILD_TYPE=Release
-      -DKokkos_ENABLE_OPENMP=True -DKokkos_ARCH_SKX=True
+      -DKokkos_ARCH_SKX=True
       -DKokkos_ENABLE_CUDA=True -DKokkos_ARCH_VOLTA70=True
       -DCMAKE_CXX_COMPILER=${PWD}/../external/Kokkos/bin/nvcc_wrapper
       -DPARTHENON_DISABLE_MPI=ON
       -DPARTHENON_DISABLE_HDF5=ON
       -DNUM_MPI_PROC_TESTING=1
+      -DPARTHENON_ENABLE_INIT_PACKING=ON
       ../
     - make -j${J} advection-example
     - nvidia-smi
     - ctest -R regression_test:advection_performance --timeout 3600
+    - export KOKKOS_PROFILE_LIBRARY=${CI_PROJECT_DIR}/opt/kokkos-tools/profiling/space-time-stack/kp_space_time_stack.so
+    - ctest -R regression_test:amr_performance
   artifacts:
     when: always
     expire_in: 3 days
     paths:
       - build-cuda/CMakeFiles/CMakeOutput.log
       - build-cuda/tst/regression/outputs/advection_performance/performance.png
+      - build-cuda/tst/regression/outputs/amr_performance
 

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -48,6 +48,14 @@ list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advectio
 --num_steps 5")
 list(APPEND EXTRA_TEST_LABELS "perf-reg")
 
+# AMR Performance regression test
+list(APPEND TEST_DIRS amr_performance)
+list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
+list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
+--driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/amr_performance/parthinput.amr_performance \
+--num_steps 6")
+list(APPEND EXTRA_TEST_LABELS "perf-reg")
+
 if (ENABLE_HDF5)
 
   # h5py is needed for restart and hdff5 test

--- a/tst/regression/run_test.py
+++ b/tst/regression/run_test.py
@@ -75,6 +75,8 @@ def main(**kwargs):
 
         test_manager.Run()
 
+        test_manager.Cleanup(step)
+
     test_result = test_manager.Analyse()
 
     if test_result == True:

--- a/tst/regression/test_suites/amr_performance/amr_performance.py
+++ b/tst/regression/test_suites/amr_performance/amr_performance.py
@@ -1,0 +1,120 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2021 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+#========================================================================================
+# (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
+# Modules
+import math
+import numpy as np
+import matplotlib
+matplotlib.use('agg')
+import matplotlib.pylab as plt
+import sys
+import os
+import utils.test_case
+
+""" To prevent littering up imported folders with .pyc files or __pycache_ folder"""
+sys.dont_write_bytecode = True
+
+
+class TestCase(utils.test_case.TestCaseAbs):
+    def Prepare(self, parameters, step):
+        # making sure env variable is set to produce json output from kokkos space-time-stack
+        os.environ['KOKKOS_PROFILE_EXPORT_JSON'] = 'ON'
+        
+        msg = "Missing Kokkos profiling lib.\n"
+        msg += "Please set KOKKOS_PROFILE_LIBRARY to kp_space_time_stack.so"
+        assert parameters.kokkos_profiling_lib is not None, msg
+
+        # Profiling libraries introduce fences etc.
+        # Thus, we run once with and once without.
+        if step % 2 != 0:
+            os.unsetenv('KOKKOS_PROFILE_LIBRARY')
+
+        if step == 1 or step == 2:
+            parameters.driver_cmd_line_args = [
+                'Advection/num_vars=9',
+                'Advection/vec_size=1'
+            ]
+        elif step == 3 or step == 4:
+            parameters.driver_cmd_line_args = [
+                'Advection/num_vars=3',
+                'Advection/vec_size=3'
+            ]
+        elif step == 5 or step == 6:
+            parameters.driver_cmd_line_args = [
+                'Advection/num_vars=1',
+                'Advection/vec_size=9'
+            ]
+
+        return parameters
+
+    def Cleanup(self, parameters, step):
+        # move json output to unique location for later analysis
+        if step % 2 == 0:
+            os.rename("noname.json", "step_%d.json" % step)
+
+        with open("step_%d.out" % step,"wb") as outfile:
+            outfile.write(parameters.stdouts[-1])
+        
+        # Reset to orig environment value
+        if parameters.kokkos_profiling_lib is not None:
+            os.environ['KOKKOS_PROFILE_LIBRARY'] = parameters.kokkos_profiling_lib
+
+
+
+    def Analyse(self, parameters):
+
+        fig, p = plt.subplots(4,1, sharex=True, figsize=(4,10))
+
+        for (step, lbl) in [(1, "9 var. with 1 component "),
+                            (3, "3 var. with 3 components"),
+                            (5, "1 var. with 9 components"),
+                           ]:
+            cycle_all = []
+            for line in parameters.stdouts[step - 1].decode("utf-8").split('\n'):
+                # sample output:
+                # cycle=3 time=2.6367187499999997e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=9.16e+07 wsec_total=4.00e-01 wsec_step=8.30e-02 zone-cycles/wsec=9.16e+07 wsec_AMR=3.60e-06
+                if "cycle=" == line[:6]:
+                    cycle_current = []
+                    for vals in line.split(" "):
+                        cycle_current.append(float(vals.split("=")[-1]))
+                    cycle_all.append(cycle_current)
+
+            # convert to array and skip cycle cycle 0
+            cycle_all = np.array(cycle_all)[1:,:]
+
+            label = lbl + ": total wtime %.2f" % cycle_all[-1,4]
+            p[0].plot(cycle_all[:,0], cycle_all[:,3], label=label)
+            p[1].plot(cycle_all[:,0], cycle_all[:,5])
+            p[2].plot(cycle_all[:,0], cycle_all[:,6])
+            p[3].plot(cycle_all[:,0], cycle_all[:,7])
+
+        p[0].legend(loc="lower right", bbox_to_anchor=(1,1))
+        p[0].set_ylabel("zone-cycles/wsec_step")
+        p[1].set_ylabel("wsec_step")
+        p[2].set_ylabel("zone-cycles/wsec")
+        p[3].set_ylabel("wsec_AMR")
+        p[-1].set_xlabel("cycle #")
+
+        for i in range(4):
+            p[i].grid()
+
+        fig.tight_layout()
+
+        fig.savefig(os.path.join(parameters.output_path, "amr_performance.png"),
+                    bbox_inches='tight')
+
+        return True

--- a/tst/regression/test_suites/amr_performance/parthinput.amr_performance
+++ b/tst/regression/test_suites/amr_performance/parthinput.amr_performance
@@ -1,0 +1,75 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2021 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for detail
+# ========================================================================================
+#  (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+#
+#  This program was produced under U.S. Government contract 89233218CNA000001 for Los
+#  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+#  for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+#  in the program are reserved by Triad National Security, LLC, and the U.S. Department
+#  of Energy/National Nuclear Security Administration. The Government is granted for
+#  itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+#  license in this material to reproduce, prepare derivative works, distribute copies to
+#  the public, perform publicly and display publicly, and to permit others to do so.
+# ========================================================================================
+
+<parthenon/job>
+problem_id = advection
+
+<parthenon/mesh>
+refinement = adaptive
+numlevel = 4
+
+nx1 = 128
+x1min = -1.50
+x1max = 1.50
+ix1_bc = periodic
+ox1_bc = periodic
+
+nx2 = 128
+x2min = -1.50
+x2max = 1.50
+ix2_bc = periodic
+ox2_bc = periodic
+
+nx3 = 128
+x3min = -1.50
+x3max = 1.50
+ix3_bc = periodic
+ox3_bc = periodic
+
+<parthenon/meshblock>
+nx1 = 32
+nx2 = 32
+nx3 = 32
+
+<parthenon/time>
+tlim = 1.0
+integrator = rk1
+nlim = 10
+ncycle_out_mesh=-10
+
+<Advection>
+cfl = 0.30
+vx = 1.0
+vy = 1.0
+vz = 1.0
+profile = smooth_gaussian
+ang_2 = 0.0
+ang_3 = 0.0
+ang_2_vert = false
+ang_3_vert = false
+amp = 1.0
+
+refine_tol = 1.050    # control the package specific refinement tagging function
+derefine_tol = 1.001
+compute_error = false
+
+num_vars = 9 # number of variables
+vec_size = 1 # size of each variable
+fill_derived = false # whether to fill one-copy test vars
+buffer_send_pack = true  # send all buffers using packs
+buffer_recv_pack = true  # receive buffers using packs
+buffer_set_pack =  true  # set received buffers using packs


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This test reflects the test case we used during the hackathon, i.e., 32^3 blocks with the following "evolution":
```
cycle=0 time=0.0000000000000000e+00 dt=8.7890624999999991e-04 zone-cycles/wsec_step=0.00e+00 wsec_total=5.54e-03 wsec_step=5.47e+00 zone-cycles/wsec=0.00e+00 wsec_AMR=0.00e+00
---------------------- Current Mesh structure ----------------------
Root grid = 4 x 4 x 4 MeshBlocks
Total number of MeshBlocks = 232
Number of physical refinement levels = 3
Number of logical  refinement levels = 5
  Physical level = 0 (logical level = 2): 56 MeshBlocks, cost = 56
  Physical level = 1 (logical level = 3): 56 MeshBlocks, cost = 56
  Physical level = 2 (logical level = 4): 56 MeshBlocks, cost = 56
  Physical level = 3 (logical level = 5): 64 MeshBlocks, cost = 64
--------------------------------------------------------------------
cycle=1 time=8.7890624999999991e-04 dt=8.7890624999999991e-04 zone-cycles/wsec_step=8.69e+06 wsec_total=8.81e-01 wsec_step=8.75e-01 zone-cycles/wsec=8.69e+06 wsec_AMR=2.03e-05
cycle=2 time=1.7578124999999998e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.20e+07 wsec_total=1.52e+00 wsec_step=6.35e-01 zone-cycles/wsec=1.20e+07 wsec_AMR=1.14e-05
cycle=3 time=2.6367187499999997e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.20e+07 wsec_total=2.15e+00 wsec_step=6.33e-01 zone-cycles/wsec=1.20e+07 wsec_AMR=6.23e-06
cycle=4 time=3.5156249999999997e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.21e+07 wsec_total=2.78e+00 wsec_step=6.29e-01 zone-cycles/wsec=1.21e+07 wsec_AMR=4.82e-06
cycle=5 time=4.3945312500000000e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.17e+07 wsec_total=3.43e+00 wsec_step=6.48e-01 zone-cycles/wsec=1.17e+07 wsec_AMR=1.79e-05
cycle=6 time=5.2734375000000003e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.20e+07 wsec_total=4.06e+00 wsec_step=6.33e-01 zone-cycles/wsec=1.20e+07 wsec_AMR=4.91e-06
cycle=7 time=6.1523437500000007e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.21e+07 wsec_total=9.03e+00 wsec_step=6.30e-01 zone-cycles/wsec=1.53e+06 wsec_AMR=4.34e+00
-------------- New Mesh structure after (de)refinement -------------
Root grid = 4 x 4 x 4 MeshBlocks
Total number of MeshBlocks = 484
Number of physical refinement levels = 3
Number of logical  refinement levels = 5
  Physical level = 0 (logical level = 2): 44 MeshBlocks, cost = 44
  Physical level = 1 (logical level = 3): 140 MeshBlocks, cost = 140
  Physical level = 2 (logical level = 4): 140 MeshBlocks, cost = 140
  Physical level = 3 (logical level = 5): 160 MeshBlocks, cost = 160
--------------------------------------------------------------------
cycle=8 time=7.0312500000000010e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=9.08e+06 wsec_total=1.08e+01 wsec_step=1.75e+00 zone-cycles/wsec=9.08e+06 wsec_AMR=1.80e-05
cycle=9 time=7.9101562500000014e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.17e+07 wsec_total=1.21e+01 wsec_step=1.35e+00 zone-cycles/wsec=1.17e+07 wsec_AMR=1.86e-05
cycle=10 time=8.7890625000000017e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=1.17e+07 wsec_total=1.35e+01 wsec_step=1.35e+00 zone-cycles/wsec=1.17e+07 wsec_AMR=1.88e-05
```

The resulting plot currently looks like:

![amr_performance](https://user-images.githubusercontent.com/22685568/120014882-e034c180-bfe2-11eb-95ae-3ee6782dde1e.png)

(unfortunately the IAS CI machine has "no space left on device", which I cannot fix directly).

Right now, the all the kernel  and region data is also collected (i.e., there will be json files in the output directory) but not being processed.
I'll add that next week along with a little doc (especially with respect to the Kokkos profiling tools that are now required here).

Nevertheless, I'm already happy to get some early feedback.
Wanted to get this out also for comparing performance of #508 


Finally, already thinking ahead @JoshuaSBrown 
I used the following script to create the plot in #508 to compare the performance across results taken from different runs and could imagine sth along those lines being integrated in the performance app (also including CPU runs).

```python


path_commits = [
    ('/mnt/home/gretephi/tmp-perf-data', 'develop'),
    ('/mnt/home/gretephi/src/parthenon-fork/build-cuda/tst/regression/outputs/amr_performance', 'unify restrict.')
]

num_rows = 4
num_cols = 3
fig, p = plt.subplots(num_rows, num_cols, sharex=True, sharey="row", figsize=(10,10))

for path, commit in path_commits:

    for i, (step, lbl) in enumerate([(1, "9 var. with 1 component "),
                                     (3, "3 var. with 3 components"),
                                     (5, "1 var. with 9 components"),
                       ]):
        with open(path + "/step_%d.out" % (step), "rb") as infile:
            cycle_all = []
            for line in infile.readlines():
                line = line.decode("utf-8")
                # sample output:
                # cycle=3 time=2.6367187499999997e-03 dt=8.7890624999999991e-04 zone-cycles/wsec_step=9.16e+07 wsec_total=4.00e-01 wsec_step=8.30e-02 zone-cycles/wsec=9.16e+07 wsec_AMR=3.60e-06
                if "cycle=" == line[:6]:
                    cycle_current = []
                    for vals in line.split(" "):
                        cycle_current.append(float(vals.split("=")[-1]))
                    cycle_all.append(cycle_current)

        # convert to array and skip cycle cycle 0
        cycle_all = np.array(cycle_all)[1:,:]

        label = commit + ": tot wtime %.2f" % cycle_all[-1,4]
        p[0, i].plot(cycle_all[:,0], cycle_all[:,3], label=label)
        p[1, i].plot(cycle_all[:,0], cycle_all[:,5])
        p[2, i].plot(cycle_all[:,0], cycle_all[:,6])
        p[3, i].plot(cycle_all[:,0], cycle_all[:,7])
        
        p[0, i].set_title(lbl)

p[0,0].set_ylabel("zone-cycles/wsec_step")
p[1,0].set_ylabel("wsec_step")
p[2,0].set_ylabel("zone-cycles/wsec")
p[3,0].set_ylabel("wsec_AMR")

for j in range(num_cols):
    p[-1,j].set_xlabel("cycle #")
    p[0,j].legend(fontsize=8)
    for i in range(num_rows):
        p[i,j].grid()

fig.tight_layout()

```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
