### PR TITLE
Fix restart bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [[PR 522]](https://github.com/lanl/parthenon/pull/522) Corrected ordering of `OutputDatasetNames` to match `ComponentNames`
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 539]](https://github.com/lanl/parthenon/pull/539) Fix restart indexing/hdf5 bugs
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.
 - [[PR 531]](https://github.com/lanl/parthenon/pull/531) Work around in parthenon_hdf5.cpp for GCC 7.3.0
 

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -151,7 +151,7 @@ void ParthenonManager::ParthenonInitPackagesAndMesh() {
 
     // close hdf5 file to prevent HDF5 hangs and corrupted files
     // if code dies after restart
-    this->restartReader = nullptr;
+    restartReader = nullptr;
   }
 
   // add root_level to all max_level

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -255,7 +255,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
           for (int k = out_kb.s; k <= out_kb.e; ++k) {
             for (int j = out_jb.s; j <= out_jb.e; ++j) {
               for (int i = out_ib.s; i <= out_ib.e; ++i) {
-                for (int l = 0; l < vlen; ++l) {
+		      for (int l = 0; l < v_h.GetDim(4); ++l) {
                   v_h(l, k, j, i) = tmp[index++];
                 }
               }

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -148,6 +148,10 @@ void ParthenonManager::ParthenonInitPackagesAndMesh() {
 
     // Read package data from restart file
     RestartPackages(*pmesh, *restartReader);
+
+    // close hdf5 file to prevent HDF5 hangs and corrupted files
+    // if code dies after restart
+    this->restartReader = nullptr; 
   }
 
   // add root_level to all max_level

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -161,14 +161,12 @@ void ParthenonManager::ParthenonInitPackagesAndMesh() {
     }
   }
 
-  pmesh->Initialize(!Restart(), pinput.get(), app_input.get());
+  pmesh->Initialize(!IsRestart(), pinput.get(), app_input.get());
 
   ChangeRunDir(arg.prundir);
 }
 
 ParthenonStatus ParthenonManager::ParthenonFinalize() {
-  // close restart file before finalizing MPI
-  this->restartReader = nullptr;
   pmesh.reset();
   Kokkos::finalize();
 #ifdef MPI_PARALLEL

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -151,7 +151,7 @@ void ParthenonManager::ParthenonInitPackagesAndMesh() {
 
     // close hdf5 file to prevent HDF5 hangs and corrupted files
     // if code dies after restart
-    this->restartReader = nullptr; 
+    this->restartReader = nullptr;
   }
 
   // add root_level to all max_level
@@ -255,7 +255,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
           for (int k = out_kb.s; k <= out_kb.e; ++k) {
             for (int j = out_jb.s; j <= out_jb.e; ++j) {
               for (int i = out_ib.s; i <= out_ib.e; ++i) {
-		      for (int l = 0; l < v_h.GetDim(4); ++l) {
+                for (int l = 0; l < v_h.GetDim(4); ++l) {
                   v_h(l, k, j, i) = tmp[index++];
                 }
               }

--- a/src/parthenon_manager.hpp
+++ b/src/parthenon_manager.hpp
@@ -38,7 +38,7 @@ class ParthenonManager {
   void ParthenonInitPackagesAndMesh();
   ParthenonStatus ParthenonFinalize();
 
-  bool Restart() { return (arg.restart_filename == nullptr ? false : true); }
+  bool IsRestart() { return (arg.restart_filename == nullptr ? false : true); }
   static Packages_t ProcessPackagesDefault(std::unique_ptr<ParameterInput> &pin);
   void RestartPackages(Mesh &rm, RestartReader &resfile);
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Downstream, I tried to restart a simulation in Phoebus, and got a very cryptic segfault. I found two issues causing the problem:
1. One loop bound was wrong---Parthenon is currently looping over the *max* number of vector elements in all variables. It should loop over the number of elements in a *given* variable.
2. Obfuscating the issue, if the code crashes, because the HDF5 file is not closed, hdf5 errors can pollute the output *and* corrupt the restart file. I found this even causes a problem in the advection example, where sometimes the restart would just hang for certain combinations of gcc and hdf5 versions.

In this PR, I fix the loop bounds and I call the destructor for the restart reader after reading is finished, which closes the HDF5 file.

To catch this in the future, I recommend we have an integration test where we restart with variables of different sizes. However, that's a bigger lift than this little bug fix, and this bug is blocking functionality. I would recommend we get this in, and I will create an issue that that reminds us to put in a test at a later date.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
