### PR TITLE
Avoid use of variable named restrict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 553]](https://github.com/lanl/parthenon/pull/553) Avoid use of variable named restrict
 - [[PR 476]](https://github.com/lanl/parthenon/pull/476) Update min. `CMake` version to 3.16 (matching `Kokkos`) and add option to compile with C++17 (`PARTHENON_ENABLE_CPP17` - default: off)
 - [[PR 532]](https://github.com/lanl/parthenon/pull/532) Remove obsolete `Properties_t`, they have been replaced by `Packages_t`
 - [[PR 508]](https://github.com/lanl/parthenon/pull/508) Modify `RestrictCellCenteredVariables` to support a restriction over meshblock packs.

--- a/src/bvals/bvals_refine.cpp
+++ b/src/bvals/bvals_refine.cpp
@@ -130,7 +130,7 @@ void BoundaryValues::FillRestrictionMetadata(cell_centered_bvars::BufferCacheHos
           info(idx).coarse_coords = pmb->pmr->coarse_coords;
           info(idx).fine = fine;
           info(idx).coarse = coarse;
-          info(idx).restrict = true;
+          info(idx).restriction = true;
           info(idx).Nv = Nv;
           idx++;
         }

--- a/src/bvals/cc/bvals_cc_in_one.cpp
+++ b/src/bvals/cc/bvals_cc_in_one.cpp
@@ -342,7 +342,7 @@ void ResetSendBufferBoundaryInfo(MeshData<Real> *md, size_t buffers_used) {
 
             auto &coarse_buf = v->vbvar->coarse_buf;
             boundary_info_h(b).var = coarse_buf.Get<4>();
-            boundary_info_h(b).restrict = true;
+            boundary_info_h(b).restriction = true;
 
           } else {
             CalcIndicesLoadToFiner(si, ei, sj, ej, sk, ek, nb, pmb.get());

--- a/src/bvals/cc/bvals_cc_in_one.hpp
+++ b/src/bvals/cc/bvals_cc_in_one.hpp
@@ -52,7 +52,7 @@ struct BndInfo {
   int sk = 0;
   int ek = 0;
   int Nv = 0;
-  bool restrict = false;
+  bool restriction = false;
   Coordinates_t coords, coarse_coords; // coords
   parthenon::BufArray1D<Real> buf;     // comm buffer
   parthenon::ParArray4D<Real> var;     // data variable used for comms

--- a/src/mesh/mesh_refinement.cpp
+++ b/src/mesh/mesh_refinement.cpp
@@ -87,7 +87,7 @@ void MeshRefinement::RestrictCellCenteredValues(const ParArrayND<Real> &fine,
       info_h(b).sk = csk;
       info_h(b).ek = cek;
       info_h(b).Nv = nvars;
-      info_h(b).restrict = true;
+      info_h(b).restriction = true;
       info_h(b).coords = pmb->coords;
       info_h(b).coarse_coords = this->coarse_coords;
       info_h(b).fine = fine.Get(l, m);

--- a/src/mesh/refinement_cc_in_one.cpp
+++ b/src/mesh/refinement_cc_in_one.cpp
@@ -42,7 +42,7 @@ void Restrict(cell_centered_bvars::BufferCache_t &info, IndexShape &cellbounds,
         DEFAULT_OUTER_LOOP_PATTERN, "RestrictCellCenteredValues3d", DevExecSpace(),
         scratch_size_in_bytes, scratch_level, 0, nbuffers - 1,
         KOKKOS_LAMBDA(team_mbr_t team_member, const int buf) {
-          if (info(buf).restrict) {
+          if (info(buf).restriction) {
             par_for_inner(
                 inner_loop_pattern_ttr_tag, team_member, 0, info(buf).Nv - 1,
                 info(buf).sk, info(buf).ek, info(buf).sj, info(buf).ej, info(buf).si,
@@ -83,7 +83,7 @@ void Restrict(cell_centered_bvars::BufferCache_t &info, IndexShape &cellbounds,
         DEFAULT_OUTER_LOOP_PATTERN, "RestrictCellCenteredValues2d", DevExecSpace(),
         scratch_size_in_bytes, scratch_level, 0, nbuffers - 1,
         KOKKOS_LAMBDA(team_mbr_t team_member, const int buf) {
-          if (info(buf).restrict) {
+          if (info(buf).restriction) {
             const int k = kb.s;
             par_for_inner(inner_loop_pattern_ttr_tag, team_member, 0, info(buf).Nv - 1,
                           info(buf).sj, info(buf).ej, info(buf).si, info(buf).ei,
@@ -115,7 +115,7 @@ void Restrict(cell_centered_bvars::BufferCache_t &info, IndexShape &cellbounds,
         DEFAULT_OUTER_LOOP_PATTERN, "RestrictCellCenteredValues1d", DevExecSpace(),
         scratch_size_in_bytes, scratch_level, 0, nbuffers - 1,
         KOKKOS_LAMBDA(team_mbr_t team_member, const int buf) {
-          if (info(buf).restrict) {
+          if (info(buf).restriction) {
             const int ck = ckb.s;
             const int cj = cjb.s;
             const int k = kb.s;


### PR DESCRIPTION

## PR Summary

The variable named `restrict` in the `BndInfo` struct is not accepted by nvc++ which treats this as a reserved keyword. Since this is likely a not-uncommon problem, my recommendation is just to change the name to `restriction` or something like that.

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
