### PR TITLE
Hotfix to make particles compile without MPI again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [[PR 522]](https://github.com/lanl/parthenon/pull/522) Corrected ordering of `OutputDatasetNames` to match `ComponentNames`
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 551]](https://github.com/lanl/parthenon/pull/551) Hotfix to make particles compile without MPI again
 - [[PR 537]](https://github.com/lanl/parthenon/pull/538) Fix inconsistent treatment of coarse buffers.
 - [[PR 539]](https://github.com/lanl/parthenon/pull/539) Fix restart indexing/hdf5 bugs
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -386,6 +386,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
 // TODO(BRR) Should this be a Swarm method?
 TaskStatus InitializeCommunicationMesh(const BlockList_t &blocks) {
   // Boundary transfers on same MPI proc are blocking
+#ifdef MPI_PARALLEL
   for (auto &block : blocks) {
     auto &pmb = block;
     auto swarm = pmb->swarm_data.Get()->Get("my particles");
@@ -394,17 +395,7 @@ TaskStatus InitializeCommunicationMesh(const BlockList_t &blocks) {
       swarm->vbswarm->bd_var_.req_send[nb.bufid] = MPI_REQUEST_NULL;
     }
   }
-
-  for (auto &block : blocks) {
-    auto &pmb = block;
-    auto sc = pmb->swarm_data.Get();
-    auto swarm = sc->Get("my particles");
-
-    for (int n = 0; n < swarm->vbswarm->bd_var_.nbmax; n++) {
-      auto &nb = pmb->pbval->neighbor[n];
-      swarm->vbswarm->bd_var_.flag[nb.bufid] = BoundaryStatus::waiting;
-    }
-  }
+#endif
 
   // Reset boundary statuses
   for (auto &block : blocks) {

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -325,6 +325,7 @@ TaskStatus Defrag(MeshBlock *pmb) {
 // Mark all MPI requests as NULL / initialize boundary flags.
 TaskStatus InitializeCommunicationMesh(const BlockList_t &blocks) {
   // Boundary transfers on same MPI proc are blocking
+#ifdef MPI_PARALLEL
   for (auto &block : blocks) {
     auto swarm = block->swarm_data.Get()->Get("tracers");
     for (int n = 0; n < block->pbval->nneighbor; n++) {
@@ -332,23 +333,14 @@ TaskStatus InitializeCommunicationMesh(const BlockList_t &blocks) {
       swarm->vbswarm->bd_var_.req_send[nb.bufid] = MPI_REQUEST_NULL;
     }
   }
-
-  for (auto &block : blocks) {
-    auto &pmb = block;
-    auto sc = pmb->swarm_data.Get();
-    auto swarm = sc->Get("tracers");
-
-    for (int n = 0; n < swarm->vbswarm->bd_var_.nbmax; n++) {
-      auto &nb = pmb->pbval->neighbor[n];
-      swarm->vbswarm->bd_var_.flag[nb.bufid] = BoundaryStatus::waiting;
-    }
-  }
+#endif
 
   // Reset boundary statuses
   for (auto &block : blocks) {
     auto &pmb = block;
     auto sc = pmb->swarm_data.Get();
     auto swarm = sc->Get("tracers");
+
     for (int n = 0; n < swarm->vbswarm->bd_var_.nbmax; n++) {
       auto &nb = pmb->pbval->neighbor[n];
       swarm->vbswarm->bd_var_.flag[nb.bufid] = BoundaryStatus::waiting;

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -478,6 +478,8 @@ TaskStatus StopCommunicationMesh(const BlockList_t &blocks) {
     num_sent_local += swarm->num_particles_sent_;
   }
 
+  int num_sent_global = num_sent_local; // potentially overwritte by following Allreduce
+#ifdef MPI_PARALLEL
   for (auto &block : blocks) {
     auto swarm = block->swarm_data.Get()->Get("my particles");
     for (int n = 0; n < block->pbval->nneighbor; n++) {
@@ -497,8 +499,8 @@ TaskStatus StopCommunicationMesh(const BlockList_t &blocks) {
     }
   }
 
-  int num_sent_global = 0;
   MPI_Allreduce(&num_sent_local, &num_sent_global, 1, MPI_INT, MPI_SUM, MPI_COMM_WORLD);
+#endif // MPI_PARALLEL
 
   if (num_sent_global == 0) {
     for (auto &block : blocks) {

--- a/src/bvals/bvals_swarm.cpp
+++ b/src/bvals/bvals_swarm.cpp
@@ -110,7 +110,7 @@ void BoundarySwarm::Send(BoundaryCommSubset phase) {
         if (bd_var_.send[nb.bufid].extent(0) >
             ptarget_bswarm->bd_var_.recv[nb.targetid].extent(0)) {
           ptarget_bswarm->bd_var_.recv[nb.targetid] =
-              ParArray1D<Real>("Buffer", (bd_var_.send[nb.bufid].extent(0)));
+              BufArray1D<Real>("Buffer", (bd_var_.send[nb.bufid].extent(0)));
         }
 
         target_block.deep_copy(ptarget_bswarm->bd_var_.recv[nb.targetid],

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -108,7 +108,6 @@ void Swarm::Add(const std::string &label, const Metadata &metadata) {
                                 " already enrolled during Add()!");
   }
 
-  int vec_type;
   if (metadata.Type() == Metadata::Integer) {
     Add_<int>(label);
   } else if (metadata.Type() == Metadata::Real) {
@@ -722,7 +721,7 @@ int Swarm::CountParticlesToSend_() {
     // Resize buffer if too small
     auto sendbuf = vbswarm->bd_var_.send[n];
     if (sendbuf.extent(0) < num_particles_to_send_h(n) * particle_size) {
-      sendbuf = ParArray1D<Real>("Buffer", num_particles_to_send_h(n) * particle_size);
+      sendbuf = BufArray1D<Real>("Buffer", num_particles_to_send_h(n) * particle_size);
       vbswarm->bd_var_.send[n] = sendbuf;
     }
     vbswarm->send_size[n] = num_particles_to_send_h(n) * particle_size;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixing non-MPI builds with particles and HostCommBuffer support.

Note, that the removed for loop was present twice back-to-back in those function (if I didn't miss anything)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
