### PR TITLE
WIP: getHDF5Type Compiler workaround for g++-10 on OS X

### DIFF
--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -102,6 +102,9 @@ static hid_t getHDF5Type(const int32_t *) { return H5T_NATIVE_INT32; }
 static hid_t getHDF5Type(const int64_t *) { return H5T_NATIVE_INT64; }
 static hid_t getHDF5Type(const uint32_t *) { return H5T_NATIVE_UINT32; }
 static hid_t getHDF5Type(const uint64_t *) { return H5T_NATIVE_UINT64; }
+#ifdef __APPLE__
+static hid_t getHDF5Type(const size_t *) { return H5T_NATIVE_UINT64; }
+#endif
 static hid_t getHDF5Type(const float *) { return H5T_NATIVE_FLOAT; }
 static hid_t getHDF5Type(const double *) { return H5T_NATIVE_DOUBLE; }
 static H5T getHDF5Type(const char *const *) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Added an Apple specific getType for getHDF5Type with size_t as argument since it is not recognized as uint64_t by g++-10

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Enables compiling on OSX with g++-10.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
