### PR TITLE
Add Ookami & Spock machine file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
-- [[PR 646]](https://github.com/lanl/parthenon/pull/646) Add machine configuration file for Stony Brook's Ookami A64FX supercomputer.
+- [[PR 646]](https://github.com/lanl/parthenon/pull/646) Add machine configuration file for Stony Brook's Ookami A64FX and OLCF's Spock AMD systems.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 646]](https://github.com/lanl/parthenon/pull/646) Add machine configuration file for Stony Brook's Ookami A64FX supercomputer.
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/cmake/machinecfg/Ookami.cmake
+++ b/cmake/machinecfg/Ookami.cmake
@@ -1,0 +1,33 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2022 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+#========================================================================================
+# (C) (or copyright) 2022. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
+message(STATUS "Loading machine configuration for Stony Brook's A64FX Ookami.\n"
+	"This machine file is configured for the Fujitsu compiler in Clang mode.\n"
+	"$ module load cmake fujitsu/compiler/4.5 hdf5/fujitsu/1.12.0\n"
+	"This requires Kokkos patch https://github.com/kokkos/kokkos/pull/4745 to compile.\n"
+	"Also note that very aggressive optmization flags are used.\n")
+
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default release build")
+set(Kokkos_ARCH_A64FX ON CACHE BOOL "CPU architecture")
+set(PARTHENON_DISABLE_OPENMP ON CACHE BOOL "OpenMP support not yet tested in Parthenon.")
+
+set(CMAKE_CXX_COMPILER "mpiFCC" CACHE STRING "Default compiler")
+set(CMAKE_CXX_FLAGS "-Nclang -ffj-fast-matmul -ffast-math -ffp-contract=fast -ffj-fp-relaxed -ffj-ilfunc -fbuiltin -fomit-frame-pointer -finline-functions -ffj-preex -ffj-zfill -ffj-swp -fopenmp-simd" CACHE STRING "Default opt flags")
+
+set(TEST_MPIEXEC mpirun CACHE STRING "Command to launch MPI applications")
+set(TEST_NUMPROC_FLAG "-np" CACHE STRING "Flag to set number of processes")
+set(NUM_MPI_PROC_TESTING "4" CACHE STRING "Run tests with4 ranks")

--- a/cmake/machinecfg/Spock.cmake
+++ b/cmake/machinecfg/Spock.cmake
@@ -1,0 +1,58 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2022 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+#========================================================================================
+# (C) (or copyright) 2022. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
+message(STATUS "Loading machine configuration for OLCF's Spock.\n"
+  "Supported MACHINE_VARIANT includes 'hip', 'mpi', and 'hip-mpi'\n"
+  "This configuration has been tested using the following modules: \n"
+  "module load PrgEnv-amd craype-accel-amd-gfx908 cmake cray-hdf5-parallel\n"
+  "and environment varables:\n"
+  "export MPIR_CVAR_GPU_EAGER_DEVICE_MEM=0\n"
+  "export MPICH_GPU_SUPPORT_ENABLED=1\n"
+  "export MPICH_SMP_SINGLE_COPY_MODE=CMA\n")
+
+# common options
+set(Kokkos_ARCH_ZEN2 ON CACHE BOOL "CPU architecture")
+set(PARTHENON_DISABLE_OPENMP ON CACHE BOOL "OpenMP support not yet tested in Parthenon.")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default release build")
+set(MACHINE_VARIANT "hip-mpi" CACHE STRING "Default build for CUDA and MPI")
+
+# variants
+set(MACHINE_CXX_FLAGS "")
+if (${MACHINE_VARIANT} MATCHES "hip")
+  set(Kokkos_ARCH_VEGA908 ON CACHE BOOL "GPU architecture")
+  set(Kokkos_ENABLE_HIP ON CACHE BOOL "Enable HIP")
+  set(CMAKE_CXX_COMPILER hipcc CACHE STRING "Use hip wrapper")
+else()
+  set(CMAKE_CXX_COMPILER $ENV{ROCM_PATH}/llvm/bin/clang++ CACHE STRING "Use g++")
+  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -fopenmp-simd -fprefetch-loop-arrays")
+endif()
+
+# Setting launcher options independent of parallel or serial test as the launcher always
+# needs to be called from the batch node (so that the tests are actually run on the
+# compute nodes.
+set(TEST_MPIEXEC srun CACHE STRING "Command to launch MPI applications")
+set(TEST_NUMPROC_FLAG "-n" CACHE STRING "Flag to set number of processes")
+set(NUM_GPU_DEVICES_PER_NODE "4" CACHE STRING "6x V100 per node")
+set(PARTHENON_ENABLE_GPU_MPI_CHECKS OFF CACHE BOOL "Disable check by default")
+
+if (${MACHINE_VARIANT} MATCHES "mpi")
+  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -I$ENV{MPICH_DIR}/include -L$ENV{MPICH_DIR}/lib -lmpi -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa")
+else()
+  set(PARTHENON_DISABLE_MPI ON CACHE BOOL "Disable MPI")
+endif()
+
+set(CMAKE_CXX_FLAGS "${MACHINE_CXX_FLAGS}" CACHE STRING "Default flags for this config")

--- a/cmake/machinecfg/Spock.cmake
+++ b/cmake/machinecfg/Spock.cmake
@@ -17,9 +17,9 @@
 
 message(STATUS "Loading machine configuration for OLCF's Spock.\n"
   "Supported MACHINE_VARIANT includes 'hip', 'mpi', and 'hip-mpi'\n"
-  "This configuration has been tested using the following modules: \n"
-  "module load PrgEnv-amd craype-accel-amd-gfx908 cmake cray-hdf5-parallel\n"
-  "and environment varables:\n"
+  "This configuration has been tested (on 2022-03-24) using the following modules: \n"
+  "module load PrgEnv-amd craype-accel-amd-gfx908 cmake hdf5 cray-python\n"
+  "and environment variables:\n"
   "export MPIR_CVAR_GPU_EAGER_DEVICE_MEM=0\n"
   "export MPICH_GPU_SUPPORT_ENABLED=1\n"
   "export MPICH_SMP_SINGLE_COPY_MODE=CMA\n")
@@ -46,11 +46,13 @@ endif()
 # compute nodes.
 set(TEST_MPIEXEC srun CACHE STRING "Command to launch MPI applications")
 set(TEST_NUMPROC_FLAG "-n" CACHE STRING "Flag to set number of processes")
-set(NUM_GPU_DEVICES_PER_NODE "4" CACHE STRING "6x V100 per node")
+set(NUM_GPU_DEVICES_PER_NODE "4" CACHE STRING "4x MI100 per node")
 set(PARTHENON_ENABLE_GPU_MPI_CHECKS OFF CACHE BOOL "Disable check by default")
 
 if (${MACHINE_VARIANT} MATCHES "mpi")
-  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -I$ENV{MPICH_DIR}/include -L$ENV{MPICH_DIR}/lib -lmpi -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa")
+  # need to set include flags here as the target is not know yet when this file is parsed
+  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -I$ENV{MPICH_DIR}/include")
+  set(CMAKE_EXE_LINKER_FLAGS "-L$ENV{MPICH_DIR}/lib -lmpi -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa" CACHE STRING "Default flags for this config")
 else()
   set(PARTHENON_DISABLE_MPI ON CACHE BOOL "Disable MPI")
 endif()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Adds a machine configuration that works using the Fujitsu compilers.
Optimization options are chosen to the result in the fasted configuration based on some prelim. testing with `parthenon-hydro` -- though auto vectorization is still not great (compared to Intel compilers on x86 platforms).

```cmake
cmake -Bbuild -S. -DMACHINE_CFG=${PWD}/cmake/machinecfg/Ookami.cmake
-- Loading machine configuration for Stony Brook's A64FX Ookami.
This machine file is configured for the Fujitsu compiler in Clang mode.
$ module load cmake fujitsu/compiler/4.5 hdf5/fujitsu/1.12.0
This requires Kokkos patch https://github.com/kokkos/kokkos/pull/4745 to compile.
Also note that very aggressive optmization flags are used.

-- The C compiler identification is GNU 8.4.1
-- The CXX compiler identification is FujitsuClang 4.5.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /opt/FJSVstclanga/cp-1.0.20.06/bin/mpiFCC - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- clang-format --version: 11.0.0
CMake Warning at cmake/Format.cmake:57 (message):
  clang-format version 8.0 is required - results on other versions may not be
  stable
Call Stack (most recent call first):
  CMakeLists.txt:65 (include)


-- Found MPI_CXX: /opt/FJSVstclanga/cp-1.0.20.06/bin/mpiFCC (found version "3.1") 
-- Found MPI: TRUE (found version "3.1") found components: CXX 
-- Found HDF5: /lustre/software/hdf5/fujitsu/1.12.0/lib/libhdf5.a;/usr/lib64/libz.so;/usr/lib64/libdl.so;/usr/lib64/libm.so (found version "1.12.0") found components: C 
-- Setting default Kokkos CXX standard to 14
-- Setting policy CMP0074 to use <Package>_ROOT variables
-- The project name is: Kokkos
-- SERIAL backend is being turned on to ensure there is at least one Host space. To change this, you must enable another host execution space and configure with -DKokkos_ENABLE_SERIAL=OFF or change CMakeCache.txt
-- Using -std=c++14 for C++14 standard as feature
-- Built-in Execution Spaces:
--     Device Parallel: NoTypeDefined
--     Host Parallel: NoTypeDefined
--       Host Serial: SERIAL
-- 
-- Architectures:
--  A64FX
-- Found TPLLIBDL: /usr/lib64/libdl.so  
-- Kokkos Devices: SERIAL, Kokkos Backends: SERIAL
-- Using Kokkos source from Parthenon submodule at /lustre/home/pgrete/src/parthenon-hydro/external/parthenon/external/Kokkos
-- Gold standard is up-to-date (version 13). No download required.
-- Building unit tests.
-- Found Python3: /lustre/software/python/3.9.5/bin/python3.9 (found version "3.9.5") found components: Interpreter 
-- Building integration tests.
-- Building performance tests.
-- Building regression tests.
-- PAR_LOOP_LAYOUT='SIMDFOR_LOOP' (default par_for wrapper layout)
-- PAR_LOOP_INNER_LAYOUT='SIMDFOR_INNER_LOOP' (default par_for_inner wrapper layout)
-- Found Git: /usr/bin/git (found version "2.18.4") 
-- Configuring done
-- Generating done
-- Build files have been written to: /lustre/home/pgrete/src/parthenon-hydro/external/parthenon/build
```

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
