### PR TITLE
Bump Catch2 version due to GCC11.2 incompatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 651]](https://github.com/lanl/parthenon/pull/651) Bump Catch2 version due to GCC11.2 incompatibility
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,7 +311,7 @@ if (${PARTHENON_ENABLE_UNIT_TESTS} OR ${PARTHENON_ENABLE_INTEGRATION_TESTS} OR $
   endif()
 
   # Try finding an installed Catch2 first
-  find_package(Catch2 2.11.1 QUIET)
+  find_package(Catch2 2.13.8 QUIET)
 
   if (NOT Catch2_FOUND)
     # If Catch2 is not found, instead use the git submodule
@@ -327,7 +327,7 @@ if (${PARTHENON_ENABLE_UNIT_TESTS} OR ${PARTHENON_ENABLE_INTEGRATION_TESTS} OR $
     list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/Catch2/contrib")
   endif()
 
-  include(ParseAndAddCatchTests)
+  include(Catch)
   add_subdirectory(tst)
 endif()
 

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -1,4 +1,8 @@
 //========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2022 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
 // (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
@@ -11,6 +15,7 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+#include <string>
 #define CATCH_CONFIG_RUNNER
 
 #include <catch2/catch.hpp>
@@ -18,10 +23,21 @@
 #include <Kokkos_Core.hpp>
 
 int main(int argc, char *argv[]) {
+  // With Catch2 >2.13.4 catch_discover_tests() is used to discover tests by calling the
+  // test executable with `--list-test-names-only` and parsing the results.
+  // However, we have to init Kokkos first, which potentially shows warnings that are
+  // incorrectly parsed as test. Thus, we here disable the warning for when the tests are
+  // parsed.
+  for (auto i = 1; i < argc; i++) {
+    if (std::string(argv[i]) == "--list-test-names-only") {
+      setenv("KOKKOS_DISABLE_WARNINGS", "ON", 1);
+    }
+  }
+
   // global setup...
-  int result;
   Kokkos::initialize(argc, argv);
 
+  int result;
   {
     result = Catch::Session().run(argc, argv);
 

--- a/tst/performance/CMakeLists.txt
+++ b/tst/performance/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(performance_tests test_meshblock_data_iterator.cpp)
 target_link_libraries(performance_tests PRIVATE Parthenon::parthenon catch2_define Kokkos::kokkos)
 lint_target(performance_tests)
 
-catch_discover_tests(performance_tests EXTRA_ARGS "--kokkos-disable-warnings")
+catch_discover_tests(performance_tests)

--- a/tst/performance/CMakeLists.txt
+++ b/tst/performance/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 ##========================================================================================
-## Athena++ astrophysical MHD code
-## Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+## Parthenon performance portable AMR framework
+## Copyright(C) 2020-2022 The Parthenon collaboration
 ## Licensed under the 3-clause BSD License, see LICENSE file for details
 ##========================================================================================
 ## (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
@@ -20,4 +20,4 @@ add_executable(performance_tests test_meshblock_data_iterator.cpp)
 target_link_libraries(performance_tests PRIVATE Parthenon::parthenon catch2_define Kokkos::kokkos)
 lint_target(performance_tests)
 
-catch_discover_tests(performance_tests)
+catch_discover_tests(performance_tests EXTRA_ARGS "--kokkos-disable-warnings")

--- a/tst/performance/CMakeLists.txt
+++ b/tst/performance/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(performance_tests test_meshblock_data_iterator.cpp)
 target_link_libraries(performance_tests PRIVATE Parthenon::parthenon catch2_define Kokkos::kokkos)
 lint_target(performance_tests)
 
-catch_discover_tests(performance_tests)
+catch_discover_tests(performance_tests PROPERTIES LABELS "performance")

--- a/tst/performance/CMakeLists.txt
+++ b/tst/performance/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(performance_tests test_meshblock_data_iterator.cpp)
 target_link_libraries(performance_tests PRIVATE Parthenon::parthenon catch2_define Kokkos::kokkos)
 lint_target(performance_tests)
 
-ParseAndAddCatchTests(performance_tests)
+catch_discover_tests(performance_tests)

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -1,7 +1,7 @@
 
 ##========================================================================================
-## Athena++ astrophysical MHD code
-## Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+## Parthenon performance portable AMR framework
+## Copyright(C) 2020-2022 The Parthenon collaboration
 ## Licensed under the 3-clause BSD License, see LICENSE file for details
 ##========================================================================================
 ## (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
@@ -48,7 +48,7 @@ endif()
 
 lint_target(unit_tests)
 
-catch_discover_tests(unit_tests)
+catch_discover_tests(unit_tests EXTRA_ARGS "--kokkos-disable-warnings")
 
 get_property(ALL_TESTS DIRECTORY . PROPERTY TESTS)
 

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 
 lint_target(unit_tests)
 
-catch_discover_tests(unit_tests EXTRA_ARGS "--kokkos-disable-warnings")
+catch_discover_tests(unit_tests)
 
 get_property(ALL_TESTS DIRECTORY . PROPERTY TESTS)
 

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 
 lint_target(unit_tests)
 
-ParseAndAddCatchTests(unit_tests)
+catch_discover_tests(unit_tests)
 
 get_property(ALL_TESTS DIRECTORY . PROPERTY TESTS)
 

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -48,7 +48,10 @@ endif()
 
 lint_target(unit_tests)
 
-catch_discover_tests(unit_tests)
+# separating test cases here because performance tests should (later) only be run
+# for Release build types.
+catch_discover_tests(unit_tests TEST_SPEC "~[performance]" PROPERTIES LABELS "unit")
+catch_discover_tests(unit_tests TEST_SPEC "[performance]" PROPERTIES LABELS "performance")
 
 get_property(ALL_TESTS DIRECTORY . PROPERTY TESTS)
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I also stumbled across https://github.com/catchorg/Catch2/issues/2178 
```
[ 18%] Building CXX object tst/CMakeFiles/catch2_define.dir/catch2_define.cpp.o
In file included from /usr/include/signal.h:328,
                 from /home/pgrete/src/parthenon/external/Catch2/single_include/catch2/catch.hpp:7955,
                 from /home/pgrete/src/parthenon/tst/catch2_define.cpp:16:
/home/pgrete/src/parthenon/external/Catch2/single_include/catch2/catch.hpp:10735:58: error: call to non-‘constexpr’ function ‘long int sysconf(int)’
10735 |     static constexpr std::size_t sigStackSize = 32768 >= MINSIGSTKSZ ? 32768 : MINSIGSTKSZ;
      |                                                          ^~~~~~~~~~~
In file included from /usr/include/bits/sigstksz.h:24,
                 from /usr/include/signal.h:328,
                 from /home/pgrete/src/parthenon/external/Catch2/single_include/catch2/catch.hpp:7955,
                 from /home/pgrete/src/parthenon/tst/catch2_define.cpp:16:
/usr/include/unistd.h:640:17: note: ‘long int sysconf(int)’ declared here
  640 | extern long int sysconf (int __name) __THROW;
      |                 ^~~~~~~
In file included from /home/pgrete/src/parthenon/tst/catch2_define.cpp:16:
/home/pgrete/src/parthenon/external/Catch2/single_include/catch2/catch.hpp:10794:45: error: size of array ‘altStackMem’ is not an integral constant-expression
10794 |     char FatalConditionHandler::altStackMem[sigStackSize] = {};
      |                                             ^~~~~~~~~~~~
make[2]: *** [tst/CMakeFiles/catch2_define.dir/build.make:76: tst/CMakeFiles/catch2_define.dir/catch2_define.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1510: tst/CMakeFiles/catch2_define.dir/all] Error 2
make: *** [Makefile:146: all] Error 2

```

Given this was fixed in upstream Catch2, this now includes the latest stable release.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files


Still WIP because the discovery now gets confused with Kokkos info output, see first and last tests
```bash
$ ctest -N
Test project /home/pgrete/build-test
  Test  #1: Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  Test  #2:   In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  Test  #3:   For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  Test  #4:   For unit testing set OMP_PROC_BIND=false
  Test  #5: Adding MeshBlockData objects to a DataCollection
  Test  #6: Just check everything
  Test  #7: Task Object Lifecycle
  Test  #8: Can create a vector-valued face-variable
  Test  #9: Add, Get, and Update are called
  Test #10: reset is called
  Test #11: when hasKey is called
  Test #12: Physical constants
  Test #13: Checking IndexShape indices
  Test #14: Checking IndexShape cell counts
  Test #15: Sorting
  Test #16: par_for loops
  Test #17: nested par_for loops
  Test #18: Overlapping SpaceInstances
  Test #19: Device Object Allocation
  Test #20: Built-in flags are registered
  Test #21: A Metadata flag is allocated
  Test #22: A Metadata struct is created
  Test #23: ParArrayND
  Test #24: ParArrayND with LayoutLeft
  Test #25: ParArray resizing
  Test #26: Time simple stencil operations
  Test #27: Check registry pressure
  Test #28: Check many arrays
  Test #29: Can pull variables from containers based on Metadata
  Test #30: Coarse variable from meshblock_data for cell variable
  Test #31: Get the correct access pattern when using FlatIdx
  Test #32: MeshData works as expected for simple packs
  Test #33: Swarm memory management
  Test #34: Test required/desired checking from inputs
  Test #35: Parthenon Error Checking
  Test #36: Check that integer division, rounded up, works
  Test #37: Check that partitioning a container works
  Test #38: Test Add/Get in Packages_t
  Test #39: Test Associate in StateDescriptor
  Test #40: Test dependency resolution in StateDescriptor
  Test #41: Test SparsePool interface
  Test #42: Kokkos::OpenMP::initialize WARNING: OMP_PROC_BIND environment variable not set
  Test #43:   In general, for best performance with OpenMP 4.0 or better set OMP_PROC_BIND=spread and OMP_PLACES=threads
  Test #44:   For best performance with OpenMP 3.1 set OMP_PROC_BIND=true
  Test #45:   For unit testing set OMP_PROC_BIND=false
  Test #46: Catch2 Container Iterator Performance
```

```