### PR TITLE
Restore functionality to index map for sparse fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 616]](https://github.com/lanl/parthenon/pull/609) Restore sparse base names in PackIndexMap
 - [[PR 609]](https://github.com/lanl/parthenon/pull/609) Fix bug where .final is not written if signal raised while writing regular output
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -455,6 +455,9 @@ void AppendSparseBaseMap(const CellVariableVector<T> &vars, PackIndexMap *pvmap)
           }
         }
         pvmap->insert(v->base_name(), IndexPair(start, stop), shape);
+        vi = vj;
+      } else {
+        vi++;
       }
     }
   }

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -426,6 +426,41 @@ template <typename T>
 using MapToSwarmVariablePack = std::map<std::vector<std::string>, SwarmPackIndxPair<T>>;
 
 template <typename T>
+void AppendSparseBaseMap(const CellVariableVector<T> &vars, PackIndexMap *pvmap) {
+  using vpack_types::IndexPair;
+
+  if (pvmap != nullptr) {
+    // add in start and stop indices for sparse fields based on base_name
+    auto vi = vars.begin();
+    int start, stop;
+    while (vi != vars.end()) {
+      auto &v = *vi;
+      int sparse_id = v->GetSparseID();
+      if (sparse_id != InvalidSparseID) {
+        std::vector<int> shape;
+        if (v->GetDim(4) > 1) shape.push_back(v->GetDim(4));
+        if (v->GetDim(5) > 1) shape.push_back(v->GetDim(5));
+        if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
+        auto &pair = pvmap->get(v->label());
+        start = pair.first;
+        stop = pair.second;
+        auto vj = vi+1;
+        while (vj != vars.end()) {
+          auto &q = *vj;
+          if (q->base_name() == v->base_name()) {
+            stop = pvmap->get(q->label()).second;
+            vj++;
+          } else {
+            break;
+          }
+        }
+        pvmap->insert(v->base_name(), IndexPair(start, stop), shape);
+      }
+    }
+  }
+}
+
+template <typename T>
 void FillVarView(const CellVariableVector<T> &vars, bool coarse,
                  ViewOfParArrays<T> &cv_out, ParArray1D<int> &sparse_id_out,
                  ParArray1D<int> &vector_component_out, PackIndexMap *pvmap) {
@@ -470,6 +505,8 @@ void FillVarView(const CellVariableVector<T> &vars, bool coarse,
       pvmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);
     }
   }
+
+  AppendSparseBaseMap(vars, pvmap);
 
   Kokkos::deep_copy(cv_out, host_cv);
   Kokkos::deep_copy(sparse_id_out, host_sp);
@@ -539,6 +576,8 @@ void FillFluxViews(const CellVariableVector<T> &vars, const int ndim,
       pvmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);
     }
   }
+
+  AppendSparseBaseMap(vars, pvmap);
 
   Kokkos::deep_copy(f1_out, host_f1);
   Kokkos::deep_copy(f2_out, host_f2);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -444,7 +444,7 @@ void AppendSparseBaseMap(const CellVariableVector<T> &vars, PackIndexMap *pvmap)
         auto &pair = pvmap->get(v->label());
         start = pair.first;
         stop = pair.second;
-        auto vj = vi+1;
+        auto vj = vi + 1;
         while (vj != vars.end()) {
           auto &q = *vj;
           if (q->base_name() == v->base_name()) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
This small PR restores functionality that was removed in #535 (I think) that populated a `PackIndexMap` with the start and stop indices assocated with a sparse field's base name.  This is critical downstream and is blocking development there, so I'd like to get this merged ASAP.

This has been tested downstream and works as expected.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
