### PR TITLE
WIP: Remove extra same-rank deep copy for flux correction

### DIFF
--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -258,6 +258,7 @@ class BoundaryVariable : public BoundaryCommunication, public BoundaryBuffer {
   void ReceiveAndSetBoundariesWithWait() override;
   void SetBoundaries() override;
   auto GetPBdVar() { return &bd_var_; }
+  auto GetPBdVarFlcor() { return &bd_var_flcor_; }
 
  protected:
   // deferred initialization of BoundaryData objects in derived class constructors
@@ -277,7 +278,6 @@ class BoundaryVariable : public BoundaryCommunication, public BoundaryBuffer {
   }
 
   void CopyVariableBufferSameProcess(NeighborBlock &nb, int ssize);
-  void CopyFluxCorrectionBufferSameProcess(NeighborBlock &nb, int ssize);
 
   void InitBoundaryData(BoundaryData<> &bd, BoundaryQuantity type);
   void DestroyBoundaryData(BoundaryData<> &bd);

--- a/src/bvals/bvals_var.cpp
+++ b/src/bvals/bvals_var.cpp
@@ -135,19 +135,6 @@ void BoundaryVariable::CopyVariableBufferSameProcess(NeighborBlock &nb, int ssiz
   return;
 }
 
-// KGF: change ssize to send_count
-
-void BoundaryVariable::CopyFluxCorrectionBufferSameProcess(NeighborBlock &nb, int ssize) {
-  // Locate target buffer
-  // 1) which MeshBlock?
-  MeshBlock &target_block = *pmy_mesh_->FindMeshBlock(nb.snb.gid);
-  // 2) which element in vector of BoundaryVariable *?
-  BoundaryData<> *ptarget_bdata = &(target_block.pbval->bvars[bvar_index]->bd_var_flcor_);
-  target_block.deep_copy(ptarget_bdata->recv[nb.targetid], bd_var_flcor_.send[nb.bufid]);
-  ptarget_bdata->flag[nb.targetid] = BoundaryStatus::arrived;
-  return;
-}
-
 // Default / shared implementations of 4x BoundaryBuffer public functions
 
 //----------------------------------------------------------------------------------------


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Partially addresses #627 by removing extra `Kokkos::deep_copy`s between send and receive buffer on same rank in favor of directly filling the receive buffer.
Still WIP as I'm unsure if this is worth merging now or fully addressing "flux correction in one" at the same time.
Also there may be side effects with respect to sparse variables that I haven't checked/tested yet and sparse has higher priority.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
