### PR TITLE
Fix bug where .final is not written if signal raised while writing regular output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 609]](https://github.com/lanl/parthenon/pull/609) Fix bug where .final is not written if signal raised while writing regular output
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -95,13 +95,15 @@ DriverStatus EvolutionDriver::Execute() {
     // check for signals
     signal = SignalHandler::CheckSignalFlags();
 
-    if (tm.time < tm.tlim) { // skip the final output as it happens later
+    // skip the final output as it happens later
+    if (signal == OutputSignal::final) {
+      break;
+    }
+
+    if (tm.time < tm.tlim) {
       pouts->MakeOutputs(pmesh, pinput, &tm, signal);
     }
 
-    if (SignalHandler::CheckSignalFlags() == OutputSignal::final) {
-      break;
-    }
     if (tm.ncycle == perf_cycle_offset) {
       pmesh->mbcnt = 0;
       timer_main.reset();

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -98,7 +98,7 @@ DriverStatus EvolutionDriver::Execute() {
     if (signal == OutputSignal::final) {
       break;
     }
-
+    // skip the final (last) output at the end of the simulation time as it happens later
     if (tm.time < tm.tlim) {
       pouts->MakeOutputs(pmesh, pinput, &tm, signal);
     }
@@ -114,7 +114,7 @@ DriverStatus EvolutionDriver::Execute() {
 
   DriverStatus status = DriverStatus::complete;
 
-  pouts->MakeOutputs(pmesh, pinput, &tm, signal);
+  pouts->MakeOutputs(pmesh, pinput, &tm, OutputSignal::final);
   PostExecute(status);
   return status;
 }

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -95,7 +95,6 @@ DriverStatus EvolutionDriver::Execute() {
     // check for signals
     signal = SignalHandler::CheckSignalFlags();
 
-    // skip the final output as it happens later
     if (signal == OutputSignal::final) {
       break;
     }

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -45,8 +45,8 @@ namespace parthenon {
 
 void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
                                     const SignalHandler::OutputSignal signal) {
-  // Don't update history log for forced (signaling or `output_now` file based) outputs.
-  if (signal != SignalHandler::OutputSignal::none) {
+  // Don't update history log for `output_now` file based outputs.
+  if (signal == SignalHandler::OutputSignal::now) {
     return;
   }
   std::vector<std::string> all_labels = {};

--- a/tst/regression/test_suites/advection_outflow/advection_outflow.py
+++ b/tst/regression/test_suites/advection_outflow/advection_outflow.py
@@ -45,7 +45,7 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         delta = compare(
             [
-                "outflow.out0.00001.phdf",
+                "outflow.out0.final.phdf",
                 parameters.parthenon_path
                 + "/tst/regression/gold_standard/outflow.out0.00001.phdf",
             ]

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -96,14 +96,14 @@ class TestCase(utils.test_case.TestCaseAbs):
         # TODO(pgrete) make sure this also works/doesn't fail for the user
         ret_2d = phdf_diff.compare(
             [
-                "advection_2d.out0.00001.phdf",
+                "advection_2d.out0.final.phdf",
                 parameters.parthenon_path
                 + "/tst/regression/gold_standard/advection_2d.out0.00001.phdf",
             ]
         )
         ret_3d = phdf_diff.compare(
             [
-                "advection_3d.out0.00001.phdf",
+                "advection_3d.out0.final.phdf",
                 parameters.parthenon_path
                 + "/tst/regression/gold_standard/advection_3d.out0.00001.phdf",
             ]

--- a/tst/regression/test_suites/restart/parthinput.restart
+++ b/tst/regression/test_suites/restart/parthinput.restart
@@ -36,13 +36,16 @@ x3max = 0.5
 ix3_bc = periodic
 ox3_bc = periodic
 
+derefine_count = 999999 # disable this since derefinement counter resets on
+                        # restart and thus leads to different results
+
 <parthenon/meshblock>
 nx1 = 16
 nx2 = 16
 nx3 = 1
 
 <parthenon/time>
-tlim = 0.5
+tlim = 1.0  # need enough time here to run for a few seconds at least with MPI
 integrator = rk2
 
 <Advection>

--- a/tst/regression/test_suites/restart/parthinput.restart
+++ b/tst/regression/test_suites/restart/parthinput.restart
@@ -45,7 +45,7 @@ nx2 = 16
 nx3 = 1
 
 <parthenon/time>
-tlim = 1.0  # need enough time here to run for a few seconds at least with MPI
+tlim = 0.5  # need enough time here to run for a few seconds at least with MPI
 integrator = rk2
 
 <Advection>

--- a/tst/regression/test_suites/restart/restart.py
+++ b/tst/regression/test_suites/restart/restart.py
@@ -59,8 +59,8 @@ class TestCase(utils.test_case.TestCaseAbs):
     def Analyse(self, parameters):
         success = True
         # spotcheck one variable
-        goldFile = "gold.out0.00005.rhdf"
-        silverFile = "silver.out0.00005.rhdf"
+        goldFile = "gold.out0.final.rhdf"
+        silverFile = "silver.out0.final.rhdf"
         varName = "advected"
         with h5py.File(goldFile, "r") as gold, h5py.File(silverFile, "r") as silver:
             goldData = np.zeros(gold[varName].shape, dtype=np.float64)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes bug introduced in #605.

When an alarm signal is raised during a regular output, the driver will stop but not write the `.final` output. This PR fixes this.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
