### PR TITLE
Add missing fstream include to particle_leapfrog example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [[PR 522]](https://github.com/lanl/parthenon/pull/522) Corrected ordering of `OutputDatasetNames` to match `ComponentNames`
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 552]](https://github.com/lanl/parthenon/pull/552) Fix missing include for fstream
 - [[PR 537]](https://github.com/lanl/parthenon/pull/538) Fix inconsistent treatment of coarse buffers.
 - [[PR 539]](https://github.com/lanl/parthenon/pull/539) Fix restart indexing/hdf5 bugs
 - [[PR 487]](https://github.com/lanl/parthenon/pull/487) Add default tiling matching `i` index range to MDRange loop pattern.

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -23,6 +23,7 @@
 #include <iomanip>
 #include <ios>
 #include <iostream>
+#include <fstream>
 #include <limits>
 #include <memory>
 #include <string>

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -20,10 +20,10 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <fstream>
 #include <iomanip>
 #include <ios>
 #include <iostream>
-#include <fstream>
 #include <limits>
 #include <memory>
 #include <string>


### PR DESCRIPTION
## PR Summary

The particle_leapfrog example uses std::ofstream to create a file but doesn't do `#include <fstream>`, which is a problem at least with gcc 8.3 for some configurations.

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
