### PR TITLE
Add output triggering by signaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 605]](https://github.com/lanl/parthenon/pull/605) Add output triggering by signaling.
 
 ### Changed (changing behavior/API/variables/...)
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -4,6 +4,24 @@ Outputs from Parthenon are controled via `<parthenon/output*>` blocks, where `*`
 
 To disable an output block without removing it from the intput file set the block's `dt < 0.0`.
 
+In addition to time base outputs, two additional options to trigger outputs
+(applies to HDF5 and restart outputs) exist.
+
+- Signaling: If `Parthenon` catches a signal, e.g., `SIGALRM` which is often sent by
+schedulers such as Slurm to signal a job of exceeding the job's allocated walltime,
+`Parthenon` will gracefully terminate and write output files with a `final` id rather
+than a number.
+This also applies to the `Parthenon` internal walltime limit, e.g., when executing an
+application with the `-t HH:MM:SS` parameter on the command line.
+- File trigger: If a user places a file with the name `output_now` in the working
+directory of a running application, `Parthenon` will write output files with a `now` id
+rather than a number.
+After the output is being written the `output_now` file is removed and the simulation
+continues normally.
+The user can repeat the process any time by creating a new `output_now` file.
+
+Note, in both cases the original numbering of the output will be unaffected and the
+`final` and `now` files will be overwritten each time without warning.
 ## HDF5
 
 Parthenon allows users to select which fields are captured in the HDF5 (`.phdf`) dumps at

--- a/src/outputs/formatted_table.cpp
+++ b/src/outputs/formatted_table.cpp
@@ -39,7 +39,8 @@ namespace parthenon {
 //  \brief writes OutputData to file in tabular format using C style std::fprintf
 //         Writes one file per MeshBlock
 
-void FormattedTableOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
+void FormattedTableOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                                           const SignalHandler::OutputSignal signal) {
   throw std::runtime_error(std::string(__func__) + " is not implemented");
 }
 

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -43,7 +43,12 @@ namespace parthenon {
 //! \fn void OutputType::HistoryFile()
 //  \brief Writes a history file
 
-void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
+void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                                    const SignalHandler::OutputSignal signal) {
+  // Don't update history log for forced (signaling or `output_now` file based) outputs.
+  if (signal != SignalHandler::OutputSignal::none) {
+    return;
+  }
   std::vector<std::string> all_labels = {};
   std::vector<Real> all_results = {};
 

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -465,7 +465,8 @@ void OutputType::ClearOutputData() {
 //! \fn void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, bool wtflag)
 //  \brief scans through singly linked list of OutputTypes and makes any outputs needed.
 
-void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
+void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                          SignalHandler::OutputSignal signal) {
   Kokkos::Profiling::pushRegion("MakeOutputs");
   bool first = true;
   OutputType *ptype = pfirst_type_;
@@ -473,7 +474,7 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     if ((tm == nullptr) ||
         ((ptype->output_params.dt >= 0.0) &&
          ((tm->ncycle == 0) || (tm->time >= ptype->output_params.next_time) ||
-          (tm->time >= tm->tlim)))) {
+          (tm->time >= tm->tlim) || (signal == SignalHandler::OutputSignal::now)))) {
       if (first && ptype->output_params.file_type != "hst") {
         pm->ApplyUserWorkBeforeOutput(pin);
         first = false;

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -466,7 +466,7 @@ void OutputType::ClearOutputData() {
 //  \brief scans through singly linked list of OutputTypes and makes any outputs needed.
 
 void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
-                          SignalHandler::OutputSignal signal) {
+                          const SignalHandler::OutputSignal signal) {
   Kokkos::Profiling::pushRegion("MakeOutputs");
   bool first = true;
   OutputType *ptype = pfirst_type_;
@@ -474,12 +474,12 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
     if ((tm == nullptr) ||
         ((ptype->output_params.dt >= 0.0) &&
          ((tm->ncycle == 0) || (tm->time >= ptype->output_params.next_time) ||
-          (tm->time >= tm->tlim) || (signal == SignalHandler::OutputSignal::now)))) {
+          (tm->time >= tm->tlim) || (signal != SignalHandler::OutputSignal::none)))) {
       if (first && ptype->output_params.file_type != "hst") {
         pm->ApplyUserWorkBeforeOutput(pin);
         first = false;
       }
-      ptype->WriteOutputFile(pm, pin, tm);
+      ptype->WriteOutputFile(pm, pin, tm, signal);
     }
     ptype = ptype->pnext_type; // move to next OutputType node in signly linked list
   }

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -117,7 +117,8 @@ class OutputType {
   void CalculateCartesianVector(ParArrayND<Real> &src, ParArrayND<Real> &dst,
                                 Coordinates *pco);
   // following pure virtual function must be implemented in all derived classes
-  virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) = 0;
+  virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                               const SignalHandler::OutputSignal signal) = 0;
   virtual void WriteContainer(SimTime &tm, Mesh *pm, ParameterInput *pin, bool flag) {
     return;
   }
@@ -156,7 +157,8 @@ const char hist_param_key[] = "HistoryFunctions";
 class HistoryOutput : public OutputType {
  public:
   explicit HistoryOutput(const OutputParameters &oparams) : OutputType(oparams) {}
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) override;
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                       const SignalHandler::OutputSignal signal) override;
 };
 
 //----------------------------------------------------------------------------------------
@@ -166,7 +168,8 @@ class HistoryOutput : public OutputType {
 class FormattedTableOutput : public OutputType {
  public:
   explicit FormattedTableOutput(const OutputParameters &oparams) : OutputType(oparams) {}
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) override;
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                       const SignalHandler::OutputSignal signal) override;
 };
 
 //----------------------------------------------------------------------------------------
@@ -177,7 +180,8 @@ class VTKOutput : public OutputType {
  public:
   explicit VTKOutput(const OutputParameters &oparams) : OutputType(oparams) {}
   void WriteContainer(SimTime &tm, Mesh *pm, ParameterInput *pin, bool flag) override;
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) override;
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                       const SignalHandler::OutputSignal signal) override;
 };
 
 #ifdef ENABLE_HDF5
@@ -190,9 +194,11 @@ class PHDF5Output : public OutputType {
   // Function declarations
   PHDF5Output(const OutputParameters &oparams, bool restart)
       : OutputType(oparams), restart_(restart) {}
-  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) override;
+  void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                       const SignalHandler::OutputSignal signal) override;
   template <bool WRITE_SINGLE_PRECISION>
-  void WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm);
+  void WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                           const SignalHandler::OutputSignal signal);
 
  private:
   const bool restart_; // true if we write a restart file, false for regular output files

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -210,7 +210,9 @@ class Outputs {
   Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm = nullptr);
   ~Outputs();
 
-  void MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm = nullptr);
+  void
+  MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm = nullptr,
+              SignalHandler::OutputSignal signal = SignalHandler::OutputSignal::none);
 
  private:
   OutputType *pfirst_type_; // ptr to head OutputType node in singly linked list

--- a/src/outputs/vtk.cpp
+++ b/src/outputs/vtk.cpp
@@ -232,7 +232,8 @@ void VTKOutput::WriteContainer(SimTime &tm, Mesh *pm, ParameterInput *pin, bool 
   return;
   */
 }
-void VTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm) {
+void VTKOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
+                                const SignalHandler::OutputSignal signal) {
   throw std::runtime_error(std::string(__func__) + " is not implemented");
 }
 

--- a/src/utils/signal_handler.cpp
+++ b/src/utils/signal_handler.cpp
@@ -18,6 +18,7 @@
 //  \brief contains functions that implement a simple SignalHandler
 //  These functions are based on TAG's signal handler written for Athena 8/19/2004
 
+#include <sys/stat.h>
 #include <unistd.h> // alarm() Unix OS utility; not in C standard --> no <cunistd>
 
 // first 2x macros and signal() are the only ISO C features; rest are POSIX C extensions
@@ -37,7 +38,8 @@ namespace SignalHandler {
 //  \brief install handlers for selected signals
 
 void SignalHandlerInit() {
-  for (int n = 0; n < nsignal; n++) {
+  // +1 for "output_now" trigger
+  for (int n = 0; n < nsignal + 1; n++) {
     signalflag[n] = 0;
   }
   // C++11 standard guarantees that <csignal> places C-standard signal.h contents in std::
@@ -57,21 +59,44 @@ void SignalHandlerInit() {
 //! \fn int CheckSignalFlags()
 //  \brief Synchronize and check signal flags and return true if any of them is caught
 
-int CheckSignalFlags() {
+OutputSignal CheckSignalFlags() {
+  if (Globals::my_rank == 0) {
+    // TODO(the person bumping std to C++17): use std::filesystem::exists
+    struct stat buffer;
+    // if file "output_now" exists
+    if (stat("output_now", &buffer) == 0) {
+      signalflag[nsignal] = 1;
+    }
+  }
   // Currently, only checking for nonzero return code at the end of each timestep in
   // main.cpp; i.e. if an issue prevents a process from reaching the end of a cycle, the
   // signals will never be handled by that process / the solver may hang
-  int ret = 0;
   sigprocmask(SIG_BLOCK, &mask, nullptr);
 #ifdef MPI_PARALLEL
   PARTHENON_MPI_CHECK(MPI_Allreduce(
       MPI_IN_PLACE, const_cast<void *>(reinterpret_cast<volatile void *>(signalflag)),
-      nsignal, MPI_INT, MPI_MAX, MPI_COMM_WORLD));
+      nsignal + 1, MPI_INT, MPI_MAX, MPI_COMM_WORLD));
 #endif
-  for (int n = 0; n < nsignal; n++)
-    ret += signalflag[n];
   sigprocmask(SIG_UNBLOCK, &mask, nullptr);
-  return ret;
+  for (int n = 0; n < nsignal; n++) {
+    if (signalflag[n] != 0) {
+      return OutputSignal::final;
+    }
+  }
+  if (signalflag[nsignal] != 0) {
+    // reset signalflag and cleanup trigger file
+    signalflag[nsignal] = 0;
+    if (Globals::my_rank == 0) {
+      // Cleanup trigger file.
+      // Fail hard in case there's an issue as otherwise this could lead to
+      // excessive file system load by writing dumps triggered every single cycle.
+      PARTHENON_REQUIRE_THROWS(
+          remove("output_now") == 0,
+          "Could not remove 'output_now' file that triggered output.");
+    }
+    return OutputSignal::now;
+  }
+  return OutputSignal::none;
 }
 
 //----------------------------------------------------------------------------------------

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -36,12 +36,14 @@ void ShowConfig();
 //  \brief static data and functions that implement a simple signal handling system
 namespace SignalHandler {
 
-const int nsignal = 3;
-static volatile int signalflag[nsignal];
+enum class OutputSignal { none, now, final };
+constexpr int nsignal = 3;
+// using the +1 for signaling based on "output_now" trigger
+static volatile int signalflag[nsignal + 1];
 const int ITERM = 0, IINT = 1, IALRM = 2;
 static sigset_t mask;
 void SignalHandlerInit();
-int CheckSignalFlags();
+OutputSignal CheckSignalFlags();
 int GetSignalFlag(int s);
 void SetSignalFlag(int s);
 void SetWallTimeAlarm(int t);

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -72,7 +72,7 @@ if (ENABLE_HDF5)
   list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
   list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
     --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/restart/parthinput.restart \
-    --num_steps 2")
+    --num_steps 3")
   list(APPEND EXTRA_TEST_LABELS "")
 
   # Calculate pi example

--- a/tst/regression/test_suites/restart/parthinput.restart
+++ b/tst/regression/test_suites/restart/parthinput.restart
@@ -58,4 +58,4 @@ compute_error = false
 
 <parthenon/output0>
 file_type = rst
-dt = 0.25
+dt = 0.10

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -1,6 +1,6 @@
 # ========================================================================================
 # Parthenon performance portable AMR framework
-# Copyright(C) 2020 The Parthenon collaboration
+# Copyright(C) 2020-2021 The Parthenon collaboration
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
 # (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
@@ -35,21 +35,32 @@ class TestCase(utils.test_case.TestCaseAbs):
         # files are both read and written
         parameters.coverage_status = "both"
 
+        # run baseline (to the very end)
         if step == 1:
             parameters.driver_cmd_line_args = ["parthenon/job/problem_id=gold"]
-        else:
+        # restart from an early snapshot and run for two seconds
+        elif step == 2:
             parameters.driver_cmd_line_args = [
                 "-r",
                 "gold.out0.00001.rhdf",
                 "parthenon/job/problem_id=silver",
+                "-t",
+                "00:00:02",
+            ]
+        # now restart from the walltime based output
+        else:
+            parameters.driver_cmd_line_args = [
+                "-r",
+                "silver.out0.final.rhdf",
             ]
 
         return parameters
 
     def Analyse(self, parameters):
+        success = True
         # spotcheck one variable
-        goldFile = "gold.out0.00002.rhdf"
-        silverFile = "silver.out0.00002.rhdf"
+        goldFile = "gold.out0.00005.rhdf"
+        silverFile = "silver.out0.00005.rhdf"
         varName = "advected"
         with h5py.File(goldFile, "r") as gold, h5py.File(silverFile, "r") as silver:
             goldData = np.zeros(gold[varName].shape, dtype=np.float64)
@@ -59,4 +70,16 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         maxdiff = np.abs(goldData - silverData).max()
         print("Variable: %s, diff=%g, N=%d" % (varName, maxdiff, len(goldData)))
-        return maxdiff == 0.0
+        if maxdiff != 0.0:
+            print("ERROR: Found difference between gold and silver output.")
+            success = False
+
+        found_line = False
+        for line in parameters.stdouts[1].decode("utf-8").split("\n"):
+            if "Terminating on wall-time limit" in line:
+                found_line = True
+        if not found_line:
+            print("ERROR: wall-time limit based termination not triggered.")
+            success = False
+
+        return success


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

From the updated docs:
```
In addition to time base outputs, two additional options to trigger outputs
(applies to HDF5 and restart outputs) exist.

- Signaling: If `Parthenon` catches a signal, e.g., `SIGALRM` which is often sent by
schedulers such as Slurm to signal a job of exceeding the job's allocated walltime,
`Parthenon` will gracefully terminate and write output files with a `final` id rather
than a number.
This also applies to the `Parthenon` internal walltime limit, e.g., when executing an
application with the `-t HH:MM:SS` parameter on the command line.
- File trigger: If a user places a file with the name `output_now` in the working
directory of a running application, `Parthenon` will write output files with a `now` id
rather than a number.
After the output is being written the `output_now` file is removed and the simulation
continues normally.
The user can repeat the process any time by creating a new `output_now` file.

Note, in both cases the original numbering of the output will be unaffected and the
`final` and `now` files will be overwritten each time without warning.
```

Closes #574

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
