### PR TITLE
Release v0.6.1 -- fix typo in testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 ### Removed (removing behavior/API/varaibles/...)
 
-## Release 0.6.0
+## Release 0.6.1
 Date: 09/22/2021
 
 ### Added (new features/APIs/variables/...)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ cmake_minimum_required(VERSION 3.16)
 # Imports machine-specific configuration
 include(cmake/MachineCfg.cmake)
 
-project(parthenon VERSION 0.6.0 LANGUAGES C CXX)
+project(parthenon VERSION 0.6.1 LANGUAGES C CXX)
 
 if (${CMAKE_VERSION} VERSION_GREATER_EQUAL 3.19.0)
   cmake_policy(SET CMP0110 NEW)

--- a/tst/regression/test_suites/bvals/bvals.py
+++ b/tst/regression/test_suites/bvals/bvals.py
@@ -37,7 +37,7 @@ class TestCase(utils.test_case.TestCaseAbs):
                 "parthenon/mesh/ox2_bc=reflecting",
                 "parthenon/mesh/ix3_bc=reflecting",
                 "parthenon/mesh/ox3_bc=reflecting",
-                "parthenon/output0/id=periodic",
+                "parthenon/output0/id=reflecting",
             ]
         # Step 2: periodic BC
         if step == 2:


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

A typo in the extended testing infrastructure made it to the v0.6.0 release.
Given that this was discovered immediately, I suggest to "skip" the v0.6.0 release (i.e., create no tag for it and also don't mention it in the changelog) and just bump numbers to v0.6.1.
In other words, "v0.6.1 is the new v0.6.0"

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
