### PR TITLE
Add EstimateTimestep to particles example task list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 564]](https://github.com/lanl/parthenon/pull/564) Add EstimateTimestep to particles example task list
 - [[PR 557]](https://github.com/lanl/parthenon/pull/557) Re-enable `InitMeshBlockUserData` so data can be set per-remeshing
 - [[PR 509]](https://github.com/lanl/parthenon/pull/509) Add `elapsed_main`, `elapsed_cycle`, and `elapsed_LBandAMR` functions to `Driver` as static functions to enable access to timing information in output and restart files.
 - [[PR 479]](https://github.com/lanl/parthenon/pull/479) Add `Update` function to `Params` to update the value of an existing key.

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -96,7 +96,6 @@ Real EstimateTimestepBlock(MeshBlockData<Real> *rc) {
   auto pmb = rc->GetBlockPointer();
   auto pkg = pmb->packages.Get("particles_package");
   const Real &dt = pkg->Param<Real>("const_dt");
-  printf("dt: %e\n", dt);
   return dt;
 }
 
@@ -598,8 +597,8 @@ TaskCollection ParticleDriver::MakeFinalizationTaskCollection() const {
     auto defrag = tl.AddTask(deposit_particles, Defrag, pmb.get());
 
     // estimate next time step
-    auto new_dt =
-        tl.AddTask(defrag, parthenon::Update::EstimateTimestep<MeshBlockData<Real>>, sc1.get());
+    auto new_dt = tl.AddTask(
+        defrag, parthenon::Update::EstimateTimestep<MeshBlockData<Real>>, sc1.get());
   }
 
   return tc;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

I must have forgotten to enroll `EstimateTimestep` in the task list for the `example/particles/` example -- this leads to the timestep growing exponentially until the end of the simulation. This small PR fixes that. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
