### PR TITLE
fix issue with shared pointer being garbage collected in meshblock iterator performance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 618]](https://github.com/lanl/parthenon/pull/618) Fix bug in variable pack performance test
 - [[PR 616]](https://github.com/lanl/parthenon/pull/609) Restore sparse base names in PackIndexMap
 - [[PR 609]](https://github.com/lanl/parthenon/pull/609) Fix bug where .final is not written if signal raised while writing regular output
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib

--- a/tst/performance/test_meshblock_data_iterator.cpp
+++ b/tst/performance/test_meshblock_data_iterator.cpp
@@ -74,7 +74,9 @@ void performance_test_wrapper(const std::string &test_name, InitFunc init_func,
   };
 }
 
-static MeshBlockData<Real> createTestContainer() {
+// we need to connect the MeshBlockData to a dummy mesh block, otherwise variables
+// won't be allocated
+static MeshBlockData<Real> createTestContainer(std::shared_ptr<MeshBlock> &dummy_mb) {
   // Make a container for testing performance
   std::vector<int> scalar_shape{N, N, N};
   std::vector<int> vector_shape{N, N, N, 3};
@@ -90,10 +92,6 @@ static MeshBlockData<Real> createTestContainer() {
   pkg->AddField("v3", m_in);
   pkg->AddField("v4", m_in_vec);
   pkg->AddField("v5", m_in);
-
-  // we need to connect the MeshBlockData to a dummy mesh block, otherwise variables
-  // won't be allocated
-  auto dummy_mb = std::make_shared<MeshBlock>(16, 3);
 
   MeshBlockData<Real> mbd;
   mbd.Initialize(pkg, dummy_mb);
@@ -197,7 +195,8 @@ TEST_CASE("Catch2 Container Iterator Performance",
 
   SECTION("Iterate Variables") {
     GIVEN("A container.") {
-      MeshBlockData<Real> container = createTestContainer();
+      auto dummy_mb = std::make_shared<MeshBlock>(16, 3);
+      MeshBlockData<Real> container = createTestContainer(dummy_mb);
       auto init_container = createLambdaContainer(container);
 
       // Make a function for initializing the container variables
@@ -215,7 +214,8 @@ TEST_CASE("Catch2 Container Iterator Performance",
       });
     } // GIVEN
     GIVEN("A container cellvar.") {
-      MeshBlockData<Real> container = createTestContainer();
+      auto dummy_mb = std::make_shared<MeshBlock>(16, 3);
+      MeshBlockData<Real> container = createTestContainer(dummy_mb);
       std::vector<std::string> names({"v0", "v1", "v2", "v3", "v4", "v5"});
       auto init_container = createLambdaContainerCellVar(container, names);
 
@@ -237,7 +237,8 @@ TEST_CASE("Catch2 Container Iterator Performance",
 
   SECTION("View of Views") {
     GIVEN("A container.") {
-      MeshBlockData<Real> container = createTestContainer();
+      auto dummy_mb = std::make_shared<MeshBlock>(16, 3);
+      MeshBlockData<Real> container = createTestContainer(dummy_mb);
       WHEN("The view of views does not have any names.") {
         parthenon::VariablePack<Real> var_view =
             container.PackVariables({Metadata::Independent});


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes bug accidentally introduced into `develop` in PR #617. The issue is only in the tests. `MeshBlockData::PackVariables` now requires a valid `MeshBlock` to access to set the `coords` object. A shared pointer to a `MeshBlock` is initialized in this test, but it's garbage collected away before it can be used. This PR moves it up one scope so it isn't garbage collected.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
