### PR TITLE
Update invalid indices to allow for no-op loops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 577]](https://github.com/lanl/parthenon/pull/577) Update invalid indices to allow for no-op loops
 - [[PR 564]](https://github.com/lanl/parthenon/pull/564) Add EstimateTimestep to particles example task list
 - [[PR 557]](https://github.com/lanl/parthenon/pull/557) Re-enable `InitMeshBlockUserData` so data can be set per-remeshing
 - [[PR 509]](https://github.com/lanl/parthenon/pull/509) Add `elapsed_main`, `elapsed_cycle`, and `elapsed_LBandAMR` functions to `Driver` as static functions to enable access to timing information in output and restart files.

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -106,7 +106,7 @@ class PackIndexMap {
   // It will silently return invalid indices if the key doesn't exist (e.g. misspelled or
   // sparse id not part of label)
   const vpack_types::IndexPair &operator[](const std::string &key) const {
-    static const vpack_types::IndexPair invalid_indices(-1, -1);
+    static const vpack_types::IndexPair invalid_indices(-1, -2);
     auto itr = map_.find(key);
     if (itr == map_.end()) {
       return invalid_indices;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

When variable pack index pairs are requested for variables that don't exist, a set of invalid indices are returned. This provides a convenient way to turn loops over those variables' indices into no-ops without additional checking. We use this extensively downstream. To have loops like
```c++
for (int i = pack.first; i <= pack.second; i++) {
  /* Work we don't want to do for invalid packs */
}
```
work, though, we need `pack.second` to be more negative than `pack.first`. The invalid indices were changed from `0, -1` to `-1, -1` by #535, which made sense since `0` isn't necessarily invalid, but this PR changes them to `-1, -2` so the above pattern still works. A bit dangerous (as the code comments now say) but it's a very effective pattern downstream in performance-critical code. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
