### PR TITLE
Sort particles by cell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 619]](https://github.com/lanl/parthenon/pull/619) Sort particles by cell
 - [[PR 605]](https://github.com/lanl/parthenon/pull/605) Add output triggering by signaling.
 - [[PR 602]](https://github.com/lanl/parthenon/pull/602) Added tuning functionality for HDF5 output
 

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -62,7 +62,13 @@ swarm.pmy_block->par_for("Simple loop", 0, swarm.GetMaxActiveIndex(),
 
 ## Sorting
 
-
+By default, particles are stored in per-meshblock pools of memory. However, one frequently wants
+convenient access to all the particles in each computational cell separately. To facilitate this,
+the Swarm provides the method `SortParticlesByCell` (and the `SwarmContainer` provides the matching
+task `SortParticlesByCell`). Calling this function populates internal data structures that map from
+per-cell indices to the per-meshblock data array. These are accessed by the `SwarmDeviceContext`
+member functions `GetParticleCountPerCell` and `GetFullIndex`. See `examples/particles` for example
+usage.
 
 ## Defragmenting
 

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -60,6 +60,10 @@ swarm.pmy_block->par_for("Simple loop", 0, swarm.GetMaxActiveIndex(),
   });
 ```
 
+## Sorting
+
+
+
 ## Defragmenting
 
 Because one typically loops over particles from 0 to `max_active_index`, if only a small

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -21,13 +21,13 @@ problem_id = particles
 <parthenon/mesh>
 refinement = none
 
-nx1 = 16
+nx1 = 4 # 16
 x1min = -0.5
 x1max = 0.5
 ix1_bc = periodic
 ox1_bc = periodic
 
-nx2 = 16
+nx2 = 4 # 16
 x2min = -0.5
 x2max = 0.5
 ix2_bc = periodic
@@ -40,8 +40,8 @@ ix3_bc = periodic
 ox3_bc = periodic
 
 <parthenon/meshblock>
-nx1 = 16
-nx2 = 16
+nx1 = 4 # 16
+nx2 = 4 # 16
 
 <parthenon/output0>
 file_type = hdf5

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -21,13 +21,13 @@ problem_id = particles
 <parthenon/mesh>
 refinement = none
 
-nx1 = 4 # 16
+nx1 = 16
 x1min = -0.5
 x1max = 0.5
 ix1_bc = periodic
 ox1_bc = periodic
 
-nx2 = 4 # 16
+nx2 = 16
 x2min = -0.5
 x2max = 0.5
 ix2_bc = periodic
@@ -40,8 +40,8 @@ ix3_bc = periodic
 ox3_bc = periodic
 
 <parthenon/meshblock>
-nx1 = 4 # 16
-nx2 = 4 # 16
+nx1 = 16
+nx2 = 16
 
 <parthenon/output0>
 file_type = hdf5

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -57,4 +57,5 @@ num_particles = 10
 particle_speed = 1.0
 rng_seed = 23487
 const_dt = 0.5
+deposition_method = per_cell
 destroy_particles_frac = 0.1

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -20,6 +20,71 @@
 #include <utility>
 #include <vector>
 
+// TODO(BRR) remove!
+//#include <Kokkos_Sort.hpp>
+/*struct SwarmKey {
+  KOKKOS_INLINE_FUNCTION
+  SwarmKey() {}
+  KOKKOS_INLINE_FUNCTION
+  SwarmKey(const int cell_idx_1d, const int swarm_idx_1d) :
+    cell_idx_1d_(cell_idx_1d), swarm_idx_(swarm_idx_1d) {}
+
+  int cell_idx_1d_;
+  int swarm_idx_;
+};
+struct SwarmKeyCompare {
+  KOKKOS_INLINE_FUNCTION
+  bool operator() (const SwarmKey& s1, SwarmKey& s2) {
+    return s1.cell_idx_1d_ < s2.cell_idx_1d_;
+  }
+};
+
+KOKKOS_INLINE_FUNCTION
+bool operator< (const SwarmKey s1, const SwarmKey s2) {
+  return s1.cell_idx_1d_ < s2.cell_idx_1d_;
+}
+KOKKOS_INLINE_FUNCTION
+bool operator> (const SwarmKey s1, const SwarmKey s2) {
+  return s1.cell_idx_1d_ > s2.cell_idx_1d_;
+}
+KOKKOS_INLINE_FUNCTION
+bool operator== (const SwarmKey s1, const SwarmKey s2) {
+  return s1.cell_idx_1d_ == s2.cell_idx_1d_;
+}
+KOKKOS_INLINE_FUNCTION
+int operator- (const SwarmKey s1, const SwarmKey s2) {
+  return s1.cell_idx_1d_ - s2.cell_idx_1d_;
+}
+namespace Kokkos {
+template<>
+struct reduction_identity<SwarmKey> {
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int sum() {
+    return static_cast<int>(0);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int prod() {
+    return static_cast<int>(1);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int min() {
+    return INT_MIN;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int max() {
+    return INT_MAX;
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int bor() {
+    return static_cast<int>(0x0);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int band() {
+    return ~static_cast<int>(0x0);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int lor() {
+    return static_cast<int>(0);
+  }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static int land() {
+    return static_cast<int>(1);
+  }
+};
+}*/
+
 // *************************************************//
 // redefine some internal parthenon functions      *//
 // *************************************************//
@@ -170,6 +235,34 @@ TaskStatus DepositParticles(MeshBlock *pmb) {
       });
 
   const int ndim = pmb->pmy_mesh->ndim;
+
+  /*// Practice a sort
+  using KeyType = SwarmKey;
+  //using KeyType = int;
+  using KeyViewType = Kokkos::View<KeyType*, DevExecSpace>;
+  int nkeys = 10;
+  KeyViewType keys("keys", nkeys);
+  pmb->par_for("Set Keys", 0, nkeys-1, KOKKOS_LAMBDA(const int i) {
+    int cell_idx_1d = nkeys - i;
+    if (i == 4) {
+      cell_idx_1d = 5;
+    }
+    keys(i) = SwarmKey(cell_idx_1d, i);
+    //keys(i) = nkeys - i;
+    //if (i == 4) keys(i) = 5;
+  });
+  pmb->par_for("Print Keys", 0, nkeys-1, KOKKOS_LAMBDA(const int i) {
+    printf("key(%i) = %i\n", keys(i).swarm_idx_, keys(i).cell_idx_1d_);
+  });
+  printf("\n");
+  std::sort(keys.data(), keys.data() + keys.extent(0), SwarmKeyCompare());
+  //Kokkos::sort(keys);
+  pmb->par_for("Print Keys", 0, nkeys-1, KOKKOS_LAMBDA(const int i) {
+    //printf("key(%i) = %i\n", i, keys(i));
+    printf("key(%i) = %i\n", keys(i).swarm_idx_, keys(i).cell_idx_1d_);
+  });
+  printf("\n");
+  exit(-1);*/
 
   pmb->par_for(
       "DepositParticles", 0, swarm->GetMaxActiveIndex(), KOKKOS_LAMBDA(const int n) {
@@ -595,8 +688,11 @@ TaskCollection ParticleDriver::MakeFinalizationTaskCollection() const {
 
     auto destroy_some_particles = tl.AddTask(none, DestroySomeParticles, pmb.get());
 
+    auto sort_particles =
+        tl.AddTask(destroy_some_particles, &SwarmContainer::SortParticlesByCell, sc.get());
+
     auto deposit_particles =
-        tl.AddTask(destroy_some_particles, DepositParticles, pmb.get());
+        tl.AddTask(sort_particles, DepositParticles, pmb.get());
 
     // Defragment if swarm memory pool occupancy is 90%
     auto defrag = tl.AddTask(deposit_particles, &SwarmContainer::Defrag, sc.get(), 0.9);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -206,6 +206,7 @@ add_library(parthenon
   utils/reductions.hpp
   utils/show_config.cpp
   utils/signal_handler.cpp
+  utils/sort.hpp
   utils/string_utils.cpp
   utils/string_utils.hpp
   utils/utils.hpp

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -18,6 +18,7 @@
 
 #include "mesh/mesh.hpp"
 #include "swarm.hpp"
+#include "utils/error_checking.hpp"
 #include "utils/sort.hpp"
 
 namespace parthenon {
@@ -515,8 +516,10 @@ void Swarm::SortParticlesByCell() {
       "Write unsorted list", 0, max_active_index_, KOKKOS_LAMBDA(const int n) {
         int i, j, k;
         swarm_d.Xtoijk(x(n), y(n), z(n), i, j, k);
-        const int cell_idx_1d = i + nx1 * (j + nx2 * k);
-        cellSorted(n) = SwarmKey(cell_idx_1d, n);
+        const int64_t cell_idx_1d = i + nx1 * (j + nx2 * k);
+        PARTHENON_DEBUG_REQUIRE(cell_idx_1d < std::numeric_limits<int>::max(),
+                                "cell_idx_1d exceeds size of int32!");
+        cellSorted(n) = SwarmKey(static_cast<int>(cell_idx_1d), n);
       });
 
   sort(cellSorted, SwarmKeyComparator(), 0, max_active_index);

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -497,6 +497,8 @@ void Swarm::SortParticlesByCell() {
   const int nx1 = pmb->cellbounds.ncellsi(IndexDomain::entire);
   const int nx2 = pmb->cellbounds.ncellsj(IndexDomain::entire);
   const int nx3 = pmb->cellbounds.ncellsk(IndexDomain::entire);
+  PARTHENON_REQUIRE(nx1 * nx2 * nx3 < std::numeric_limits<int>::max(),
+                    "Too many cells for an int32 to store cell_idx_1d below!");
 
   auto cellSorted = cellSorted_;
   int ncells = pmb->cellbounds.GetTotal(IndexDomain::entire);
@@ -518,8 +520,6 @@ void Swarm::SortParticlesByCell() {
         int i, j, k;
         swarm_d.Xtoijk(x(n), y(n), z(n), i, j, k);
         const int64_t cell_idx_1d = i + nx1 * (j + nx2 * k);
-        PARTHENON_DEBUG_REQUIRE(cell_idx_1d < std::numeric_limits<int>::max(),
-                                "cell_idx_1d exceeds size of int32!");
         cellSorted(n) = SwarmKey(static_cast<int>(cell_idx_1d), n);
       });
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -16,11 +16,9 @@
 #include <utility>
 #include <vector>
 
-#include <thrust/sort.h>
-#include <thrust/device_ptr.h>
-
 #include "mesh/mesh.hpp"
 #include "swarm.hpp"
+#include "utils/sort.hpp"
 
 namespace parthenon {
 
@@ -523,12 +521,13 @@ void Swarm::SortParticlesByCell() {
       });
 
   // Sort the list
-#ifdef KOKKOS_ENABLE_CUDA
+  sort(cellSorted_.data(), cellSorted_.data() + max_active_index_ + 1, SwarmKeyComparator());
+/*#ifdef KOKKOS_ENABLE_CUDA
   thrust::device_ptr<SwarmKey> d = thrust::device_pointer_cast(cellSorted_.data());
   thrust::sort(d, d + max_active_index_ + 1, SwarmKeyCompare());
 #else
   std::sort(cellSorted_.data(), cellSorted_.data() + max_active_index_ + 1, SwarmKeyCompare());
-#endif
+#endif*/
 
 
   printf("extent0: %i (%i)\n", cellSorted_.extent(0), max_active_index_ + 1);

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -16,6 +16,9 @@
 #include <utility>
 #include <vector>
 
+#include <thrust/sort.h>
+#include <thrust/device_ptr.h>
+
 #include "mesh/mesh.hpp"
 #include "swarm.hpp"
 
@@ -521,7 +524,8 @@ void Swarm::SortParticlesByCell() {
 
   // Sort the list
 #ifdef KOKKOS_ENABLE_CUDA
-  thrust::sort(cellSorted_.data(), cellSorted_.data() + max_active_index_ + 1, SwarmKeyCompare());
+  thrust::device_ptr<SwarmKey> d = thrust::device_pointer_cast(cellSorted_.data());
+  thrust::sort(d, d + max_active_index_ + 1, SwarmKeyCompare());
 #else
   std::sort(cellSorted_.data(), cellSorted_.data() + max_active_index_ + 1, SwarmKeyCompare());
 #endif
@@ -601,6 +605,8 @@ void Swarm::SortParticlesByCell() {
       printf("cellSortedBegin_(%i,%i,%i) = %i\n", k,j,i,cellSortedBegin_(k,j,i));
       printf("cellSortedNumber_(%i,%i%i) = %i\n", k,j,i,cellSortedNumber_(k,j,i));
     });
+
+  pmb->exec_space.fence();
 
   exit(-1);
 }

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -12,6 +12,7 @@
 //========================================================================================
 #include <algorithm>
 #include <cstdlib>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -520,7 +520,12 @@ void Swarm::SortParticlesByCell() {
       });
 
   // Sort the list
+#ifdef KOKKOS_ENABLE_CUDA
+  thrust::sort(cellSorted_.data(), cellSorted_.data() + max_active_index_ + 1, SwarmKeyCompare());
+#else
   std::sort(cellSorted_.data(), cellSorted_.data() + max_active_index_ + 1, SwarmKeyCompare());
+#endif
+
 
   printf("extent0: %i (%i)\n", cellSorted_.extent(0), max_active_index_ + 1);
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -28,6 +28,9 @@ SwarmDeviceContext Swarm::GetDeviceContext() const {
   context.mask_ = mask_.data;
   context.blockIndex_ = blockIndex_;
   context.neighborIndices_ = neighborIndices_;
+  //context.cellSorted_ = cellSorted_;
+  //context.cellSortedBegin_ = cellSortedBegin_;
+  //context.cellSortedNumber_ = cellSortedNumber_;
 
   auto pmb = GetBlockPointer();
   auto pmesh = pmb->pmy_mesh;
@@ -64,6 +67,7 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
       neighbor_send_index_("nsi", nmax_pool_, Metadata({Metadata::Integer})),
       blockIndex_("blockIndex_", nmax_pool_),
       neighborIndices_("neighborIndices_", 4, 4, 4),
+      //cellSortedMap_("cellSortedMap_", nmax_pool_),
       cellSorted_("cellSorted_", nmax_pool_), mpiStatus(true) {
   PARTHENON_REQUIRE_THROWS(typeid(Coordinates_t) == typeid(UniformCartesian),
                            "SwarmDeviceContext only supports a uniform Cartesian mesh!");
@@ -278,6 +282,7 @@ void Swarm::setPoolMax(const int nmax_pool) {
       KOKKOS_LAMBDA(const int n) { marked_for_removal_data(n) = false; });
 
   Kokkos::resize(cellSorted_, nmax_pool);
+  //Kokkos::resize(cellSortedMap_, nmax_pool);
 
   neighbor_send_index_.Get().Resize(nmax_pool);
 
@@ -484,7 +489,6 @@ void Swarm::Defrag() {
 ///
 void Swarm::SortParticlesByCell() {
   auto pmb = GetBlockPointer();
-  auto swarm_d = GetDeviceContext();
 
   auto &x = Get<Real>("x").Get();
   auto &y = Get<Real>("y").Get();
@@ -495,17 +499,20 @@ void Swarm::SortParticlesByCell() {
   const int nx3 = pmb->cellbounds.ncellsk(IndexDomain::entire);
 
   auto cellSorted = cellSorted_;
-  auto cellSortedBegin = cellSortedBegin_;
-  auto cellSortedNumber = cellSortedNumber_;
+  //auto cellSortedMap = cellSortedMap_;
   int ncells = pmb->cellbounds.GetTotal(IndexDomain::entire);
   int num_active = num_active_;
   int max_active_index = max_active_index_;
 
   // Allocate data if necessary
-  if (cellSortedBegin.GetDim(1) == 0) {
-    cellSortedBegin = ParArrayND<int>("cellSortedBegin_", 0, 0, 0, nx3, nx2, nx1);
-    cellSortedNumber = ParArrayND<int>("cellSortedEnd_", 0, 0, 0, nx3, nx2, nx1);
+  if (cellSortedBegin_.GetDim(1) == 0) {
+    cellSortedBegin_ = ParArrayND<int>("cellSortedBegin_", nx3, nx2, nx1);
+    cellSortedNumber_ = ParArrayND<int>("cellSortedNumber_", nx3, nx2, nx1);
   }
+  auto cellSortedBegin = cellSortedBegin_;
+  auto cellSortedNumber = cellSortedNumber_;
+  printf("%s:%i\n", __FILE__, __LINE__);
+  auto swarm_d = GetDeviceContext();
 
   // Write an unsorted list
   pmb->par_for(
@@ -517,11 +524,35 @@ void Swarm::SortParticlesByCell() {
       });
 
   sort(cellSorted, SwarmKeyComparator(), 0, max_active_index);
+  printf("%s:%i\n", __FILE__, __LINE__);
+
+  //printf("cell map extents: %i %i\n", cellSortedMap.extent(0), cellSorted.extent(0));
+
+//  pmb->par_for(
+//       "Write sorted integer map", 0, max_active_index_, KOKKOS_LAMBDA(const int n) {
+//         cellSortedMap(n) = cellSorted(n).swarm_idx_;
+ //      });
+  printf("%s:%i\n", __FILE__, __LINE__);
 
   // Update per-cell arrays for easier accessing later
   const IndexRange &ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   const IndexRange &jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   const IndexRange &kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
+  printf("extent sort: %i\n", cellSorted.extent(0));
+  printf("extent: %i %i %i %i %i %i\n",
+    cellSortedBegin.GetDim(1),
+    cellSortedBegin.GetDim(2),
+    cellSortedBegin.GetDim(3),
+    cellSortedBegin.GetDim(4),
+    cellSortedBegin.GetDim(5),
+    cellSortedBegin.GetDim(6));
+  printf("extentnum: %i %i %i %i %i %i\n",
+    cellSortedNumber.GetDim(1),
+    cellSortedNumber.GetDim(2),
+    cellSortedNumber.GetDim(3),
+    cellSortedNumber.GetDim(4),
+    cellSortedNumber.GetDim(5),
+    cellSortedNumber.GetDim(6));
   pmb->par_for(
       "Update per-cell arrays", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
@@ -565,6 +596,7 @@ void Swarm::SortParticlesByCell() {
             continue;
           }
         }
+        //printf("i j k : %i %i %i\n", i, j, k);
         cellSortedBegin(k, j, i) = start_index;
         if (start_index == -1) {
           cellSortedNumber(k, j, i) = 0;
@@ -573,12 +605,14 @@ void Swarm::SortParticlesByCell() {
           int current_index = start_index;
           while (current_index <= max_active_index &&
                  cellSorted(current_index).cell_idx_1d_ == cell_idx_1d) {
+            printf("current_index: %i\n", current_index);
             current_index++;
             number++;
             cellSortedNumber(k, j, i) = number;
           }
         }
       });
+  printf("%s:%i\n", __FILE__, __LINE__);
 }
 
 ///

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -64,8 +64,7 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
       neighbor_send_index_("nsi", nmax_pool_, Metadata({Metadata::Integer})),
       blockIndex_("blockIndex_", nmax_pool_),
       neighborIndices_("neighborIndices_", 4, 4, 4),
-      cellSorted_("cellSorted_", nmax_pool_),
-      mpiStatus(true) {
+      cellSorted_("cellSorted_", nmax_pool_), mpiStatus(true) {
   PARTHENON_REQUIRE_THROWS(typeid(Coordinates_t) == typeid(UniformCartesian),
                            "SwarmDeviceContext only supports a uniform Cartesian mesh!");
 
@@ -479,9 +478,9 @@ void Swarm::Defrag() {
 
 ///
 /// Routine to sort particles by cell. Updates internal swarm variables:
-///  cellSorted_: 1D Per-cell sorted array of swarm memory indices (SwarmKey::swarm_index_)
-///  cellSortedBegin_: Per-cell array of starting indices in cellSorted_
-///  cellSortedNumber_: Per-cell array of number of particles in each cell
+///  cellSorted_: 1D Per-cell sorted array of swarm memory indices
+///  (SwarmKey::swarm_index_) cellSortedBegin_: Per-cell array of starting indices in
+///  cellSorted_ cellSortedNumber_: Per-cell array of number of particles in each cell
 ///
 void Swarm::SortParticlesByCell() {
   auto pmb = GetBlockPointer();
@@ -504,120 +503,82 @@ void Swarm::SortParticlesByCell() {
 
   // Allocate data if necessary
   if (cellSortedBegin.GetDim(1) == 0) {
-    cellSortedBegin = ParArrayND<int>("cellSortedBegin_", 0,0,0,nx3,nx2,nx1);
-    cellSortedNumber = ParArrayND<int>("cellSortedEnd_", 0,0,0,nx3,nx2,nx1);
+    cellSortedBegin = ParArrayND<int>("cellSortedBegin_", 0, 0, 0, nx3, nx2, nx1);
+    cellSortedNumber = ParArrayND<int>("cellSortedEnd_", 0, 0, 0, nx3, nx2, nx1);
   }
 
   // Write an unsorted list
   pmb->par_for(
-      "Write unsorted list", 0, max_active_index_,
-      KOKKOS_LAMBDA(const int n) {
+      "Write unsorted list", 0, max_active_index_, KOKKOS_LAMBDA(const int n) {
         int i, j, k;
         swarm_d.Xtoijk(x(n), y(n), z(n), i, j, k);
         const int cell_idx_1d = i + nx1 * (j + nx2 * k);
-        //int cell_idx_1d = n; // TODO(BRR) calc
         cellSorted(n) = SwarmKey(cell_idx_1d, n);
       });
 
-  // Print the unsorted list
-  pmb->par_for(
-      "Print unsorted list", 0, max_active_index_,
-      KOKKOS_LAMBDA(const int n) {
-      printf("cell(un)Sorted(%i) = cell_idx_1d: %i swarm_idx: %i\n", n, cellSorted(n).cell_idx_1d_,
-        cellSorted(n).swarm_idx_);
-      });
-
-  // Sort the list
   sort(cellSorted, SwarmKeyComparator(), 0, max_active_index);
-  //sort(cellSorted.data(), cellSorted.data() + max_active_index_ + 1, SwarmKeyComparator());
-/*#ifdef KOKKOS_ENABLE_CUDA
-  //thrust::device_ptr<SwarmKey> d = thrust::device_pointer_cast(cellSorted_.data());
-  //thrust::sort(d, d + max_active_index_ + 1, SwarmKeyCompare());
-  thrust::device_ptr<SwarmKey> first = thrust::device_pointer_cast(cellSorted.data());
-  //thrust::device_ptr<SwarmKey> last = thrust::device_pointer_cast(cellSorted.data() + max_active_index_ + 1);
-  thrust::device_ptr<SwarmKey> last = thrust::device_pointer_cast(cellSorted.data()) + max_active_index_ + 1;
-  thrust::sort(first, last, SwarmKeyComparator());
-#else
-  std::sort(cellSorted.data(), cellSorted.data() + max_active_index_ + 1, SwarmKeyCompare());
-#endif*/
-
-
-  printf("extent0: %i (%i)\n", cellSorted.extent(0), max_active_index_ + 1);
-
-  // Print the list
-  pmb->par_for(
-      "Print sorted list", 0, max_active_index_,
-      KOKKOS_LAMBDA(const int n) {
-      printf("cellSorted(%i) = cell_idx_1d: %i swarm_idx: %i\n", n, cellSorted(n).cell_idx_1d_,
-        cellSorted(n).swarm_idx_);
-      });
 
   // Update per-cell arrays for easier accessing later
   const IndexRange &ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire);
   const IndexRange &jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire);
   const IndexRange &kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire);
-  pmb->par_for("Update per-cell arrays", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-    KOKKOS_LAMBDA(const int k, const int j, const int i) {
-      int cell_idx_1d = i + nx1 * (j + nx2 * k);
-      // Find starting index, first by guessing
-      int start_index = static_cast<int>((cell_idx_1d*num_active/ncells));
-      printf("[%i %i %i] start: %i\n", k, j, i, start_index);
-      int n = 0;
-      while (true) {
-        n++;
-        // Check if we left the list
-        if (start_index < 0 || start_index > max_active_index) {
-          start_index = -1;
-          break;
-        }
+  pmb->par_for(
+      "Update per-cell arrays", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
+      KOKKOS_LAMBDA(const int k, const int j, const int i) {
+        int cell_idx_1d = i + nx1 * (j + nx2 * k);
+        // Find starting index, first by guessing
+        int start_index = static_cast<int>((cell_idx_1d * num_active / ncells));
+        int n = 0;
+        while (true) {
+          n++;
+          // Check if we left the list
+          if (start_index < 0 || start_index > max_active_index) {
+            start_index = -1;
+            break;
+          }
 
-        if (cellSorted(start_index).cell_idx_1d_ == cell_idx_1d) {
-          if (start_index == 0) {
-            break;
-          } else if (cellSorted(start_index - 1).cell_idx_1d_ != cell_idx_1d) {
-            break;
-          } else {
+          if (cellSorted(start_index).cell_idx_1d_ == cell_idx_1d) {
+            if (start_index == 0) {
+              break;
+            } else if (cellSorted(start_index - 1).cell_idx_1d_ != cell_idx_1d) {
+              break;
+            } else {
+              start_index--;
+              continue;
+            }
+          }
+
+          if (cellSorted(start_index).cell_idx_1d_ >= cell_idx_1d) {
             start_index--;
+            if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
+              start_index = -1;
+              break;
+            }
+            continue;
+          }
+          if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
+            start_index++;
+            if (cellSorted(start_index).cell_idx_1d_ > cell_idx_1d) {
+              start_index = -1;
+              break;
+            }
             continue;
           }
         }
-
-        if (cellSorted(start_index).cell_idx_1d_ >= cell_idx_1d) {
-          start_index--;
-          if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
-            start_index = -1;
-            break;
+        cellSortedBegin(k, j, i) = start_index;
+        if (start_index == -1) {
+          cellSortedNumber(k, j, i) = 0;
+        } else {
+          int number = 0;
+          int current_index = start_index;
+          while (current_index <= max_active_index &&
+                 cellSorted(current_index).cell_idx_1d_ == cell_idx_1d) {
+            current_index++;
+            number++;
+            cellSortedNumber(k, j, i) = number;
           }
-          continue;
         }
-        if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
-          start_index++;
-          if (cellSorted(start_index).cell_idx_1d_ > cell_idx_1d) {
-            start_index = -1;
-            break;
-          }
-          continue;
-        }
-      }
-      cellSortedBegin(k,j,i) = start_index;
-      if (start_index == -1) {
-        cellSortedNumber(k,j,i) = 0;
-      } else {
-        int number = 0;
-        int current_index = start_index;
-        while (current_index <= max_active_index && cellSorted(current_index).cell_idx_1d_ == cell_idx_1d) {
-          current_index++;
-          number++;
-          cellSortedNumber(k,j,i) = number;
-        }
-      }
-      printf("cellSortedBegin_(%i,%i,%i) = %i\n", k,j,i,cellSortedBegin(k,j,i));
-      printf("cellSortedNumber_(%i,%i%i) = %i\n", k,j,i,cellSortedNumber(k,j,i));
-    });
-
-  pmb->exec_space.fence();
-
-  exit(-1);
+      });
 }
 
 ///

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -53,8 +53,8 @@ struct SwarmKey {
   KOKKOS_INLINE_FUNCTION
   SwarmKey() {}
   KOKKOS_INLINE_FUNCTION
-  SwarmKey(const int cell_idx_1d, const int swarm_idx_1d) :
-    cell_idx_1d_(cell_idx_1d), swarm_idx_(swarm_idx_1d) {}
+  SwarmKey(const int cell_idx_1d, const int swarm_idx_1d)
+      : cell_idx_1d_(cell_idx_1d), swarm_idx_(swarm_idx_1d) {}
 
   int cell_idx_1d_;
   int swarm_idx_;
@@ -62,7 +62,7 @@ struct SwarmKey {
 
 struct SwarmKeyComparator {
   KOKKOS_INLINE_FUNCTION
-  bool operator() (const SwarmKey& s1, const SwarmKey& s2) {
+  bool operator()(const SwarmKey &s1, const SwarmKey &s2) {
     return s1.cell_idx_1d_ < s2.cell_idx_1d_;
   }
 };

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -59,6 +59,7 @@ struct SwarmKey {
   int cell_idx_1d_;
   int swarm_idx_;
 };
+
 struct SwarmKeyComparator {
   KOKKOS_INLINE_FUNCTION
   bool operator() (const SwarmKey& s1, const SwarmKey& s2) {

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -253,9 +253,8 @@ class Swarm {
 
   ParArrayND<int> neighbor_buffer_index_; // Map from neighbor index to neighbor bufid
 
-  ParArray1D<SwarmKey> cellSorted_; // 1D per-cell sorted array of key-value swarm memory indices
-
-  ParArray1D<int> cellSortedMap_; // 1D per-cell sorted array of swarm pool indices
+  ParArray1D<SwarmKey>
+      cellSorted_; // 1D per-cell sorted array of key-value swarm memory indices
 
   ParArrayND<int> cellSortedBegin_; // Per-cell array of starting indices in cell_sorted_
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -49,24 +49,6 @@ class MeshBlock;
 
 enum class PARTICLE_STATUS { UNALLOCATED, ALIVE, DEAD };
 
-struct SwarmKey {
-  KOKKOS_INLINE_FUNCTION
-  SwarmKey() {}
-  KOKKOS_INLINE_FUNCTION
-  SwarmKey(const int cell_idx_1d, const int swarm_idx_1d)
-      : cell_idx_1d_(cell_idx_1d), swarm_idx_(swarm_idx_1d) {}
-
-  int cell_idx_1d_;
-  int swarm_idx_;
-};
-
-struct SwarmKeyComparator {
-  KOKKOS_INLINE_FUNCTION
-  bool operator()(const SwarmKey &s1, const SwarmKey &s2) {
-    return s1.cell_idx_1d_ < s2.cell_idx_1d_;
-  }
-};
-
 class Swarm {
  private:
   static const int IntVec = 0;
@@ -271,7 +253,9 @@ class Swarm {
 
   ParArrayND<int> neighbor_buffer_index_; // Map from neighbor index to neighbor bufid
 
-  ParArray1D<SwarmKey> cellSorted_; // 1D per-cell sorted array of swarm memory indices
+  ParArray1D<SwarmKey> cellSorted_; // 1D per-cell sorted array of key-value swarm memory indices
+
+  ParArray1D<int> cellSortedMap_; // 1D per-cell sorted array of swarm pool indices
 
   ParArrayND<int> cellSortedBegin_; // Per-cell array of starting indices in cell_sorted_
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -59,9 +59,9 @@ struct SwarmKey {
   int cell_idx_1d_;
   int swarm_idx_;
 };
-struct SwarmKeyCompare {
+struct SwarmKeyComparator {
   KOKKOS_INLINE_FUNCTION
-  bool operator() (const SwarmKey& s1, SwarmKey& s2) {
+  bool operator() (const SwarmKey& s1, const SwarmKey& s2) {
     return s1.cell_idx_1d_ < s2.cell_idx_1d_;
   }
 };

--- a/src/interface/swarm_container.cpp
+++ b/src/interface/swarm_container.cpp
@@ -80,11 +80,24 @@ TaskStatus SwarmContainer::Defrag(double min_occupancy) {
                            "Max fractional occupancy of swarm must be >= 0 and <= 1");
 
   for (auto &s : swarmVector_) {
+    // TODO(BRR) Why is this called?
     s->SetupPersistentMPI();
     if (s->GetNumActive() > 0 &&
         s->GetNumActive() / (s->GetMaxActiveIndex() + 1.0) < min_occupancy) {
       s->Defrag();
     }
+  }
+
+  Kokkos::Profiling::popRegion();
+
+  return TaskStatus::complete;
+}
+
+TaskStatus SwarmContainer::SortParticlesByCell() {
+  Kokkos::Profiling::pushRegion("Task_SwarmContainer_SortParticlesByCell");
+
+  for (auto &s : swarmVector_) {
+    s->SortParticlesByCell();
   }
 
   Kokkos::Profiling::popRegion();

--- a/src/interface/swarm_container.cpp
+++ b/src/interface/swarm_container.cpp
@@ -80,8 +80,6 @@ TaskStatus SwarmContainer::Defrag(double min_occupancy) {
                            "Max fractional occupancy of swarm must be >= 0 and <= 1");
 
   for (auto &s : swarmVector_) {
-    // TODO(BRR) Why is this called?
-    s->SetupPersistentMPI();
     if (s->GetNumActive() > 0 &&
         s->GetNumActive() / (s->GetMaxActiveIndex() + 1.0) < min_occupancy) {
       s->Defrag();

--- a/src/interface/swarm_container.hpp
+++ b/src/interface/swarm_container.hpp
@@ -136,6 +136,9 @@ class SwarmContainer {
   // Defragmentation task
   TaskStatus Defrag(double min_occupancy);
 
+  // Sort-by-cell task
+  TaskStatus SortParticlesByCell();
+
   // Communication routines
   void SetupPersistentMPI();
   [[deprecated("Not yet implemented")]] void SetBoundaries();

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -101,15 +101,14 @@ class SwarmDeviceContext {
 
   KOKKOS_INLINE_FUNCTION
   int GetParticleCountPerCell(const int k, const int j, const int i) const {
-    return 0;
-    //return cellSortedNumber_(k, j, i);
+    return cellSortedNumber_(k, j, i);
   }
 
   KOKKOS_INLINE_FUNCTION
   int GetFullIndex(const int k, const int j, const int i, const int n) const {
-    return 0;
-    //PARTHENON_DEBUG_REQUIRE(n < cellSortedNumber_(k, j, i), "Particle index out of range!");
-    //return cellSorted_(cellSortedBegin_(k, j, i) + n).swarm_idx_;
+    PARTHENON_DEBUG_REQUIRE(n < cellSortedNumber_(k, j, i),
+                            "Particle index out of range!");
+    return cellSorted_(cellSortedBegin_(k, j, i) + n).swarm_idx_;
   }
 
   // private:
@@ -132,9 +131,9 @@ class SwarmDeviceContext {
   ParArrayND<bool> mask_;
   ParArrayND<int> blockIndex_;
   ParArrayND<int> neighborIndices_; // 4x4x4 array of possible block AMR regions
-  //ParArray1D<SwarmKey> cellSorted_;
-  //ParArrayND<int> cellSortedBegin_;
-  //ParArrayND<int> cellSortedNumber_;
+  ParArray1D<SwarmKey> cellSorted_;
+  ParArrayND<int> cellSortedBegin_;
+  ParArrayND<int> cellSortedNumber_;
   int ndim_;
   friend class Swarm;
   constexpr static int this_block_ = -1; // Mirrors definition in Swarm class

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -14,8 +14,27 @@
 #define INTERFACE_SWARM_DEVICE_CONTEXT_HPP_
 
 #include "coordinates/coordinates.hpp"
+#include "utils/utils.hpp"
 
 namespace parthenon {
+
+struct SwarmKey {
+  KOKKOS_INLINE_FUNCTION
+  SwarmKey() {}
+  KOKKOS_INLINE_FUNCTION
+  SwarmKey(const int cell_idx_1d, const int swarm_idx_1d)
+      : cell_idx_1d_(cell_idx_1d), swarm_idx_(swarm_idx_1d) {}
+
+  int cell_idx_1d_;
+  int swarm_idx_;
+};
+
+struct SwarmKeyComparator {
+  KOKKOS_INLINE_FUNCTION
+  bool operator()(const SwarmKey &s1, const SwarmKey &s2) {
+    return s1.cell_idx_1d_ < s2.cell_idx_1d_;
+  }
+};
 
 // TODO(BRR) Template this class on coordinates/pass appropriate additional args to e.g.
 // coords_.Dx()
@@ -80,6 +99,19 @@ class SwarmDeviceContext {
                     : kb_s_;
   }
 
+  KOKKOS_INLINE_FUNCTION
+  int GetParticleCountPerCell(const int k, const int j, const int i) const {
+    return 0;
+    //return cellSortedNumber_(k, j, i);
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  int GetFullIndex(const int k, const int j, const int i, const int n) const {
+    return 0;
+    //PARTHENON_DEBUG_REQUIRE(n < cellSortedNumber_(k, j, i), "Particle index out of range!");
+    //return cellSorted_(cellSortedBegin_(k, j, i) + n).swarm_idx_;
+  }
+
   // private:
   int ib_s_;
   int jb_s_;
@@ -100,6 +132,9 @@ class SwarmDeviceContext {
   ParArrayND<bool> mask_;
   ParArrayND<int> blockIndex_;
   ParArrayND<int> neighborIndices_; // 4x4x4 array of possible block AMR regions
+  //ParArray1D<SwarmKey> cellSorted_;
+  //ParArrayND<int> cellSortedBegin_;
+  //ParArrayND<int> cellSortedNumber_;
   int ndim_;
   friend class Swarm;
   constexpr static int this_block_ = -1; // Mirrors definition in Swarm class

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -20,6 +20,8 @@
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
 
+#include <Kokkos_Sort.hpp>
+
 #ifdef KOKKOS_ENABLE_CUDA
 #include <thrust/device_ptr.h>
 #include <thrust/sort.h>

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -21,16 +21,19 @@
 #include "parthenon_arrays.hpp"
 
 #ifdef KOKKOS_ENABLE_CUDA
-#include <thrust/sort.h>
 #include <thrust/device_ptr.h>
+#include <thrust/sort.h>
 #endif
 
 namespace parthenon {
 
-template<class Key, class KeyComparator>
-void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx, size_t max_idx) {
-  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0), "Invalid minimum sort index!");
-  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0), "Invalid maximum sort index!");
+template <class Key, class KeyComparator>
+void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx,
+          size_t max_idx) {
+  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0),
+                          "Invalid minimum sort index!");
+  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0),
+                          "Invalid maximum sort index!");
 #ifdef KOKKOS_ENABLE_CUDA
   thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data()) + min_idx;
   thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + max_idx + 1;
@@ -40,10 +43,12 @@ void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx, size_t
 #endif // KOKKOS_ENABLE_CUDA
 }
 
-template<class Key>
+template <class Key>
 void sort(ParArray1D<Key> data, size_t min_idx, size_t max_idx) {
-  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0), "Invalid minimum sort index!");
-  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0), "Invalid maximum sort index!");
+  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0),
+                          "Invalid minimum sort index!");
+  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0),
+                          "Invalid maximum sort index!");
 #ifdef KOKKOS_ENABLE_CUDA
   thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data()) + min_idx;
   thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + max_idx + 1;
@@ -53,12 +58,12 @@ void sort(ParArray1D<Key> data, size_t min_idx, size_t max_idx) {
 #endif // KOKKOS_ENABLE_CUDA
 }
 
-template<class Key, class KeyComparator>
+template <class Key, class KeyComparator>
 void sort(ParArray1D<Key> data, KeyComparator comparator) {
   sort(data, comparator, 0, data.extent(0) - 1);
 }
 
-template<class Key>
+template <class Key>
 void sort(ParArray1D<Key> data) {
   sort(data, 0, data.extent(0) - 1);
 }

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -43,7 +43,11 @@ void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx,
   thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + max_idx + 1;
   thrust::sort(first_d, last_d, comparator);
 #else
-  std::sort(data.data() + min_idx, data.data() + max_idx + 1, comparator);
+  if (std::is_same<DevExecSpace, HostExecSpace>::value) {
+    std::sort(data.data() + min_idx, data.data() + max_idx + 1, comparator);
+  } else {
+    PARTHENON_FAIL("sort is not supported outside of CPU or NVIDIA GPU");
+  }
 #endif // KOKKOS_ENABLE_CUDA
 }
 
@@ -58,7 +62,11 @@ void sort(ParArray1D<Key> data, size_t min_idx, size_t max_idx) {
   thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + max_idx + 1;
   thrust::sort(first_d, last_d);
 #else
-  std::sort(data.data() + min_idx, data.data() + max_idx + 1);
+  if (std::is_same<DevExecSpace, HostExecSpace>::value) {
+    std::sort(data.data() + min_idx, data.data() + max_idx + 1);
+  } else {
+    PARTHENON_FAIL("sort is not supported outside of CPU or NVIDIA GPU");
+  }
 #endif // KOKKOS_ENABLE_CUDA
 }
 

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -28,11 +28,61 @@
 
 namespace parthenon {
 
+template<class Key, class KeyComparator>
+void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx, size_t max_idx) {
+  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0), "Invalid minimum sort index!");
+  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0), "Invalid maximum sort index!");
+#ifdef KOKKOS_ENABLE_CUDA
+  thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data()) + min_idx;
+  thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + max_idx + 1;
+  thrust::sort(first_d, last_d, comparator);
+#else
+  std::sort(data.data() + min_idx, data.data() + max_idx + 1, comparator);
+#endif // KOKKOS_ENABLE_CUDA
+}
+
+template<class Key>
+void sort(ParArray1D<Key> data, size_t min_idx, size_t max_idx) {
+  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0), "Invalid minimum sort index!");
+  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0), "Invalid maximum sort index!");
+#ifdef KOKKOS_ENABLE_CUDA
+  thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data()) + min_idx;
+  thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + max_idx + 1;
+  thrust::sort(first_d, last_d);
+#else
+  std::sort(data.data() + min_idx, data.data() + max_idx + 1);
+#endif // KOKKOS_ENABLE_CUDA
+}
+
+template<class Key, class KeyComparator>
+void sort(ParArray1D<Key> data, KeyComparator comparator) {
+  sort(data, comparator, 0, data.extent(0) - 1);
+/*#ifdef KOKKOS_ENABLE_CUDA
+  thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data());
+  thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + data.extent(0);
+  thrust::sort(first_d, last_d, comparator);
+#else
+  std::sort(data.data(), data.extent(0), comparator);
+#endif // KOKKOS_ENABLE_CUDA*/
+}
+
+template<class Key>
+void sort(ParArray1D<Key> data) {
+  sort(data, 0, data.extent(0) - 1);
+/*#ifdef KOKKOS_ENABLE_CUDA
+  thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data());
+  thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + data.extent(0);
+  thrust::sort(first_d, last_d);
+#else
+  std::sort(first, last);
+#endif // KOKKOS_ENABLE_CUDA*/
+}
+/*
 template<class KeyIterator, class KeyComparator>
 void sort(KeyIterator first, KeyIterator last, KeyComparator comparator) {
 #ifdef KOKKOS_ENABLE_CUDA
   thrust::device_ptr<KeyIterator> first_d = thrust::device_pointer_cast(first);
-  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(last);
+  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(first) + (last - first);
   thrust::sort(first_d, last_d, comparator);
 #else
   std::sort(first, last, comparator);
@@ -43,13 +93,13 @@ template<class KeyIterator>
 void sort(KeyIterator first, KeyIterator last) {
 #ifdef KOKKOS_ENABLE_CUDA
   thrust::device_ptr<KeyIterator> first_d = thrust::device_pointer_cast(first);
-  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(last);
+  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(first) + (last - first);
   thrust::sort(first_d, last_d);
 #else
   std::sort(first, last);
 #endif // KOKKOS_ENABLE_CUDA
 }
-
+*/
 } // namespace parthenon
 
 #endif // UTILS_SORT_HPP_

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -1,0 +1,55 @@
+//========================================================================================
+// (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef UTILS_SORT_HPP_
+#define UTILS_SORT_HPP_
+
+//! \file sort.hpp
+//  \brief Contains functions for sorting data according to a provided comparator
+//  See src/interface/swarm.hpp for an example KeyIterator and KeyComparator, SwarmKey and
+//  SwarmKeyCompare
+
+#include "defs.hpp"
+#include "parthenon_arrays.hpp"
+
+#ifdef KOKKOS_ENABLE_CUDA
+#include <thrust/sort.h>
+#include <thrust/device_ptr.h>
+#endif
+
+namespace parthenon {
+
+template<class KeyIterator, class KeyComparator>
+void sort(KeyIterator first, KeyIterator last, KeyComparator comparator) {
+#ifdef KOKKOS_ENABLE_CUDA
+  thrust::device_ptr<KeyIterator> first_d = thrust::device_pointer_cast(first);
+  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(last);
+  thrust::sort(first_d, last_d, comparator);
+#else
+  std::sort(first, last, comparator);
+#endif // KOKKOS_ENABLE_CUDA
+}
+
+template<class KeyIterator>
+void sort(KeyIterator first, KeyIterator last) {
+#ifdef KOKKOS_ENABLE_CUDA
+  thrust::device_ptr<KeyIterator> first_d = thrust::device_pointer_cast(first);
+  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(last);
+  thrust::sort(first_d, last_d);
+#else
+  std::sort(first, last);
+#endif // KOKKOS_ENABLE_CUDA
+}
+
+} // namespace parthenon
+
+#endif // UTILS_SORT_HPP_

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -25,6 +25,8 @@
 #include <thrust/sort.h>
 #endif
 
+#include <algorithm>
+
 namespace parthenon {
 
 template <class Key, class KeyComparator>

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -15,8 +15,7 @@
 
 //! \file sort.hpp
 //  \brief Contains functions for sorting data according to a provided comparator
-//  See src/interface/swarm.hpp for an example KeyIterator and KeyComparator, SwarmKey and
-//  SwarmKeyCompare
+//  See tst/unit/test_unit_sort.cpp for example usage.
 
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
@@ -57,49 +56,13 @@ void sort(ParArray1D<Key> data, size_t min_idx, size_t max_idx) {
 template<class Key, class KeyComparator>
 void sort(ParArray1D<Key> data, KeyComparator comparator) {
   sort(data, comparator, 0, data.extent(0) - 1);
-/*#ifdef KOKKOS_ENABLE_CUDA
-  thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data());
-  thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + data.extent(0);
-  thrust::sort(first_d, last_d, comparator);
-#else
-  std::sort(data.data(), data.extent(0), comparator);
-#endif // KOKKOS_ENABLE_CUDA*/
 }
 
 template<class Key>
 void sort(ParArray1D<Key> data) {
   sort(data, 0, data.extent(0) - 1);
-/*#ifdef KOKKOS_ENABLE_CUDA
-  thrust::device_ptr<Key> first_d = thrust::device_pointer_cast(data.data());
-  thrust::device_ptr<Key> last_d = thrust::device_pointer_cast(data.data()) + data.extent(0);
-  thrust::sort(first_d, last_d);
-#else
-  std::sort(first, last);
-#endif // KOKKOS_ENABLE_CUDA*/
-}
-/*
-template<class KeyIterator, class KeyComparator>
-void sort(KeyIterator first, KeyIterator last, KeyComparator comparator) {
-#ifdef KOKKOS_ENABLE_CUDA
-  thrust::device_ptr<KeyIterator> first_d = thrust::device_pointer_cast(first);
-  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(first) + (last - first);
-  thrust::sort(first_d, last_d, comparator);
-#else
-  std::sort(first, last, comparator);
-#endif // KOKKOS_ENABLE_CUDA
 }
 
-template<class KeyIterator>
-void sort(KeyIterator first, KeyIterator last) {
-#ifdef KOKKOS_ENABLE_CUDA
-  thrust::device_ptr<KeyIterator> first_d = thrust::device_pointer_cast(first);
-  thrust::device_ptr<KeyIterator> last_d = thrust::device_pointer_cast(first) + (last - first);
-  thrust::sort(first_d, last_d);
-#else
-  std::sort(first, last);
-#endif // KOKKOS_ENABLE_CUDA
-}
-*/
 } // namespace parthenon
 
 #endif // UTILS_SORT_HPP_

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ list(APPEND unit_tests_SOURCES
     test_unit_params.cpp
     test_unit_constants.cpp
     test_unit_domain.cpp
+    test_unit_sort.cpp
     kokkos_abstraction.cpp
     test_metadata.cpp
     test_pararrays.cpp

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -46,7 +46,6 @@ struct KeyComparator {
 
 TEST_CASE("Sorting", "[sort]") {
   GIVEN("An unordered list of integers") {
-
     ParArray1D<int> data("Data to sort", N);
 
     parthenon::par_for(

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -1,0 +1,96 @@
+//========================================================================================
+// (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#include <catch2/catch.hpp>
+
+#include "kokkos_abstraction.hpp"
+#include "parthenon_arrays.hpp"
+#include "utils/sort.hpp"
+
+using parthenon::sort;
+using parthenon::ParArray1D;
+
+constexpr int N = 100;
+constexpr int STRLEN = 1024;
+
+struct Key {
+  KOKKOS_INLINE_FUNCTION
+  Key() {}
+  KOKKOS_INLINE_FUNCTION
+  Key(const int key, const char value[STRLEN]) : key_(key) {
+    std::copy(value, value + STRLEN, value_);
+  }
+
+  int key_;
+  char value_[STRLEN];
+};
+struct KeyComparator {
+  KOKKOS_INLINE_FUNCTION
+  bool operator() (const Key& s1, const Key& s2) {
+    return s1.key_ < s2.key_;
+  }
+};
+
+TEST_CASE("Sorting", "[sort]") {
+  GIVEN("An unordered list of integers") {
+
+    ParArray1D<int> data("Data to sort", N);
+
+
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(), 0, N - 1,
+      KOKKOS_LAMBDA(const int n) {
+        data(n) = 2*N - n;
+      });
+
+    sort(data.data(), data.data() + N);
+
+    auto data_h = Kokkos::create_mirror_view(data);
+    Kokkos::deep_copy(data_h, data);
+
+    for (int n = 0; n < N; n++) {
+      REQUIRE(data_h(n) == 101 + n);
+    }
+  }
+
+  GIVEN("An unordered list of key-value pairs") {
+    ParArray1D<Key> data("Data to sort", 5);
+
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(), 0, 5 - 1,
+      KOKKOS_LAMBDA(const int n) {
+        if (n == 0) {
+          data(n) = Key(5, "test.");
+        } else if (n == 1) {
+          data(n) = Key(4, "a");
+        } else if (n == 3) {
+          data(n) = Key(3, "is");
+        } else if (n == 2) {
+          data(n) = Key(2, "sentence");
+        } else if (n == 4) {
+          data(n) = Key(1, "This");
+        }
+      });
+
+    sort(data.data(), data.data() + 5, KeyComparator());
+
+    auto data_h = Kokkos::create_mirror_view(data);
+    Kokkos::deep_copy(data_h, data);
+
+    REQUIRE(data_h(0).value_ == std::string("This"));
+    REQUIRE(data_h(1).value_ == std::string("sentence"));
+    REQUIRE(data_h(2).value_ == std::string("is"));
+    REQUIRE(data_h(3).value_ == std::string("a"));
+    REQUIRE(data_h(4).value_ == std::string("test."));
+  }
+}

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -11,6 +11,9 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+#include <iostream>
+#include <string>
+
 #include <catch2/catch.hpp>
 
 #include "kokkos_abstraction.hpp"
@@ -28,7 +31,9 @@ struct Key {
   Key() {}
   KOKKOS_INLINE_FUNCTION
   Key(const int key, const char value[STRLEN]) : key_(key) {
-    std::copy(value, value + STRLEN, value_);
+    for (int n = 0; n < STRLEN; n++) {
+      value_[n] = value[n];
+    }
   }
 
   int key_;
@@ -53,7 +58,7 @@ TEST_CASE("Sorting", "[sort]") {
         data(n) = 2*N - n;
       });
 
-    sort(data.data(), data.data() + N);
+    sort(data);
 
     auto data_h = Kokkos::create_mirror_view(data);
     Kokkos::deep_copy(data_h, data);
@@ -82,7 +87,7 @@ TEST_CASE("Sorting", "[sort]") {
         }
       });
 
-    sort(data.data(), data.data() + 5, KeyComparator());
+    sort(data, KeyComparator());
 
     auto data_h = Kokkos::create_mirror_view(data);
     Kokkos::deep_copy(data_h, data);

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -20,8 +20,8 @@
 #include "parthenon_arrays.hpp"
 #include "utils/sort.hpp"
 
-using parthenon::sort;
 using parthenon::ParArray1D;
+using parthenon::sort;
 
 constexpr int N = 100;
 constexpr int STRLEN = 1024;
@@ -41,9 +41,7 @@ struct Key {
 };
 struct KeyComparator {
   KOKKOS_INLINE_FUNCTION
-  bool operator() (const Key& s1, const Key& s2) {
-    return s1.key_ < s2.key_;
-  }
+  bool operator()(const Key &s1, const Key &s2) { return s1.key_ < s2.key_; }
 };
 
 TEST_CASE("Sorting", "[sort]") {
@@ -51,12 +49,9 @@ TEST_CASE("Sorting", "[sort]") {
 
     ParArray1D<int> data("Data to sort", N);
 
-
     parthenon::par_for(
-      parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(), 0, N - 1,
-      KOKKOS_LAMBDA(const int n) {
-        data(n) = 2*N - n;
-      });
+        parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(),
+        0, N - 1, KOKKOS_LAMBDA(const int n) { data(n) = 2 * N - n; });
 
     sort(data);
 
@@ -72,20 +67,20 @@ TEST_CASE("Sorting", "[sort]") {
     ParArray1D<Key> data("Data to sort", 5);
 
     parthenon::par_for(
-      parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(), 0, 5 - 1,
-      KOKKOS_LAMBDA(const int n) {
-        if (n == 0) {
-          data(n) = Key(5, "test.");
-        } else if (n == 1) {
-          data(n) = Key(4, "a");
-        } else if (n == 3) {
-          data(n) = Key(3, "is");
-        } else if (n == 2) {
-          data(n) = Key(2, "sentence");
-        } else if (n == 4) {
-          data(n) = Key(1, "This");
-        }
-      });
+        parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(),
+        0, 5 - 1, KOKKOS_LAMBDA(const int n) {
+          if (n == 0) {
+            data(n) = Key(5, "test.");
+          } else if (n == 1) {
+            data(n) = Key(4, "a");
+          } else if (n == 3) {
+            data(n) = Key(3, "is");
+          } else if (n == 2) {
+            data(n) = Key(2, "sentence");
+          } else if (n == 4) {
+            data(n) = Key(1, "This");
+          }
+        });
 
     sort(data, KeyComparator());
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

We often want to be able to quickly loop through all the particles in a particular cell. By default, particles live in per-meshblock lists and these will not in general be ordered by zone. This PR introduces a method `SwarmContainer::SortParticlesByCell` that uses a 1D sort operation to populate a map from cell index `i,j,k` to a list of per-meshblock indices of all particles in that cell.

The `sort` routine is provided separately and uses separate implementations for CPU and GPU. For the GPU, it relies on `thrust` (Kokkos provides a `sort` routine but from some open issues on that repo it appears to be slow, especially on the GPU). 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
- [x] Add API for accessing this sorted list from outside `Swarm`, and demonstrate usage in the `particles` example.
