### PR TITLE
try to sfinae away weird issues with hsize_t closes #650

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 652]](https://github.com/lanl/parthenon/pull/652) Fix issue with hsize_t and size_t in utils parser
 - [[PR 649]](https://github.com/lanl/parthenon/pull/649) Ensure LoadBalancing send buffers are filled and allow async recv LB
 - [[PR 618]](https://github.com/lanl/parthenon/pull/618) Fix bug in variable pack performance test
 - [[PR 616]](https://github.com/lanl/parthenon/pull/609) Restore sparse base names in PackIndexMap

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -63,6 +63,21 @@ namespace Env {
 
 namespace Impl {
 // TODO(the person bumping standard to C++17) Clean up this mess and use constexpr if
+
+// TODO(JMM): We use template specialization below to parse
+// information from environment variables
+// where we template on return type. We hit an issue with HDF5's hsize_t, becuase:
+// (a) sometimes HDF5 is disabled, so hsize_t isn't always present
+// (b) hsize_t's type is system/compiler-dependent. Sometimes it's the same as size_t,
+//     but it doesn't have to be. If you define a specialization for size_t
+//     and hsize_t on a system where they are not the same,
+//     the compiler will see a duplicate function and complain.
+// To resolve this issue, we use SFINAE. The std::enable_ifs mean the
+// templated functions are enabled only if the appropriate conditions are met.
+// In particular, the prototype is enabled only for types that are
+// not size_t or hsize_t.
+// Then the implementation for size_t is always enabled and the implementation
+// for hsize_t is enabled ONLY if HDF5 is available, and hsize_t != size_t.
 template <typename T,
           typename std::enable_if<!std::is_same<T, size_t>::value, bool>::type = true
 #ifdef ENABLE_HDF5

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -106,7 +106,8 @@ inline T parse_value(std::string &strvalue) {
 }
 
 #ifdef ENABLE_HDF5
-template <typename T, std::enable_if<std::is_same<T, hsize_t>::value, bool>::type = true,
+template <typename T,
+          typename std::enable_if<std::is_same<T, hsize_t>::value, bool>::type = true,
           typename std::enable_if<!std::is_same<T, size_t>::value, bool>::type = true>
 inline T parse_value(std::string &strvalue) {
   return parse_unsigned<hsize_t>(strvalue);

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -106,12 +106,12 @@ inline T parse_value(std::string &strvalue) {
 }
 
 #ifdef ENABLE_HDF5
-template <std::enable_if<std::is_same<T, hsize_t>::value, bool>::type = true,
+template <typename T, std::enable_if<std::is_same<T, hsize_t>::value, bool>::type = true,
           typename std::enable_if<!std::is_same<T, size_t>::value, bool>::type = true>
 inline T parse_value(std::string &strvalue) {
   return parse_unsigned<hsize_t>(strvalue);
 }
-#endif // ifdef ENABLE_HDF5
+#Endif // ifdef ENABLE_HDF5
 } // namespace Impl
 
 // Get environment variables of various types (with checks).

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -68,7 +68,7 @@ template <typename T,
 #ifdef ENABLE_HDF5
           ,
           typename std::enable_if<!std::is_same<T, hsize_t>::value, bool>::type = true>
-#endif
+#endif // ENABLE_HDF5
 T parse_value(std::string &strvalue);
 
 // Parse env. variable expected to hold a bool value allowing for different conventions.
@@ -111,7 +111,7 @@ template <typename T, std::enable_if<std::is_same<T, hsize_t>::value, bool>::typ
 inline T parse_value(std::string &strvalue) {
   return parse_unsigned<hsize_t>(strvalue);
 }
-#Endif // ifdef ENABLE_HDF5
+#endif // ifdef ENABLE_HDF5
 } // namespace Impl
 
 // Get environment variables of various types (with checks).

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Our parser in utils struggles when HDF5 is enabled and `hsize_t` is the same as `size_t` on some platforms, as reported in #650 . This PR attempts to fix the issue by making things significantly more complicated. Rather than using template specialization, I use SFINAE so that only the relevant template specializations are compiled/present. This lets me turn on a method for `hsize_t` if and only if `hsize_t` exists and is a different type from `size_t`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
