### PR TITLE
[WIP] Attempt to create artifact in repo containing python install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ compile_commands.jsonbin
 # Files created by bad CMake hygiene
 a.out
 cmake_hdf5_test.o
+
+# CI artifacts folder
+artifacts

--- a/.gitlab-ci-darwin.yml
+++ b/.gitlab-ci-darwin.yml
@@ -24,7 +24,7 @@ stages:
       ${CI_JOB_URL}
       ${CI_JOB_TOKEN}
       ${BUILD_TARGET_BRANCH}
-      ${CI_PROJECT_DIR}/../python_scripts
+      ${CI_PROJECT_DIR}/artifacts
       ${CMAKE_BUILD_TYPE} > ${EXECUTABLE}
 - cp ${EXECUTABLE} ../
 
@@ -57,6 +57,10 @@ stages:
     - *run-script-with-check
     - git checkout ${CI_COMMIT_BRANCH}
     - git pull origin ${CI_COMMIT_BRANCH}
+  artifacts:
+    paths:
+      - ${CI_PROJECT_DIR}/artifacts
+    expire_in: 1 day
 
 .gcc-mpi-cuda-performance-regression-build:
   variables:
@@ -68,7 +72,7 @@ stages:
     - *run-script-with-check
   artifacts:
     paths:
-      - ${CI_PROJECT_DIR}
+      - ${CI_PROJECT_DIR}/artifacts
     expire_in: 1 day
 
 .gcc-mpi-cuda-performance-regression-metrics:
@@ -79,6 +83,10 @@ stages:
   script:
     - *print-copy-executable
     - *run-script-with-check
+  artifacts:
+    paths:
+      - ${CI_PROJECT_DIR}/artifacts
+    expire_in: 1 day
 
 .gcc-mpi-cuda-performance-regression-target-branch:
   variables:
@@ -88,6 +96,10 @@ stages:
   script:
     - *print-copy-executable
     - *run-script-with-check
+  artifacts:
+    paths:
+      - ${CI_PROJECT_DIR}/artifacts
+    expire_in: 1 day
 
 ########################################################################
 # Manual Jobs


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
This pr is designed to fix the issue of persistent temporary files within the jobs of a ci pipeline. To do this an artifacts folder has been added to gitignore. This artifacts folder can be created within the repository during a ci run. Files that are needed throughout the pipeline can be specified as artifacts within this folder. 

Hopefully, this will fix the problem we currently have. Currently, python scripts are installed outside of the repo. This was done because git failing during the course of the ci (switching branches within ci) if files within the repo were changed. Hence the python scripts were installed outside of the repository. However, gitlab artifacts are only allowed for files and folders that exist within the repository, hence this attempt at a solution. 

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
