### PR TITLE
fix coarse buffer vs amr incompatibility. Resolves issue #537.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [[PR 522]](https://github.com/lanl/parthenon/pull/522) Corrected ordering of `OutputDatasetNames` to match `ComponentNames`
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 537]](https://github.com/lanl/parthenon/pull/538) Fix inconsistent treatment of coarse buffers.
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.
 - [[PR 531]](https://github.com/lanl/parthenon/pull/531) Work around in parthenon_hdf5.cpp for GCC 7.3.0
 

--- a/docs/interface/Metadata.md
+++ b/docs/interface/Metadata.md
@@ -96,9 +96,11 @@ exclusive and required. All variables should be either independent or
 derived.
 
 - `Metadata::Independent` implies the variable is part of independent
-  state
+  state. In particular, implies data is in restart files 
+  and is prolongated/restricted during remeshing. 
+  Buffers for a coarse grid are allocated for independent variables.
 - `Metadata::Derived` implies the variable can be calculated, given
-  the independent state
+  the independent state. This is the default.
 
 ### Communication
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -73,7 +73,7 @@
   /** Real-valued quantity */                                                            \
   PARTHENON_INTERNAL_FOR_FLAG(Real)                                                      \
   /************************************************/                                     \
-  /** INDEPENDENT: Exactly one must be specified (default is Independent) */             \
+  /** INDEPENDENT: Exactly one must be specified (default is Derived) */                 \
   /** is an independent, evolved variable */                                             \
   PARTHENON_INTERNAL_FOR_FLAG(Independent)                                               \
   /** is a derived quantity (ignored) */                                                 \
@@ -206,7 +206,7 @@ class Metadata {
       DoBit(Real, true);
     }
     if (CountSet({Independent, Derived}) == 0) {
-      DoBit(Independent, true);
+      DoBit(Derived, true);
     }
 
     // check if all flag constraints are satisfied, throw if not

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -157,16 +157,22 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   }
 
   // TODO(jdolence): Should these loops be moved to Variable creation
+  // TODO(JMM): What variables should be in vars_cc_? They are used
+  // for counting load-balance cost. Should it be different than the
+  // variables used for refinement?
   MeshBlockDataIterator<Real> ci(real_container, {Metadata::FillGhost});
   int nindependent = ci.vars.size();
   for (int n = 0; n < nindependent; n++) {
-    RegisterMeshBlockData(ci.vars[n]);
+    // These are used for approximating number of vars registered for refinement
+    // for the purposes of computing load balancing work
+    RegisterMeshBlockData(ci.vars[n]); 
   }
 
   if (pm->multilevel) {
     pmr = std::make_unique<MeshRefinement>(shared_from_this(), pin);
     // This is very redundant, I think, but necessary for now
     for (int n = 0; n < nindependent; n++) {
+      // These are used for doing refinement
       pmr->AddToRefinement(ci.vars[n]->data, ci.vars[n]->coarse_s);
     }
   }

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -160,7 +160,17 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   // TODO(JMM): What variables should be in vars_cc_? They are used
   // for counting load-balance cost. Should it be different than the
   // variables used for refinement?
-  MeshBlockDataIterator<Real> ci(real_container, {Metadata::FillGhost});
+  // Should we even have both of these arrays? Are they both necessary?
+
+  // TODO(JMM): In principal this should be `Metadata::Independent`
+  // only. However, I am making it `Metadata::Independent` OR
+  // `Metadata::FillGhost` to work around the old Athena++
+  // `bvals_refine` machinery. When this machinery is completely
+  // removed, which can happen after dense-on-block for sparse
+  // variables is in place and after we write "prolongate-in-one,"
+  // this should be only for `Metadata::Independent`.
+  MeshBlockDataIterator<Real> ci(real_container,
+                                 {Metadata::Independent, Metadata::FillGhost}, true);
   int nindependent = ci.vars.size();
   for (int n = 0; n < nindependent; n++) {
     // These are used for approximating number of vars registered for refinement

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -165,7 +165,7 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   for (int n = 0; n < nindependent; n++) {
     // These are used for approximating number of vars registered for refinement
     // for the purposes of computing load balancing work
-    RegisterMeshBlockData(ci.vars[n]); 
+    RegisterMeshBlockData(ci.vars[n]);
   }
 
   if (pm->multilevel) {

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -157,7 +157,7 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   }
 
   // TODO(jdolence): Should these loops be moved to Variable creation
-  MeshBlockDataIterator<Real> ci(real_container, {Metadata::Independent});
+  MeshBlockDataIterator<Real> ci(real_container, {Metadata::FillGhost});
   int nindependent = ci.vars.size();
   for (int n = 0; n < nindependent; n++) {
     RegisterMeshBlockData(ci.vars[n]);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Resolves #537 . In recent metadata updates, we decided variables should only contain coarse buffers if `FillGhost` is set. However, mesh refinement is currently performed if a variable is `Independent`. This causes segfaults. This PR changes the relevant metadata flag for adding variables to the mesh refinement.

There is an open question here about how we should count variables for load-balancing, as these don't need to be the same as the variables for `var_cc_`. I have left them the same for now, as that appears to be an assumption in `amr_loadbalance.cpp` but I'm not sure that's correct in general.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
