### PR TITLE
enable volatile params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [[PR 602]](https://github.com/lanl/parthenon/pull/602) Added tuning functionality for HDF5 output
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 623]](https://github.com/lanl/parthenon/pull/623) Enable Params to optionally return non-const pointers
 - [[PR 604]](https://github.com/lanl/parthenon/pull/604) Allow modification of SimTime in PreStepUserWorkInLoop
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 

--- a/docs/interface/state.md
+++ b/docs/interface/state.md
@@ -19,9 +19,10 @@ The `StateDescriptor` class is intended to be used to inform Parthenon about the
   component names can be specified per sparse id. Currently, sparse variables are allocated on all
   blocks just like dense variables, however, in a future upgrade, they will only be allocated on
   those blocks where the user explicitly allocates them or non-zero values are advected into.
-* `void AddParam<T>(const std::string& key, T& value)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`.
+* `void AddParam<T>(const std::string& key, T& value, bool make_volatile)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. If `make_volatile` is true, parameters can be more easily modified.
 * `void UpdateParam<T>(const std::string& key, T& value)`updates a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. A parameter of the same type must exist.
 * `const T& Param(const std::string& key)` provides the getter to access parameters previously added by `AddParam`.
+* `T *VolatileParam(const std::string &key)` returns a pointer to a parameter that has been marked volatile when it was added. Note this pointer is *not* marked `const`.
 * `void FillDerivedBlock(MeshBlockData<Real>* rc)` delgates to the `std::function` member `FillDerivedBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshBlockData<Real>`.
 * `void FillDerivedMesh(MeshData<Real>* rc)` delgates to the `std::function` member `FillDerivedMesh` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshData<Real>`.
 * `Real EstimateTimestepBlock(MeshBlockData<Real>* rc)` delgates to the `std::function` member `EstimateTimestepBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a means of computing stable/accurate timesteps for a mesh block.

--- a/docs/interface/state.md
+++ b/docs/interface/state.md
@@ -19,7 +19,7 @@ The `StateDescriptor` class is intended to be used to inform Parthenon about the
   component names can be specified per sparse id. Currently, sparse variables are allocated on all
   blocks just like dense variables, however, in a future upgrade, they will only be allocated on
   those blocks where the user explicitly allocates them or non-zero values are advected into.
-* `void AddParam<T>(const std::string& key, T& value, bool make_mutable)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. If `make_mutable` is true, parameters can be more easily modified.
+* `void AddParam<T>(const std::string& key, T& value, bool is_mutable)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. If `is_mutable` is true, parameters can be more easily modified.
 * `void UpdateParam<T>(const std::string& key, T& value)`updates a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. A parameter of the same type must exist.
 * `const T& Param(const std::string& key)` provides the getter to access parameters previously added by `AddParam`.
 * `T *MutableParam(const std::string &key)` returns a pointer to a parameter that has been marked mutable when it was added. Note this pointer is *not* marked `const`.

--- a/docs/interface/state.md
+++ b/docs/interface/state.md
@@ -19,10 +19,10 @@ The `StateDescriptor` class is intended to be used to inform Parthenon about the
   component names can be specified per sparse id. Currently, sparse variables are allocated on all
   blocks just like dense variables, however, in a future upgrade, they will only be allocated on
   those blocks where the user explicitly allocates them or non-zero values are advected into.
-* `void AddParam<T>(const std::string& key, T& value, bool make_volatile)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. If `make_volatile` is true, parameters can be more easily modified.
+* `void AddParam<T>(const std::string& key, T& value, bool make_mutable)` adds a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. If `make_mutable` is true, parameters can be more easily modified.
 * `void UpdateParam<T>(const std::string& key, T& value)`updates a parameter (e.g. a timestep control coefficient, refinement tolerance, etc.) with name `key` and value `value`. A parameter of the same type must exist.
 * `const T& Param(const std::string& key)` provides the getter to access parameters previously added by `AddParam`.
-* `T *VolatileParam(const std::string &key)` returns a pointer to a parameter that has been marked volatile when it was added. Note this pointer is *not* marked `const`.
+* `T *MutableParam(const std::string &key)` returns a pointer to a parameter that has been marked mutable when it was added. Note this pointer is *not* marked `const`.
 * `void FillDerivedBlock(MeshBlockData<Real>* rc)` delgates to the `std::function` member `FillDerivedBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshBlockData<Real>`.
 * `void FillDerivedMesh(MeshData<Real>* rc)` delgates to the `std::function` member `FillDerivedMesh` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a function that fills in derived quantities from independent state per `MeshData<Real>`.
 * `Real EstimateTimestepBlock(MeshBlockData<Real>* rc)` delgates to the `std::function` member `EstimateTimestepBlock` if set (defaults to `nullptr` and therefore a no-op) that allows an application to provide a means of computing stable/accurate timesteps for a mesh block.

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -59,7 +59,7 @@ class Params {
                              "WRONG TYPE FOR KEY '" + key + "'");
     myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
   }
-  
+
   void reset() {
     myParams_.clear();
     myTypes_.clear();
@@ -79,8 +79,7 @@ class Params {
   template <typename T>
   T *GetVolatile(const std::string &key) const {
     auto typed_ptr = GetTypedPointer_<T>(key);
-    PARTHENON_REQUIRE_THROWS(myVolatile_.at(key),
-			     "Parameter must be marked as volatile");
+    PARTHENON_REQUIRE_THROWS(myVolatile_.at(key), "Parameter must be marked as volatile");
     return typed_ptr->pValue.get();
   }
 

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -43,11 +43,11 @@ class Params {
   ///
   /// Throws an error if the key is already in use
   template <typename T>
-  void Add(const std::string &key, T value, bool make_volatile = false) {
+  void Add(const std::string &key, T value, bool make_mutable = false) {
     PARTHENON_REQUIRE_THROWS(!(hasKey(key)), "Key " + key + " already exists");
     myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
     myTypes_.emplace(make_pair(key, std::type_index(typeid(value))));
-    myVolatile_[key] = make_volatile;
+    myMutable_[key] = make_mutable;
   }
 
   /// Updates existing object
@@ -63,7 +63,7 @@ class Params {
   void reset() {
     myParams_.clear();
     myTypes_.clear();
-    myVolatile_.clear();
+    myMutable_.clear();
   }
 
   template <typename T>
@@ -77,9 +77,9 @@ class Params {
   // But we also don't want the reference completely re-assigned.
   // This also avoids extraneous copies.
   template <typename T>
-  T *GetVolatile(const std::string &key) const {
+  T *GetMutable(const std::string &key) const {
     auto typed_ptr = GetTypedPointer_<T>(key);
-    PARTHENON_REQUIRE_THROWS(myVolatile_.at(key), "Parameter must be marked as volatile");
+    PARTHENON_REQUIRE_THROWS(myMutable_.at(key), "Parameter must be marked as mutable");
     return typed_ptr->pValue.get();
   }
 
@@ -186,7 +186,7 @@ class Params {
 
   std::map<std::string, std::unique_ptr<Params::base_t>> myParams_;
   std::map<std::string, std::type_index> myTypes_;
-  std::map<std::string, bool> myVolatile_;
+  std::map<std::string, bool> myMutable_;
 };
 
 } // namespace parthenon

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -43,11 +43,11 @@ class Params {
   ///
   /// Throws an error if the key is already in use
   template <typename T>
-  void Add(const std::string &key, T value, bool make_mutable = false) {
+  void Add(const std::string &key, T value, bool is_mutable = false) {
     PARTHENON_REQUIRE_THROWS(!(hasKey(key)), "Key " + key + " already exists");
     myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
     myTypes_.emplace(make_pair(key, std::type_index(typeid(value))));
-    myMutable_[key] = make_mutable;
+    myMutable_[key] = is_mutable;
   }
 
   /// Updates existing object
@@ -55,6 +55,8 @@ class Params {
   template <typename T>
   void Update(const std::string &key, T value) {
     PARTHENON_REQUIRE_THROWS((hasKey(key)), "Key " + key + "missing.");
+    PARTHENON_REQUIRE_THROWS(myMutable_.at(key),
+                             "Parameter " + key + " must be marked as mutable");
     PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
                              "WRONG TYPE FOR KEY '" + key + "'");
     myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
@@ -79,7 +81,8 @@ class Params {
   template <typename T>
   T *GetMutable(const std::string &key) const {
     auto typed_ptr = GetTypedPointer_<T>(key);
-    PARTHENON_REQUIRE_THROWS(myMutable_.at(key), "Parameter must be marked as mutable");
+    PARTHENON_REQUIRE_THROWS(myMutable_.at(key),
+                             "Parameter " + key + " must be marked as mutable");
     return typed_ptr->pValue.get();
   }
 

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -99,8 +99,8 @@ class StateDescriptor {
   CreateResolvedStateDescriptor(Packages_t &packages);
 
   template <typename T>
-  void AddParam(const std::string &key, T value, bool make_volatile = false) {
-    params_.Add<T>(key, value, make_volatile);
+  void AddParam(const std::string &key, T value, bool make_mutable = false) {
+    params_.Add<T>(key, value, make_mutable);
   }
 
   template <typename T>
@@ -114,8 +114,8 @@ class StateDescriptor {
   }
 
   template <typename T>
-  T *VolatileParam(const std::string &key) const {
-    return params_.GetVolatile<T>(key);
+  T *MutableParam(const std::string &key) const {
+    return params_.GetMutable<T>(key);
   }
 
   // Set (if not set) and get simultaneously.

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -99,8 +99,8 @@ class StateDescriptor {
   CreateResolvedStateDescriptor(Packages_t &packages);
 
   template <typename T>
-  void AddParam(const std::string &key, T value, bool make_mutable = false) {
-    params_.Add<T>(key, value, make_mutable);
+  void AddParam(const std::string &key, T value, bool is_mutable = false) {
+    params_.Add<T>(key, value, is_mutable);
   }
 
   template <typename T>

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -99,8 +99,8 @@ class StateDescriptor {
   CreateResolvedStateDescriptor(Packages_t &packages);
 
   template <typename T>
-  void AddParam(const std::string &key, T value) {
-    params_.Add<T>(key, value);
+  void AddParam(const std::string &key, T value, bool make_volatile = false) {
+    params_.Add<T>(key, value, make_volatile);
   }
 
   template <typename T>
@@ -111,6 +111,11 @@ class StateDescriptor {
   template <typename T>
   const T &Param(const std::string &key) const {
     return params_.Get<T>(key);
+  }
+
+  template <typename T>
+  T *VolatileParam(const std::string &key) const {
+    return params_.GetVolatile<T>(key);
   }
 
   // Set (if not set) and get simultaneously.

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -34,13 +34,9 @@ TEST_CASE("Add, Get, and Update are called", "[Add,Get,Update]") {
         double output = params.Get<double>(key);
         REQUIRE(output == Approx(value));
       }
-      AND_THEN("we can update the value") {
-        params.Update<double>(key, 2.0);
-        REQUIRE(params.Get<double>(key) == Approx(2.0));
-      }
-      WHEN("trying to Update with a wrong type") {
+      WHEN("Trying to update a non-mutable param") {
         THEN("an error is thrown") {
-          REQUIRE_THROWS_AS(params.Update<int>(key, 2), std::runtime_error);
+          REQUIRE_THROWS_AS(params.Update<double>(key, 2.0), std::runtime_error);
         }
       }
       WHEN("the same key is provided a second time") {
@@ -71,6 +67,18 @@ TEST_CASE("Add, Get, and Update are called", "[Add,Get,Update]") {
             double output = params.Get<double>(key);
             REQUIRE(output == Approx(new_val));
           }
+        }
+      }
+      THEN("We can update the mutable param") {
+        params.Update<double>(key, 2.0);
+        AND_THEN("The new value is reflected in Get") {
+          double output = params.Get<double>(key);
+          REQUIRE(output == Approx(2.0));
+        }
+      }
+      WHEN("trying to Update with a wrong type") {
+        THEN("an error is thrown") {
+          REQUIRE_THROWS_AS(params.Update<int>(key, 2), std::runtime_error);
         }
       }
     }

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -54,24 +54,24 @@ TEST_CASE("Add, Get, and Update are called", "[Add,Get,Update]") {
         }
       }
       WHEN("attempting to get the pointer with GetVolatile") {
-	THEN("an error is thrown") {
-	  REQUIRE_THROWS_AS(params.GetVolatile<double>(key), std::runtime_error);
-	}
+        THEN("an error is thrown") {
+          REQUIRE_THROWS_AS(params.GetVolatile<double>(key), std::runtime_error);
+        }
       }
     }
     WHEN("We add it to params as volatile") {
       params.Add(key, value, true);
       THEN("We can retrieve the pointer to the object with GetVolatile") {
-	double *pval = params.GetVolatile<double>(key);
-	REQUIRE(*pval == Approx(value));
-	AND_THEN("We can modify the value by dereferencing the pointer") {
-	  double new_val = 5;
-	  *pval = new_val;
-	  AND_THEN("params.get reflects the new value") {
-	    double output = params.Get<double>(key);
-	    REQUIRE(output == Approx(new_val));
-	  }
-	}
+        double *pval = params.GetVolatile<double>(key);
+        REQUIRE(*pval == Approx(value));
+        AND_THEN("We can modify the value by dereferencing the pointer") {
+          double new_val = 5;
+          *pval = new_val;
+          AND_THEN("params.get reflects the new value") {
+            double output = params.Get<double>(key);
+            REQUIRE(output == Approx(new_val));
+          }
+        }
       }
     }
   }

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -53,16 +53,16 @@ TEST_CASE("Add, Get, and Update are called", "[Add,Get,Update]") {
           REQUIRE_THROWS_AS(params.Get<int>(key), std::runtime_error);
         }
       }
-      WHEN("attempting to get the pointer with GetVolatile") {
+      WHEN("attempting to get the pointer with GetMutable") {
         THEN("an error is thrown") {
-          REQUIRE_THROWS_AS(params.GetVolatile<double>(key), std::runtime_error);
+          REQUIRE_THROWS_AS(params.GetMutable<double>(key), std::runtime_error);
         }
       }
     }
-    WHEN("We add it to params as volatile") {
+    WHEN("We add it to params as mutable") {
       params.Add(key, value, true);
-      THEN("We can retrieve the pointer to the object with GetVolatile") {
-        double *pval = params.GetVolatile<double>(key);
+      THEN("We can retrieve the pointer to the object with GetMutable") {
+        double *pval = params.GetMutable<double>(key);
         REQUIRE(*pval == Approx(value));
         AND_THEN("We can modify the value by dereferencing the pointer") {
           double new_val = 5;

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -53,6 +53,26 @@ TEST_CASE("Add, Get, and Update are called", "[Add,Get,Update]") {
           REQUIRE_THROWS_AS(params.Get<int>(key), std::runtime_error);
         }
       }
+      WHEN("attempting to get the pointer with GetVolatile") {
+	THEN("an error is thrown") {
+	  REQUIRE_THROWS_AS(params.GetVolatile<double>(key), std::runtime_error);
+	}
+      }
+    }
+    WHEN("We add it to params as volatile") {
+      params.Add(key, value, true);
+      THEN("We can retrieve the pointer to the object with GetVolatile") {
+	double *pval = params.GetVolatile<double>(key);
+	REQUIRE(*pval == Approx(value));
+	AND_THEN("We can modify the value by dereferencing the pointer") {
+	  double new_val = 5;
+	  *pval = new_val;
+	  AND_THEN("params.get reflects the new value") {
+	    double output = params.Get<double>(key);
+	    REQUIRE(output == Approx(new_val));
+	  }
+	}
+      }
     }
   }
 

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This is motivated by @brryan 's comment in issue #621 . I modify `Params` to enable the user to tag a param as "volatile." The effect of this is that the user can optionally extract the *non*-`const` pointer from the `Params` object with `GetVolatile` in the `Params` object or `VolatileParam` in the `StateDescriptor` object. If the user attempts to extract a non-volatile param with `GetVolatile`, a runtime error is raised.

I thought about returning a non-`const` reference, but the pointer felt safer and more explicit, without being any more cumbersome really. On the other hand, returning a pointer with `GetVolatile` means that the two `Get` methods return different types, which is a little weird. So I'd be open to returning a non-`const` reference instead, if people would like that better.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
