### PR TITLE
Add tensor field indexing functionality to PackIndexMap

### DIFF
--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -79,31 +79,31 @@ class FlatIdx {
 
   KOKKOS_FORCEINLINE_FUNCTION
   int operator()() const {
-    if (ndim_ != 0) PARTHENON_DEBUG_FAIL("Wrong number of dimensions.");
+    PARTHENON_DEBUG_REQUIRE(ndim_ == 0, "Wrong number of dimensions.");
     return offset_;
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
   int operator()(const int idx1) const {
-    if (ndim_ != 1) PARTHENON_DEBUG_FAIL("Wrong number of dimensions.");
-    if (idx1 >= shape_[0]) PARTHENON_DEBUG_FAIL("Idx1 too large.");
+    PARTHENON_DEBUG_REQUIRE(ndim_ == 1, "Wrong number of dimensions.");
+    PARTHENON_DEBUG_REQUIRE(idx1 < shape_[0], "Idx1 too large.");
     return offset_ + idx1;
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
   int operator()(const int idx1, const int idx2) const {
-    if (ndim_ != 2) PARTHENON_DEBUG_FAIL("Wrong number of dimensions.");
-    if (idx1 >= shape_[0]) PARTHENON_DEBUG_FAIL("Idx1 too large.");
-    if (idx2 >= shape_[1]) PARTHENON_DEBUG_FAIL("Idx2 too large.");
+    PARTHENON_DEBUG_REQUIRE(ndim_ == 2, "Wrong number of dimensions.");
+    PARTHENON_DEBUG_REQUIRE(idx1 < shape_[0], "Idx1 too large.");
+    PARTHENON_DEBUG_REQUIRE(idx2 < shape_[1], "Idx2 too large.");
     return offset_ + idx1 + shape_[0] * idx2;
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
   int operator()(const int idx1, const int idx2, const int idx3) const {
-    if (ndim_ != 3) PARTHENON_DEBUG_FAIL("Wrong number of dimensions.");
-    if (idx1 >= shape_[0]) PARTHENON_DEBUG_FAIL("Idx1 too large.");
-    if (idx2 >= shape_[1]) PARTHENON_DEBUG_FAIL("Idx2 too large.");
-    if (idx3 >= shape_[2]) PARTHENON_DEBUG_FAIL("Idx3 too large.");
+    PARTHENON_DEBUG_REQUIRE(ndim_ == 3, "Wrong number of dimensions.");
+    PARTHENON_DEBUG_REQUIRE(idx1 < shape_[0], "Idx1 too large.");
+    PARTHENON_DEBUG_REQUIRE(idx2 < shape_[1], "Idx2 too large.");
+    PARTHENON_DEBUG_REQUIRE(idx3 < shape_[2], "Idx3 too large.");
     return offset_ + idx1 + shape_[0] * (idx2 + shape_[1] * idx3);
   }
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -64,7 +64,10 @@ class FlatIdx {
   }
 
   KOKKOS_INLINE_FUNCTION
-  int DimSize(int iDim) const { return shape_[iDim - 1]; }
+  int DimSize(int iDim) const {
+    PARTHENON_DEBUG_REQUIRE(iDim <= ndim_, "Wrong number of dimensions.");
+    return shape_[iDim - 1];
+  }
 
   IndexRange GetBounds(int iDim) const {
     if (iDim > ndim_) {

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -49,7 +49,7 @@ using SwarmVarList = std::forward_list<std::shared_ptr<ParticleVariable<T>>>;
 // the pairs represent interval (inclusive) of those indices
 using IndexPair = std::pair<int, int>;
 
-// Used for storing the shapes of variable fields 
+// Used for storing the shapes of variable fields
 using Shape = std::vector<int>;
 
 // The key for variable packs
@@ -123,14 +123,14 @@ class PackIndexMap {
     return itr->second;
   }
 
-  void insert(std::string key, vpack_types::IndexPair val, vpack_types::Shape shape = vpack_types::Shape()) {
+  void insert(std::string key, vpack_types::IndexPair val,
+              vpack_types::Shape shape = vpack_types::Shape()) {
     map_.insert(std::pair<std::string, vpack_types::IndexPair>(key, val));
     shape_map_.insert(std::pair<std::string, vpack_types::Shape>(key, shape));
   }
 
   template <typename... Ts>
   int GetFlatIdx(const std::string &key, Ts... idx_pack) {
-
     std::vector<int> indices = {idx_pack...};
 
     // Make sure the key exists
@@ -150,7 +150,7 @@ class PackIndexMap {
     int idx = 0;
     if (indices.size() > 0) {
       // for (int idim = 0; idim < indices.size(); ++idim) {
-      for (int idim = indices.size() - 1; idim >= 0; --idim) { 
+      for (int idim = indices.size() - 1; idim >= 0; --idim) {
         if (indices[idim] >= itr_shape->second[idim]) {
           PARTHENON_THROW("Index " + std::to_string(indices[idim]) +
                           " too large for dimension " + std::to_string(idim) + " of " +

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -52,22 +52,21 @@ using IndexPair = std::pair<int, int>;
 // Used for storing the shapes of variable fields
 using Shape = std::vector<int>;
 
-class FlatIdx { 
+// Index arbitrary rank fields into flattened indices in a VariablePack
+class FlatIdx {
  public:
-  FlatIdx(std::vector<int> shape, int offset) : shape_("shape", shape.size()), offset_(offset) {
-    for (int i=0; i<shape.size(); ++i) {
+  FlatIdx(std::vector<int> shape, int offset)
+      : shape_("shape", shape.size()), offset_(offset) {
+    for (int i = 0; i < shape.size(); ++i) {
       shape_(i) = shape[i];
     }
   }
-  
-  KOKKOS_INLINE_FUNCTION 
-  int DimSize(int i) const {
-    return shape_(i);
-  }
+
+  KOKKOS_INLINE_FUNCTION
+  int DimSize(int i) const { return shape_(i); }
 
   template <typename... Ts>
-  KOKKOS_INLINE_FUNCTION
-  int operator()(Ts... idx_pack) const {
+  KOKKOS_INLINE_FUNCTION int operator()(Ts... idx_pack) const {
     std::vector<int> indices = {idx_pack...};
 
     // Check that the correct dimensionality is being specified
@@ -90,9 +89,10 @@ class FlatIdx {
     idx += offset_;
 
     return idx;
-  } 
+  }
+
  private:
-  ParArray1D<int> shape_; 
+  ParArray1D<int> shape_;
   int offset_;
 };
 
@@ -172,15 +172,15 @@ class PackIndexMap {
     map_.insert(std::pair<std::string, vpack_types::IndexPair>(key, val));
     shape_map_.insert(std::pair<std::string, vpack_types::Shape>(key, shape));
   }
-  
-  vpack_types::FlatIdx GetFlatIdx(const std::string &key) { 
+
+  vpack_types::FlatIdx GetFlatIdx(const std::string &key) {
     // Make sure the key exists
     auto itr = map_.find(key);
     auto itr_shape = shape_map_.find(key);
     if ((itr == map_.end()) || (itr_shape == shape_map_.end())) {
-      PARTHENON_THROW("Key " + key + " does not exist."); 
+      PARTHENON_THROW("Key " + key + " does not exist.");
     }
-    return vpack_types::FlatIdx(itr_shape->second, itr->second.first); 
+    return vpack_types::FlatIdx(itr_shape->second, itr->second.first);
   }
 
   std::vector<int> GetShape(const std::string &key) {

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -426,8 +426,7 @@ void FillVarView(const CellVariableVector<T> &vars, bool coarse,
     if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
 
     if (pvmap != nullptr) {
-      pvmap->insert(
-          v->label(), IndexPair(vstart, vindex - 1), shape);
+      pvmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);
     }
   }
 
@@ -496,8 +495,7 @@ void FillFluxViews(const CellVariableVector<T> &vars, const int ndim,
     if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
 
     if (pvmap != nullptr) {
-      pvmap->insert(
-          v->label(), IndexPair(vstart, vindex - 1), shape);
+      pvmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);
     }
   }
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -73,7 +73,7 @@ class FlatIdx {
     }
     IndexRange rng;
     rng.s = 0;
-    rng.e = shape_[iDim-1]-1;
+    rng.e = shape_[iDim - 1] - 1;
     return rng;
   }
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -69,25 +69,22 @@ class FlatIdx {
 
   template <typename... Ts>
   KOKKOS_INLINE_FUNCTION int operator()(Ts... idx_pack) const {
-    std::vector<int> indices = {idx_pack...};
+    const int size = sizeof...(idx_pack);
+    int indices[size] = {idx_pack...};
 
     // Check that the correct dimensionality is being specified
-    if (indices.size() != shape_.size()) {
-      PARTHENON_FAIL(std::string("Wrong number of indices for variable.").c_str())
+    if (size != shape_.size()) {
+      PARTHENON_FAIL("Wrong number of indices for variable.");
     }
 
     // Find the flat index from the indices assuming fastest moving index is
     // the rightmost index
     int idx = 0;
-    if (indices.size() > 0) {
-      for (int idim = indices.size() - 1; idim >= 0; --idim) {
-        if (indices[idim] >= shape_(idim)) {
-          PARTHENON_FAIL(("Index " + std::to_string(indices[idim]) +
-                          " too large for dimension " + std::to_string(idim) + ".")
-                             .c_str())
-        }
-        idx = indices[idim] + idx * shape_(idim);
+    for (int idim = size - 1; idim >= 0; --idim) {
+      if (indices[idim] >= shape_(idim)) {
+        PARTHENON_FAIL("Index too large for dimension .");
       }
+      idx = indices[idim] + idx * shape_(idim);
     }
     idx += offset_;
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -149,7 +149,6 @@ class PackIndexMap {
     // the rightmost index
     int idx = 0;
     if (indices.size() > 0) {
-      // for (int idim = 0; idim < indices.size(); ++idim) {
       for (int idim = indices.size() - 1; idim >= 0; --idim) {
         if (indices[idim] >= itr_shape->second[idim]) {
           PARTHENON_THROW("Index " + std::to_string(indices[idim]) +

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -498,13 +498,15 @@ TEST_CASE("Get the correct access pattern when using FlatIdx", "[FlatIdx]") {
         auto v = pmbd->PackVariables(std::vector<std::string>{"v2", "v3"}, imap);
 
         auto idx_v3 = imap.GetFlatIdx("v3");
+        const auto tb1 = idx_v3.GetBounds(1);
+        const auto tb2 = idx_v3.GetBounds(2);
+        const auto tb3 = idx_v3.GetBounds(3);
         Real err3 = 0.0;
         par_reduce(
-            loop_pattern_mdrange_tag, "compare v3", DevExecSpace(), 0,
-            idx_v3.DimSize(1) - 1, 0, idx_v3.DimSize(0) - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
-            ib.e,
+            loop_pattern_mdrange_tag, "compare v3", DevExecSpace(), tb2.s, tb2.e, tb1.s,
+            tb1.e, kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
             KOKKOS_LAMBDA(int idx2, int idx1, int k, int j, int i, Real &lerr) {
-              for (int idx3 = 0; idx3 < idx_v3.DimSize(2); ++idx3) {
+              for (int idx3 = tb3.s; idx3 <= tb3.e; ++idx3) {
                 Real n_expected =
                     i + N * (j + N * (k + N1 * (idx1 + N2 * (idx2 + N3 * idx3))));
                 Real n_actual = v(idx_v3(idx1, idx2, idx3), k, j, i);

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -440,3 +440,81 @@ TEST_CASE("Coarse variable from meshblock_data for cell variable",
     }
   }
 }
+
+TEST_CASE("Get the correct access pattern when using FlatIdx", "[FlatIdx]") {
+  using parthenon::IndexDomain;
+  using parthenon::IndexShape;
+
+  constexpr int N = 20;
+  constexpr int NDIM = 3;
+  constexpr int N1 = 3;
+  constexpr int N2 = 2;
+  constexpr int N3 = 4;
+  const std::vector<int> tensor2_shape{N, N, N, N1, N2};
+  const std::vector<int> tensor3_shape{N, N, N, N1, N2, N3};
+
+  auto pkg = std::make_shared<StateDescriptor>("Test package");
+
+  auto pmb = std::make_shared<MeshBlock>(N, NDIM);
+
+  GIVEN("Tensor fields accessed using CellVariables") {
+    Metadata m_tensor2({Metadata::Independent, Metadata::WithFluxes, Metadata::Vector},
+                       tensor2_shape);
+    Metadata m_tensor3({Metadata::Independent, Metadata::WithFluxes, Metadata::Vector},
+                       tensor3_shape);
+
+    pkg->AddField("v2", m_tensor2);
+    pkg->AddField("v3", m_tensor3);
+
+    auto &pmbd = pmb->meshblock_data.Get();
+    pmbd->Initialize(pkg, pmb);
+    WHEN("they are initialized to unique values depending on their indices") {
+      auto ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
+      auto jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
+      auto kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+
+      auto var2 = pmbd->Get("v2").data;
+      auto var3 = pmbd->Get("v3").data;
+      int n1 = var3.GetDim(4);
+      int n2 = var3.GetDim(5);
+      int n3 = var3.GetDim(6);
+      par_for(
+          loop_pattern_mdrange_tag, "initialize v2, v3", DevExecSpace(), kb.s, kb.e, jb.s,
+          jb.e, ib.s, ib.e, KOKKOS_LAMBDA(int k, int j, int i) {
+            for (int c3 = 0; c3 < n3; ++c3) {
+              for (int c2 = 0; c2 < n2; ++c2) {
+                for (int c1 = 0; c1 < n1; ++c1) {
+                  var2(c2, c1, k, j, i) = i + N * (j + N * (k + N1 * (c1 + N2 * c2)));
+                  var3(c3, c2, c1, k, j, i) =
+                      i + N * (j + N * (k + N1 * (c1 + N2 * (c2 + c3 * N3))));
+                }
+              }
+            }
+          });
+
+      THEN("Accessing the tensor fields from a VariablePack and using FlatIdx to access "
+           "elements of the tensors gives the correct unique values.") {
+        PackIndexMap imap;
+        auto v = pmbd->PackVariables(std::vector<std::string>{"v2", "v3"}, imap);
+
+        auto idx_v3 = imap.GetFlatIdx("v3");
+        Real err3 = 0.0;
+        par_reduce(
+            loop_pattern_mdrange_tag, "compare v3", DevExecSpace(), 0,
+            idx_v3.DimSize(1) - 1, 0, idx_v3.DimSize(0) - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
+            ib.e,
+            KOKKOS_LAMBDA(int idx2, int idx1, int k, int j, int i, Real &lerr) {
+              for (int idx3 = 0; idx3 < idx_v3.DimSize(2); ++idx3) {
+                Real n_expected =
+                    i + N * (j + N * (k + N1 * (idx1 + N2 * (idx2 + N3 * idx3))));
+                Real n_actual = v(idx_v3(idx1, idx2, idx3), k, j, i);
+                lerr += abs(n_actual - n_expected);
+              }
+            },
+            err3);
+
+        REQUIRE(err3 == 0.0);
+      }
+    }
+  }
+}


### PR DESCRIPTION
## PR Summary
Add an internal map to PackIndexMap which contains the shape of all variables in the associated VariablePack and also define a method in PackIndexMap which gets the flattened index of a tensor component given the components indices. Also defines a method to return the shape of any object included in the PackIndexMap. This is an attempt to simplify and reduce the likelihood of error when indexing into tensor fields in VariablePacks.

## PR Checklist

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
