### PR TITLE
Fix parallel hdf5 incompatibility with non-mpi builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -165,8 +165,17 @@ if (NOT PARTHENON_DISABLE_HDF5)
   if (ENABLE_MPI AND (NOT HDF5_IS_PARALLEL))
     message(FATAL_ERROR "Both MPI and HDF5 are enabled but only a serial version of HDF5 "
     "was found. Please install a parallel version of HDF5 (or point CMake to it by adding its path "
-    "to the CMAKE_PREFIX_PATH environment variable), or disable either MPI or HDF5 by rerunning "
+    "to the CMAKE_PREFIX_PATH environment variable or by setting the HDF5_ROOT variable), "
+    "or disable either MPI or HDF5 by rerunning "
     "CMake with -DPARTHENON_DISABLE_MPI=ON or -DPARTHENON_DISABLE_HDF5=ON")
+  endif()
+
+  if ((NOT ENABLE_MPI) AND HDF5_IS_PARALLEL)
+    message(FATAL_ERROR "MPI is disabled and HDF5 is enabled but only a parallel version of HDF5 "
+    "was found. Please install a serial version of HDF5 (or point CMake to it by adding its path "
+    "to the CMAKE_PREFIX_PATH environment variable or by setting the HDF5_ROOT variable), or "
+    "either enable MPI or disable HDF5 by rerunning "
+    "CMake with -DPARTHENON_DISABLE_MPI=OFF or -DPARTHENON_DISABLE_HDF5=ON")
   endif()
 
   if ((NOT PARTHENON_DISABLE_HDF5_COMPRESSION) AND ENABLE_MPI)

--- a/src/utils/reductions.hpp
+++ b/src/utils/reductions.hpp
@@ -23,7 +23,10 @@
 
 namespace parthenon {
 
-#ifndef MPI_PARALLEL
+// According to the MPI standard MPI_VERSION is defined by every MPI library.
+// Thus, the following check ensures that there's no clash between our custom workaround
+// for reductions in non-MPI builds.
+#ifndef MPI_VERSION
 enum MPI_Op {
   MPI_MAX,
   MPI_MIN,


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Closes #592

I originally thought about adding an option for force override that new safety check.
However, I then discovered that an included MPI lib through HDF5 also causes issues when OpenMP is enabled as host execution space:
```make
[100%] Linking CXX executable poisson-example
/usr/bin/ld: CMakeFiles/poisson-example.dir/poisson_driver.cpp.o: undefined reference to symbol 'ompi_mpi_op_max'
/usr/bin/ld: /usr/lib/openmpi/libmpi.so.40: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make[2]: *** [example/poisson/CMakeFiles/poisson-example.dir/build.make:156: example/poisson/poisson-example] Error 1
make[1]: *** [CMakeFiles/Makefile2:2157: example/poisson/CMakeFiles/poisson-example.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

This would result in even more logic to also cover that case, so in the end I decided to not allow incompatible libraries (hopefully saving us other unexpected headaches in the future).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
