### PR TITLE
Ensure LB send buffers are filled and allow async recv LB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 649]](https://github.com/lanl/parthenon/pull/649) Ensure LoadBalancing send buffers are filled and allow async recv LB
 - [[PR 618]](https://github.com/lanl/parthenon/pull/618) Fix bug in variable pack performance test
 - [[PR 616]](https://github.com/lanl/parthenon/pull/609) Restore sparse base names in PackIndexMap
 - [[PR 609]](https://github.com/lanl/parthenon/pull/609) Fix bug where .final is not written if signal raised while writing regular output

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -694,7 +694,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     for (auto idx = 0; idx < sb_idx; idx++) {
       PARTHENON_MPI_CHECK(MPI_Isend(sendbuf[idx].data(), count[idx], MPI_PARTHENON_REAL,
                                     dest[idx], tags[idx], MPI_COMM_WORLD,
-                                    &(req_send[sb_idx])));
+                                    &(req_send[idx])));
     }
   }                               // if (nsend !=0)
   Kokkos::Profiling::popRegion(); // Step 7
@@ -814,8 +814,8 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         }
       }
       // rb_idx is a running index, so we repeat the loop until all vals are true
-    } while (std::all_of(received.begin(), received.begin() + rb_idx,
-                         [](bool v) { return v; }));
+    } while (!std::all_of(received.begin(), received.begin() + rb_idx,
+                          [](bool v) { return v; }));
     Kokkos::fence();
   }
 #endif

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -1,4 +1,8 @@
 //========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2020-2022 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
 // Athena++ astrophysical MHD code
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
@@ -639,6 +643,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
   Kokkos::Profiling::pushRegion("Step 7: Pack and send buffers");
   if (nsend != 0) {
     req_send = new MPI_Request[nsend];
+    std::vector<int> tags(nsend);
+    std::vector<int> dest(nsend);
+    std::vector<int> count(nsend);
     int sb_idx = 0; // send buffer index
     for (int n = onbs; n <= onbe; n++) {
       int nn = oldtonew[n];
@@ -651,10 +658,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
             BufArray1D<Real>(bufs, std::make_pair(buf_offset, buf_offset + bssame));
         buf_offset += bssame;
         PrepareSendSameLevel(pb.get(), sendbuf[sb_idx]);
-        int tag = CreateAMRMPITag(nn - nslist[newrank[nn]], 0, 0, 0);
-        PARTHENON_MPI_CHECK(MPI_Isend(sendbuf[sb_idx].data(), bssame, MPI_PARTHENON_REAL,
-                                      newrank[nn], tag, MPI_COMM_WORLD,
-                                      &(req_send[sb_idx])));
+        tags[sb_idx] = CreateAMRMPITag(nn - nslist[newrank[nn]], 0, 0, 0);
+        dest[sb_idx] = newrank[nn];
+        count[sb_idx] = bssame;
         sb_idx++;
       } else if (nloc.level > oloc.level) { // c2f
         // c2f must communicate to multiple leaf blocks (unlike f2c, same2same)
@@ -664,10 +670,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
               BufArray1D<Real>(bufs, std::make_pair(buf_offset, buf_offset + bsc2f));
           buf_offset += bsc2f;
           PrepareSendCoarseToFineAMR(pb.get(), sendbuf[sb_idx], newloc[nn + l]);
-          int tag = CreateAMRMPITag(nn + l - nslist[newrank[nn + l]], 0, 0, 0);
-          PARTHENON_MPI_CHECK(MPI_Isend(sendbuf[sb_idx].data(), bsc2f, MPI_PARTHENON_REAL,
-                                        newrank[nn + l], tag, MPI_COMM_WORLD,
-                                        &(req_send[sb_idx])));
+          tags[sb_idx] = CreateAMRMPITag(nn + l - nslist[newrank[nn + l]], 0, 0, 0);
+          dest[sb_idx] = newrank[nn + l];
+          count[sb_idx] = bsc2f;
           sb_idx++;
         }      // end loop over nleaf (unique to c2f branch in this step 6)
       } else { // f2c: restrict + pack + send
@@ -678,12 +683,18 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         PrepareSendFineToCoarseAMR(pb.get(), sendbuf[sb_idx]);
         int ox1 = ((oloc.lx1 & 1LL) == 1LL), ox2 = ((oloc.lx2 & 1LL) == 1LL),
             ox3 = ((oloc.lx3 & 1LL) == 1LL);
-        int tag = CreateAMRMPITag(nn - nslist[newrank[nn]], ox1, ox2, ox3);
-        PARTHENON_MPI_CHECK(MPI_Isend(sendbuf[sb_idx].data(), bsf2c, MPI_PARTHENON_REAL,
-                                      newrank[nn], tag, MPI_COMM_WORLD,
-                                      &(req_send[sb_idx])));
+        tags[sb_idx] = CreateAMRMPITag(nn - nslist[newrank[nn]], ox1, ox2, ox3);
+        dest[sb_idx] = newrank[nn];
+        count[sb_idx] = bsf2c;
         sb_idx++;
       }
+    }
+    // wait until all send buffers are filled
+    Kokkos::fence();
+    for (auto idx = 0; idx < sb_idx; idx++) {
+      PARTHENON_MPI_CHECK(MPI_Isend(sendbuf[idx].data(), count[idx], MPI_PARTHENON_REAL,
+                                    dest[idx], tags[idx], MPI_COMM_WORLD,
+                                    &(req_send[sb_idx])));
     }
   }                               // if (nsend !=0)
   Kokkos::Profiling::popRegion(); // Step 7
@@ -763,7 +774,6 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       LogicalLocation &oloc = loclist[on];
       LogicalLocation &nloc = newloc[n];
       auto pb = FindMeshBlock(n);
-      pb->exec_space.fence();
       if (oloc.level == nloc.level) { // same
         if (ranklist[on] == Globals::my_rank) continue;
         PARTHENON_MPI_CHECK(MPI_Wait(&(req_recv[rb_idx]), MPI_STATUS_IGNORE));


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

First part of the PR:
As far as I can tell there might have been issues on devices because there was no `fence` before the `MPI_ISend`.
Within the functions called in that loop, we also used the triple argument `deep_copy`, which is non-blocking.
Now, all the MPI comm is started at the end of the loop and we first gather the info (tags, destination rank, data count) similar to other places in the code.

Second part of the PR:
Blocking `MPI_Wait` was used for receiving blocks during AMR LB.
This was probably never a performance issue with only "few" blocks per process, but on GPUs we now handle thousands of blocks, so I expect a performance gain by actually using non-blocking calls.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
