### PR TITLE
fix meshblock pack issues coming from template shadowing and add a test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [[PR 522]](https://github.com/lanl/parthenon/pull/522) Corrected ordering of `OutputDatasetNames` to match `ComponentNames`
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 572]](https://github.com/lanl/parthenon/pull/572) Fix meshblockpack issue coming from variatic template shadowing
 - [[PR 551]](https://github.com/lanl/parthenon/pull/551) Hotfix to make particles compile without MPI again
 - [[PR 552]](https://github.com/lanl/parthenon/pull/552) Fix missing include for fstream
 - [[PR 537]](https://github.com/lanl/parthenon/pull/538) Fix inconsistent treatment of coarse buffers.

--- a/example/calculate_pi/calculate_pi.cpp
+++ b/example/calculate_pi/calculate_pi.cpp
@@ -168,10 +168,17 @@ TaskStatus ComputeArea(std::shared_ptr<MeshData<Real>> &md, ParArrayHost<Real> a
   bool const use_sparse =
       md->GetMeshPointer()->packages.Get("calculate_pi")->Param<bool>("use_sparse");
 
+  PackIndexMap imap;            // PackIndex map can be used to get the index in
+                                // a pack of a specific variable
+  std::vector<std::string> key; // The key is a hash used for caching
+                                // packs. You shouldn't need to use
+                                // it, but it is accessible.
+  // This call signature works
   const auto &pack = use_sparse
                          ? md->PackVariables(std::vector<std::string>({"in_or_out"}),
-                                             std::vector<int>{0})
+                                             std::vector<int>{0}, imap, key)
 
+                         // and so does this one
                          : md->PackVariables(std::vector<std::string>({"in_or_out"}));
 
   areas(i) = use_sparse ? ComputeAreaInternal(


### PR DESCRIPTION

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Downstream, @brryan noticed that calls to `MeshData::PackVariables` with a `PackIndexMap`, for example
```C++
// MeshData *rc defined above
PackIndexMap imap;
rc->PackVariables(names, imap);
```
cause compile-time errors. The issue was introduced in the sparse interface update, #535 , where this machinery changed significantly. In short, in that update, explicit overloads were replaced with variatic templates. Unfortunately, C++ does not resolve these templates appropriately, and they shadow each other, causing bugs. We didn't catch this until now because templated functions are optimized out if they're not called.

This MR resolves #570 . I replace the variatics with explicit overloads again, with a few changes to reduce line number as best I can. I also add a call to this machinery in the calculate pi example, so this issue should be caught by regression tests in the future.

Note that the full regression test suite is currently failing. (See #571 ). So we should either merge this in without triggering the full suite on the CI, or we should wait for #571 to be resolved. I lean towards the former. Thoughts? 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
