### PR TITLE
Allow for multi-D particle variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 653]](https://github.com/lanl/parthenon/pull/653) Allow for multi-D particle variables
 - [[PR 622]](https://github.com/lanl/parthenon/pull/622) Extend reduction framework to support more general data types. Now uses PR 623.
 - [[PR 619]](https://github.com/lanl/parthenon/pull/619) Sort particles by cell
 - [[PR 605]](https://github.com/lanl/parthenon/pull/605) Add output triggering by signaling.

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -113,8 +113,9 @@ AMR is currently not supported, but support will be added in the future.
 Similarly to grid variables, particle swarms support `ParticleVariable` packing, by the function
 `Swarm::PackVariables`.
 
-Note that this 1D or 2D ParticleVariables are currently untested with this function; in particular,
-`FlatIdx` is not guaranteed to work correctly.
+Note that higher-dimensional (more than one element per particle) ParticleVariables are
+currently untested with this function; in particular, `FlatIdx` is not guaranteed to work
+correctly.
 
 ## Boundary conditions
 

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -12,8 +12,8 @@ positions `x`, `y`, and `z` of the particles in a swarm are three separate
 `ParticleVariable`s. `ParticleVariable`s can be either `Real`- or `int`-valued, which is
 specified by the metadata values `Metadata::Real` and `Metadata::Integer`.
 `ParticleVariable`s should also contain the `Metadata::Particle` flag. By default,
-`ParticleVariable`s provide one scalar quantity per particle, but 1D data per particle is
-currently supported, by passing `std::vector<int>{N}` as the second argument to the
+`ParticleVariable`s provide one scalar quantity per particle, but up to 2D data per particle is
+currently supported, by passing `std::vector<int>{N1, N2}` as the second argument to the
 `ParticleVariable` `Metadata`. All `Swarm`s by default contain `x`, `y`, and `z`
 `ParticleVariable`s; additional fields can be added as:
 ```c++
@@ -107,6 +107,14 @@ further details. Note that this pattern is blocking, and may be replaced in the
 future.
 
 AMR is currently not supported, but support will be added in the future.
+
+## Variable Packing
+
+Similarly to grid variables, particle swarms support `ParticleVariable` packing, by the function
+`Swarm::PackVariables`.
+
+Note that this 1D or 2D ParticleVariables are currently untested with this function; in particular,
+`FlatIdx` is not guaranteed to work correctly.
 
 ## Boundary conditions
 

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -110,12 +110,9 @@ AMR is currently not supported, but support will be added in the future.
 
 ## Variable Packing
 
-Similarly to grid variables, particle swarms support `ParticleVariable` packing, by the function
-`Swarm::PackVariables`.
-
-Note that higher-dimensional (more than one element per particle) ParticleVariables are
-currently untested with this function; in particular, `FlatIdx` is not guaranteed to work
-correctly.
+Similarly to grid variables, particle swarms support `ParticleVariable` packing, by the
+function `Swarm::PackVariables`. This also supports `FlatIdx` for indexing; see the
+`particle_leapfrog` example for usage.
 
 ## Boundary conditions
 

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -10,8 +10,12 @@ A `Swarm` contains all the particle data for all particles of a given species. I
 set of `ParticleVariable`s, one for each value of each particle. For example, the spatial
 positions `x`, `y`, and `z` of the particles in a swarm are three separate
 `ParticleVariable`s. `ParticleVariable`s can be either `Real`- or `int`-valued, which is
-specified by the metadata values `Metadata::Real` and `Metadata::Integer`. All `Swarm`s by
-default contain `x`, `y`, and `z` `ParticleVariable`s; additional fields can be added as:
+specified by the metadata values `Metadata::Real` and `Metadata::Integer`.
+`ParticleVariable`s should also contain the `Metadata::Particle` flag. By default,
+`ParticleVariable`s provide one scalar quantity per particle, but 1D data per particle is
+currently supported, by passing `std::vector<int>{N}` as the second argument to the
+`ParticleVariable` `Metadata`. All `Swarm`s by default contain `x`, `y`, and `z`
+`ParticleVariable`s; additional fields can be added as:
 ```c++
 Swarm.Add(name, metadata)
 ```
@@ -26,10 +30,10 @@ Hereafter we refer to it as `swarm_d`.
 
 To add particles to a `Swarm`, one calls
 ```c++
-ParArrayND<bool> new_particles_mask = swarm->AddEmptyParticles(num_to_add, new_indices)
+ParArray1D<bool> new_particles_mask = swarm->AddEmptyParticles(num_to_add, new_indices)
 ```
 This call automatically resizes the memory pools as necessary and returns a
-`ParArrayND<bool>` mask indicating which indices in the `ParticleVariable`s are newly
+`ParArray1D<bool>` mask indicating which indices in the `ParticleVariable`s are newly
 available. `new_indices` is a reference to a `ParArrayND<int>` of size `num_to_add` which
 contains the indices of each newly added particle.
 

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -1,9 +1,9 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2021 The Parthenon collaboration
+// Copyright(C) 2021-2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -69,8 +69,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string swarm_name = "my particles";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
-  Metadata real_swarmvalue_metadata({Metadata::Real});
-  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer}));
+  Metadata real_swarmvalue_metadata({Metadata::Real, Metadata::Particle});
+  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer, Metadata::Particle}));
   pkg->AddSwarmValue("vx", swarm_name, real_swarmvalue_metadata);
   pkg->AddSwarmValue("vy", swarm_name, real_swarmvalue_metadata);
   pkg->AddSwarmValue("vz", swarm_name, real_swarmvalue_metadata);
@@ -136,7 +136,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
     auto &pmb = blocks[i];
 
     auto swarm = pmb->swarm_data.Get()->Get("my particles");
-    const auto &is_active = Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
+    const auto &is_active =
+        Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
     for (auto n = 0; n <= swarm->GetMaxActiveIndex(); n++) {
       if (is_active(n)) {
         num_particles_this_rank += 1;
@@ -162,7 +163,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
     const auto &vy = swarm->Get<Real>("vy").Get().GetHostMirrorAndCopy();
     const auto &vz = swarm->Get<Real>("vz").Get().GetHostMirrorAndCopy();
 
-    const auto &is_active = Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
+    const auto &is_active =
+        Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
     for (auto n = 0; n <= swarm->GetMaxActiveIndex(); n++) {
       if (is_active(n)) {
         particle_output_this_rank(offset++) = static_cast<Real>(pmb->gid);

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -193,24 +193,24 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
         }
       }
     }
-  
+
     const auto is_active_d = swarm->GetMask();
     pmb->par_for(
-      "CheckParticlePacks", 0, swarm->GetMaxActiveIndex(), KOKKOS_LAMBDA(const int n) {
-      if (is_active_d(n)) {
-        for (int i = 0; i < 3; i++) {
-          for (int j = 0; j < 3; j++) {
-            if (std::fabs(vp(ivv(i, j), n)) > 1.e-10) {
-              PARTHENON_REQUIRE(
-                  2. * std::fabs(vp(ivv(i, j), n) - vp(iv(i), n) * vp(iv(j), n)) <
-                      1.e-10 * (std::fabs(vp(ivv(i, j), n)) +
-                                std::fabs(vp(iv(i), n) * vp(iv(j), n))),
-                  "packed vv not consistent with packed v*v!");
+        "CheckParticlePacks", 0, swarm->GetMaxActiveIndex(), KOKKOS_LAMBDA(const int n) {
+          if (is_active_d(n)) {
+            for (int i = 0; i < 3; i++) {
+              for (int j = 0; j < 3; j++) {
+                if (std::fabs(vp(ivv(i, j), n)) > 1.e-10) {
+                  PARTHENON_REQUIRE(
+                      2. * std::fabs(vp(ivv(i, j), n) - vp(iv(i), n) * vp(iv(j), n)) <
+                          1.e-10 * (std::fabs(vp(ivv(i, j), n)) +
+                                    std::fabs(vp(iv(i), n) * vp(iv(j), n))),
+                      "packed vv not consistent with packed v*v!");
+                }
+              }
             }
           }
-        }
-      }
-    });
+        });
   }
 
   // Step 2b. Gather data on root process

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -136,8 +136,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
     auto &pmb = blocks[i];
 
     auto swarm = pmb->swarm_data.Get()->Get("my particles");
-    const auto &is_active = swarm->GetMask().Get().GetHostMirrorAndCopy();
-    for (auto n = 0; n < is_active.GetSize(); n++) {
+    const auto &is_active = Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
+    for (auto n = 0; n <= swarm->GetMaxActiveIndex(); n++) {
       if (is_active(n)) {
         num_particles_this_rank += 1;
       }
@@ -162,8 +162,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
     const auto &vy = swarm->Get<Real>("vy").Get().GetHostMirrorAndCopy();
     const auto &vz = swarm->Get<Real>("vz").Get().GetHostMirrorAndCopy();
 
-    const auto &is_active = swarm->GetMask().Get().GetHostMirrorAndCopy();
-    for (auto n = 0; n < is_active.GetSize(); n++) {
+    const auto &is_active = Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
+    for (auto n = 0; n <= swarm->GetMaxActiveIndex(); n++) {
       if (is_active(n)) {
         particle_output_this_rank(offset++) = static_cast<Real>(pmb->gid);
         particle_output_this_rank(offset++) = static_cast<Real>(id(n));

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -89,11 +89,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
   pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer}));
-  Metadata vreal_swarmvalue_metadata({Metadata::Real},
-                                     std::vector<int>{3});
+  Metadata vreal_swarmvalue_metadata({Metadata::Real}, std::vector<int>{3});
   pkg->AddSwarmValue("v", swarm_name, vreal_swarmvalue_metadata);
-  Metadata vvreal_swarmvalue_metadata({Metadata::Real},
-                                      std::vector<int>{2, 2});
+  Metadata vvreal_swarmvalue_metadata({Metadata::Real}, std::vector<int>{2, 2});
   pkg->AddSwarmValue("vv", swarm_name, vvreal_swarmvalue_metadata);
 
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -88,11 +88,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string swarm_name = "my particles";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
-  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer, Metadata::Particle}));
-  Metadata vreal_swarmvalue_metadata({Metadata::Real, Metadata::Particle},
+  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer}));
+  Metadata vreal_swarmvalue_metadata({Metadata::Real},
                                      std::vector<int>{3});
   pkg->AddSwarmValue("v", swarm_name, vreal_swarmvalue_metadata);
-  Metadata vvreal_swarmvalue_metadata({Metadata::Real, Metadata::Particle},
+  Metadata vvreal_swarmvalue_metadata({Metadata::Real},
                                       std::vector<int>{2, 2});
   pkg->AddSwarmValue("vv", swarm_name, vvreal_swarmvalue_metadata);
 

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -184,10 +184,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
         for (int i = 0; i < 3; i++) {
           for (int j = 0; j < 3; j++) {
             if (std::fabs(vv(i, j, n)) > 1.e-10) {
-              PARTHENON_REQUIRE(
-                  2. * std::fabs(vv(i, j, n) - v(i, n) * v(j, n)) <
-                      1.e-10 * (std::fabs(vv(i, j, n)) + std::fabs(v(i, n) * v(j, n))),
-                  "vv not consistent with v*v!");
+              PARTHENON_REQUIRE(vv(i, j, n) == v(i, n) * v(j, n),
+                                "vv not consistent with v*v!");
             }
           }
         }
@@ -201,11 +199,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
             for (int i = 0; i < 3; i++) {
               for (int j = 0; j < 3; j++) {
                 if (std::fabs(vp(ivv(i, j), n)) > 1.e-10) {
-                  PARTHENON_REQUIRE(
-                      2. * std::fabs(vp(ivv(i, j), n) - vp(iv(i), n) * vp(iv(j), n)) <
-                          1.e-10 * (std::fabs(vp(ivv(i, j), n)) +
-                                    std::fabs(vp(iv(i), n) * vp(iv(j), n))),
-                      "packed vv not consistent with packed v*v!");
+                  PARTHENON_REQUIRE(vp(ivv(i, j), n) == vp(iv(i), n) * vp(iv(j), n),
+                                    "packed vv not consistent with packed v*v!");
                 }
               }
             }

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -107,29 +107,6 @@ Real EstimateTimestepBlock(MeshBlockData<Real> *rc) {
   int max_active_index = swarm->GetMaxActiveIndex();
 
   const auto &v = swarm->Get<Real>("v").Get();
-  // Test, check particles
-
-
-  {
-    const auto &id = swarm->Get<int>("id").Get();
-  auto swarm_d = swarm->GetDeviceContext();
-  pmb->par_for("TEST", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
-    if (swarm_d.IsActive(n)) {
-      bool is_good = true;
-      if (particles_ic[id(n)][3] != v(0,n)) is_good = false;
-      if (particles_ic[id(n)][4] != v(1,n)) is_good = false;
-      if (particles_ic[id(n)][5] != v(2,n)) is_good = false;
-      if (!is_good) {
-        printf("%s:%i\n", __FILE__, __LINE__);
-        printf("Particle %i velocity is bad! gid: %i\n", id(n), pmb->gid);
-        printf("v: %e %e %e\n", v(0,n), v(1,n), v(2,n));
-        printf("v true: %e %e %e\n", particles_ic[id(n)][3],
-          particles_ic[id(n)][4], particles_ic[id(n)][5]);
-        exit(-1);
-      }
-    }
-  });
-  }
 
   // Assumes a grid with constant dx, dy, dz within a block
   const Real &dx_i = pmb->coords.dx1f(0);
@@ -184,7 +161,6 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
       }
     }
   }
-  printf("num particles this rank: %i\n", num_particles_this_rank);
 
   // Step 2a: Gather actual data locally
   constexpr int num_fields = 8; // block->gid, id, x, y, z, vx, vy, vz
@@ -201,27 +177,6 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
     const auto &y = swarm->Get<Real>("y").Get().GetHostMirrorAndCopy();
     const auto &z = swarm->Get<Real>("z").Get().GetHostMirrorAndCopy();
     const auto &v = swarm->Get<Real>("v").Get().GetHostMirrorAndCopy();
-  // Test, check particles
-  {
-  auto swarm_d = swarm->GetDeviceContext();
-  int max_active_index = swarm->GetMaxActiveIndex();
-  pmb->par_for("TEST", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
-    if (swarm_d.IsActive(n)) {
-      bool is_good = true;
-      if (particles_ic[id(n)][3] != v(0,n)) is_good = false;
-      if (particles_ic[id(n)][4] != v(1,n)) is_good = false;
-      if (particles_ic[id(n)][5] != v(2,n)) is_good = false;
-      if (!is_good) {
-        printf("%s:%i\n", __FILE__, __LINE__);
-        printf("Particle %i velocity is bad! gid: %i\n", id(n), pmb->gid);
-        printf("v: %e %e %e\n", v(0,n), v(1,n), v(2,n));
-        printf("v true: %e %e %e\n", particles_ic[id(n)][3],
-          particles_ic[id(n)][4], particles_ic[id(n)][5]);
-        exit(-1);
-      }
-    }
-  });
-  }
 
     const auto &is_active =
         Kokkos::create_mirror_view_and_copy(HostMemSpace(), swarm->GetMask());
@@ -400,27 +355,6 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
   auto &z = swarm->Get<Real>("z").Get();
   auto &v = swarm->Get<Real>("v").Get();
 
-  // Test, check particles
-  {
-  auto swarm_d = swarm->GetDeviceContext();
-  pmb->par_for("TEST", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
-    if (swarm_d.IsActive(n)) {
-      bool is_good = true;
-      if (particles_ic[id(n)][3] != v(0,n)) is_good = false;
-      if (particles_ic[id(n)][4] != v(1,n)) is_good = false;
-      if (particles_ic[id(n)][5] != v(2,n)) is_good = false;
-      if (!is_good) {
-        printf("%s:%i\n", __FILE__, __LINE__);
-        printf("Particle %i velocity is bad! gid: %i\n", id(n), pmb->gid);
-        printf("v: %e %e %e\n", v(0,n), v(1,n), v(2,n));
-        printf("v true: %e %e %e\n", particles_ic[id(n)][3],
-          particles_ic[id(n)][4], particles_ic[id(n)][5]);
-        exit(-1);
-      }
-    }
-  });
-  }
-
   auto swarm_d = swarm->GetDeviceContext();
   // keep particles on existing trajectory for now
   const Real ax = 0.0;
@@ -448,27 +382,6 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
           swarm_d.GetNeighborBlockIndex(n, x(n), y(n), z(n), on_current_mesh_block);
         }
       });
-
-  // Test, check particles
-  {
-  auto swarm_d = swarm->GetDeviceContext();
-  pmb->par_for("TEST", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
-    if (swarm_d.IsActive(n)) {
-      bool is_good = true;
-      if (particles_ic[id(n)][3] != v(0,n)) is_good = false;
-      if (particles_ic[id(n)][4] != v(1,n)) is_good = false;
-      if (particles_ic[id(n)][5] != v(2,n)) is_good = false;
-      if (!is_good) {
-        printf("%s:%i\n", __FILE__, __LINE__);
-        printf("Particle %i velocity is bad! gid: %i\n", id(n), pmb->gid);
-        printf("v: %e %e %e\n", v(0,n), v(1,n), v(2,n));
-        printf("v true: %e %e %e\n", particles_ic[id(n)][3],
-          particles_ic[id(n)][4], particles_ic[id(n)][5]);
-        exit(-1);
-      }
-    }
-  });
-  }
 
   return TaskStatus::complete;
 }

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -163,9 +163,7 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
 
     PackIndexMap imap;
     std::vector<std::string> pack_names = {"v", "vv"};
-    printf("PACK VARIABLES!!!!\n");
     auto vp = swarm->PackVariables<Real>(pack_names, imap);
-    printf("DONE PACKING!\n");
     auto iv = imap.GetFlatIdx("v");
     auto ivv = imap.GetFlatIdx("vv");
 
@@ -185,15 +183,12 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
         // Check that vv is still consistent with v
         for (int i = 0; i < 3; i++) {
           for (int j = 0; j < 3; j++) {
-            printf("[%i %i] ivv: %i iv: %i %i\n",
-              i, j, ivv(i,j), iv(i), iv(j));
-            printf("vv: %e v*v: %e\n", vv(i, j, n), v(i,n)*v(j,n));
-            printf("vvp: %e vp*vp: %e\n", vp(ivv(i, j), n), vp(iv(i), n)*vp(iv(j), n));
-            if (std::fabs(vv(i,j,n)) > 1.e-10) {
-              //PARTHENON_REQUIRE(
-              //    2. * std::fabs(vp(ivv(i, j), n) - vp(iv(i), n) * vp(iv(j), n)) <
-              //        1.e-10 * (std::fabs(vp(ivv(i, j), n)) + std::fabs(v(i, n) * v(j, n))),
-              //    "packed vv not consistent with v*v!");
+            if (std::fabs(vv(i, j, n)) > 1.e-10) {
+              PARTHENON_REQUIRE(
+                  2. * std::fabs(vp(ivv(i, j), n) - vp(iv(i), n) * vp(iv(j), n)) <
+                      1.e-10 * (std::fabs(vp(ivv(i, j), n)) +
+                                std::fabs(vp(iv(i), n) * vp(iv(j), n))),
+                  "packed vv not consistent with packed v*v!");
               PARTHENON_REQUIRE(
                   2. * std::fabs(vv(i, j, n) - v(i, n) * v(j, n)) <
                       1.e-10 * (std::fabs(vv(i, j, n)) + std::fabs(v(i, n) * v(j, n))),

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -183,10 +183,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
         // Check that vv is still consistent with v
         for (int i = 0; i < 3; i++) {
           for (int j = 0; j < 3; j++) {
-            if (std::fabs(vv(i, j, n)) > 1.e-10) {
-              PARTHENON_REQUIRE(vv(i, j, n) == v(i, n) * v(j, n),
-                                "vv not consistent with v*v!");
-            }
+            PARTHENON_REQUIRE(vv(i, j, n) == v(i, n) * v(j, n),
+                              "vv not consistent with v*v!");
           }
         }
       }
@@ -198,10 +196,8 @@ TaskStatus WriteParticleLog(BlockList_t &blocks, int ncycle) {
           if (is_active_d(n)) {
             for (int i = 0; i < 3; i++) {
               for (int j = 0; j < 3; j++) {
-                if (std::fabs(vp(ivv(i, j), n)) > 1.e-10) {
-                  PARTHENON_REQUIRE(vp(ivv(i, j), n) == vp(iv(i), n) * vp(iv(j), n),
-                                    "packed vv not consistent with packed v*v!");
-                }
+                PARTHENON_REQUIRE(vp(ivv(i, j), n) == vp(iv(i), n) * vp(iv(j), n),
+                                  "packed vv not consistent with packed v*v!");
               }
             }
           }

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -88,10 +88,13 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string swarm_name = "my particles";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
+  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer, Metadata::Particle}));
   Metadata vreal_swarmvalue_metadata({Metadata::Real, Metadata::Particle},
                                      std::vector<int>{3});
-  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer, Metadata::Particle}));
   pkg->AddSwarmValue("v", swarm_name, vreal_swarmvalue_metadata);
+  Metadata vvreal_swarmvalue_metadata({Metadata::Real, Metadata::Particle},
+                                      std::vector<int>{2, 2});
+  pkg->AddSwarmValue("vv", swarm_name, vvreal_swarmvalue_metadata);
 
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;
 

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -1,9 +1,9 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2021 The Parthenon collaboration
+// Copyright(C) 2021-2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2021-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -154,8 +154,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string swarm_name = "tracers";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
-  Metadata real_swarmvalue_metadata({Metadata::Real, Metadata::Particle});
-  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer, Metadata::Particle}));
+  Metadata real_swarmvalue_metadata({Metadata::Real});
+  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer}));
 
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;
 

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -154,8 +154,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string swarm_name = "tracers";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
-  Metadata real_swarmvalue_metadata({Metadata::Real});
-  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer}));
+  Metadata real_swarmvalue_metadata({Metadata::Real, Metadata::Particle});
+  pkg->AddSwarmValue("id", swarm_name, Metadata({Metadata::Integer, Metadata::Particle}));
 
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;
 

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -375,8 +375,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   int num_tracers_meshblock = std::round(num_tracers * number_meshblock / number_mesh);
 
   ParArrayND<int> new_indices;
-  const auto new_particles_mask =
-      swarm->AddEmptyParticles(num_tracers_meshblock, new_indices);
+  swarm->AddEmptyParticles(num_tracers_meshblock, new_indices);
 
   auto &x = swarm->Get<Real>("x").Get();
   auto &y = swarm->Get<Real>("y").Get();

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -441,9 +441,9 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
               Real dt_end = t0 + dt - t(n);
               Real dt_push = std::min<Real>(dt_cell, dt_end);
 
-              x(n) += v(n, 0) * dt_push;
-              y(n) += v(n, 1) * dt_push;
-              z(n) += v(n, 2) * dt_push;
+              x(n) += v(0, n) * dt_push;
+              y(n) += v(1, n) * dt_push;
+              z(n) += v(2, n) * dt_push;
               t(n) += dt_push;
 
               bool on_current_mesh_block = true;

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -89,9 +89,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Metadata real_swarmvalue_metadata({Metadata::Real, Metadata::Particle});
   pkg->AddSwarmValue("t", swarm_name, real_swarmvalue_metadata);
   Metadata real_vec_swarmvalue_metadata({Metadata::Real, Metadata::Particle}, std::vector<int>{3});
-  //pkg->AddSwarmValue("vx", swarm_name, real_swarmvalue_metadata);
-  //pkg->AddSwarmValue("vy", swarm_name, real_swarmvalue_metadata);
-  //pkg->AddSwarmValue("vz", swarm_name, real_swarmvalue_metadata);
   pkg->AddSwarmValue("v", swarm_name, real_vec_swarmvalue_metadata);
   pkg->AddSwarmValue("weight", swarm_name, real_swarmvalue_metadata);
 

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -92,8 +92,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   pkg->AddSwarm(swarm_name, swarm_metadata);
   Metadata real_swarmvalue_metadata({Metadata::Real});
   pkg->AddSwarmValue("t", swarm_name, real_swarmvalue_metadata);
-  Metadata real_vec_swarmvalue_metadata({Metadata::Real},
-                                        std::vector<int>{3});
+  Metadata real_vec_swarmvalue_metadata({Metadata::Real}, std::vector<int>{3});
   pkg->AddSwarmValue("v", swarm_name, real_vec_swarmvalue_metadata);
   pkg->AddSwarmValue("weight", swarm_name, real_swarmvalue_metadata);
 

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -88,9 +88,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   pkg->AddSwarm(swarm_name, swarm_metadata);
   Metadata real_swarmvalue_metadata({Metadata::Real});
   pkg->AddSwarmValue("t", swarm_name, real_swarmvalue_metadata);
-  pkg->AddSwarmValue("vx", swarm_name, real_swarmvalue_metadata);
-  pkg->AddSwarmValue("vy", swarm_name, real_swarmvalue_metadata);
-  pkg->AddSwarmValue("vz", swarm_name, real_swarmvalue_metadata);
+  Metadata real_vec_swarmvalue_metadata({Metadata::Real}, std::vector<int>{3});
+  //pkg->AddSwarmValue("vx", swarm_name, real_swarmvalue_metadata);
+  //pkg->AddSwarmValue("vy", swarm_name, real_swarmvalue_metadata);
+  //pkg->AddSwarmValue("vz", swarm_name, real_swarmvalue_metadata);
+  pkg->AddSwarmValue("v", swarm_name, real_vec_swarmvalue_metadata);
   pkg->AddSwarmValue("weight", swarm_name, real_swarmvalue_metadata);
 
   std::string field_name = "particle_deposition";
@@ -240,7 +242,7 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
   auto swarm = pmb->swarm_data.Get()->Get("my particles");
   auto rng_pool = pkg->Param<RNGPool>("rng_pool");
   auto num_particles = pkg->Param<int>("num_particles");
-  auto v = pkg->Param<Real>("particle_speed");
+  auto vel = pkg->Param<Real>("particle_speed");
   const auto orbiting_particles = pkg->Param<bool>("orbiting_particles");
 
   ParArrayND<int> new_indices;
@@ -264,9 +266,7 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
   auto &x = swarm->Get<Real>("x").Get();
   auto &y = swarm->Get<Real>("y").Get();
   auto &z = swarm->Get<Real>("z").Get();
-  auto &vx = swarm->Get<Real>("vx").Get();
-  auto &vy = swarm->Get<Real>("vy").Get();
-  auto &vz = swarm->Get<Real>("vz").Get();
+  auto &v = swarm->Get<Real>("v").Get();
   auto &weight = swarm->Get<Real>("weight").Get();
 
   auto swarm_d = swarm->GetDeviceContext();
@@ -291,21 +291,21 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
             // Randomly sample direction perpendicular to origin
             Real theta = acos(2. * rng_gen.drand() - 1.);
             Real phi = 2. * M_PI * rng_gen.drand();
-            vx(n) = sin(theta) * cos(phi);
-            vy(n) = sin(theta) * sin(phi);
-            vz(n) = cos(theta);
+            v(n, 0) = sin(theta) * cos(phi);
+            v(n, 1) = sin(theta) * sin(phi);
+            v(n, 2) = cos(theta);
             // Project v onto plane normal to sphere
-            Real vdN = vx(n) * x(n) + vy(n) * y(n) + vz(n) * z(n);
+            Real vdN = v(n, 0) * x(n) + v(n, 1) * y(n) + v(n, 2) * z(n);
             Real NdN = r * r;
-            vx(n) = vx(n) - vdN / NdN * x(n);
-            vy(n) = vy(n) - vdN / NdN * y(n);
-            vz(n) = vz(n) - vdN / NdN * z(n);
+            v(n, 0) = v(n, 0) - vdN / NdN * x(n);
+            v(n, 1) = v(n, 1) - vdN / NdN * y(n);
+            v(n, 2) = v(n, 2) - vdN / NdN * z(n);
 
             // Normalize
-            Real v_tmp = sqrt(vx(n) * vx(n) + vy(n) * vy(n) + vz(n) * vz(n));
-            vx(n) *= v / v_tmp;
-            vy(n) *= v / v_tmp;
-            vz(n) *= v / v_tmp;
+            Real v_tmp = sqrt(v(n, 0) * v(n, 0) + v(n, 1) * v(n, 1) + v(n, 2) * v(n, 2));
+            for (int ii = 0; ii < 3; ii++) {
+              v(n, ii) *= vel / v_tmp;
+            }
 
             // Create particles at the beginning of the timestep
             t(n) = t0;
@@ -329,9 +329,9 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
             // Randomly sample direction on the unit sphere, fixing speed
             Real theta = acos(2. * rng_gen.drand() - 1.);
             Real phi = 2. * M_PI * rng_gen.drand();
-            vx(n) = v * sin(theta) * cos(phi);
-            vy(n) = v * sin(theta) * sin(phi);
-            vz(n) = v * cos(theta);
+            v(n, 0) = vel * sin(theta) * cos(phi);
+            v(n, 1) = vel * sin(theta) * sin(phi);
+            v(n, 2) = vel * cos(theta);
 
             // Create particles at the beginning of the timestep
             t(n) = t0;
@@ -363,9 +363,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
   auto &x = swarm->Get<Real>("x").Get();
   auto &y = swarm->Get<Real>("y").Get();
   auto &z = swarm->Get<Real>("z").Get();
-  auto &vx = swarm->Get<Real>("vx").Get();
-  auto &vy = swarm->Get<Real>("vy").Get();
-  auto &vz = swarm->Get<Real>("vz").Get();
+  auto &v = swarm->Get<Real>("v").Get();
 
   const Real &dx_i = pmb->coords.dx1f(pmb->cellbounds.is(IndexDomain::interior));
   const Real &dx_j = pmb->coords.dx2f(pmb->cellbounds.js(IndexDomain::interior));
@@ -392,17 +390,17 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
     pmb->par_for(
         "TransportOrbitingParticles", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
           if (swarm_d.IsActive(n)) {
-            Real v = sqrt(vx(n) * vx(n) + vy(n) * vy(n) + vz(n) * vz(n));
+            Real vel = sqrt(v(n, 0) * v(n, 0) + v(n, 1) * v(n, 1) + v(n, 2) * v(n, 2));
             while (t(n) < t0 + dt) {
-              Real dt_cell = dx_push / v;
+              Real dt_cell = dx_push / vel;
               Real dt_end = t0 + dt - t(n);
               Real dt_push = std::min<Real>(dt_cell, dt_end);
 
               Real r = sqrt(x(n) * x(n) + y(n) * y(n) + z(n) * z(n));
 
-              x(n) += vx(n) * dt_push;
-              y(n) += vy(n) * dt_push;
-              z(n) += vz(n) * dt_push;
+              x(n) += v(n, 0) * dt_push;
+              y(n) += v(n, 1) * dt_push;
+              z(n) += v(n, 2) * dt_push;
               t(n) += dt_push;
 
               // Force point back onto spherical shell
@@ -412,17 +410,17 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
               z(n) *= r / r_tmp;
 
               // Project v onto plane normal to sphere
-              Real vdN = vx(n) * x(n) + vy(n) * y(n) + vz(n) * z(n);
+              Real vdN = v(n, 0) * x(n) + v(n, 1) * y(n) + v(n, 2) * z(n);
               Real NdN = r * r;
-              vx(n) = vx(n) - vdN / NdN * x(n);
-              vy(n) = vy(n) - vdN / NdN * y(n);
-              vz(n) = vz(n) - vdN / NdN * z(n);
+              v(n, 0) = v(n, 0) - vdN / NdN * x(n);
+              v(n, 1) = v(n, 1) - vdN / NdN * y(n);
+              v(n, 2) = v(n, 2) - vdN / NdN * z(n);
 
               // Normalize
-              Real v_tmp = sqrt(vx(n) * vx(n) + vy(n) * vy(n) + vz(n) * vz(n));
-              vx(n) *= v / v_tmp;
-              vy(n) *= v / v_tmp;
-              vz(n) *= v / v_tmp;
+              Real v_tmp = sqrt(v(n, 0) * v(n, 0) + v(n, 1) * v(n, 1) + v(n, 2) * v(n, 2));
+              for (int ii = 0; ii < 3; ii++) {
+                v(n, ii) *= vel / v_tmp;
+              }
 
               bool on_current_mesh_block = true;
               // This call is required to trigger internal boundary condition machinery
@@ -440,15 +438,15 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
     pmb->par_for(
         "TransportParticles", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
           if (swarm_d.IsActive(n)) {
-            Real v = sqrt(vx(n) * vx(n) + vy(n) * vy(n) + vz(n) * vz(n));
+            Real vel = sqrt(v(n, 0) * v(n, 0) + v(n, 1) * v(n, 1) + v(n, 2) * v(n, 2));
             while (t(n) < t0 + dt) {
-              Real dt_cell = dx_push / v;
+              Real dt_cell = dx_push / vel;
               Real dt_end = t0 + dt - t(n);
               Real dt_push = std::min<Real>(dt_cell, dt_end);
 
-              x(n) += vx(n) * dt_push;
-              y(n) += vy(n) * dt_push;
-              z(n) += vz(n) * dt_push;
+              x(n) += v(n, 0) * dt_push;
+              y(n) += v(n, 1) * dt_push;
+              z(n) += v(n, 2) * dt_push;
               t(n) += dt_push;
 
               bool on_current_mesh_block = true;

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -310,6 +310,7 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
 
             // Normalize
             Real v_tmp = sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
+            PARTHENON_DEBUG_REQUIRE(v_tmp > 0., "Speed must be > 0!");
             for (int ii = 0; ii < 3; ii++) {
               v(ii, n) *= vel / v_tmp;
             }
@@ -398,6 +399,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
         "TransportOrbitingParticles", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
           if (swarm_d.IsActive(n)) {
             Real vel = sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
+            PARTHENON_DEBUG_REQUIRE(vel > 1.e-10, "Speed must be > 0!");
             while (t(n) < t0 + dt) {
               Real dt_cell = dx_push / vel;
               Real dt_end = t0 + dt - t(n);
@@ -412,6 +414,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
 
               // Force point back onto spherical shell
               Real r_tmp = sqrt(x(n) * x(n) + y(n) * y(n) + z(n) * z(n));
+              PARTHENON_DEBUG_REQUIRE(r_tmp > 0., "r_tmp must be > 0 for division!");
               x(n) *= r / r_tmp;
               y(n) *= r / r_tmp;
               z(n) *= r / r_tmp;
@@ -419,6 +422,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
               // Project v onto plane normal to sphere
               Real vdN = v(0, n) * x(n) + v(1, n) * y(n) + v(2, n) * z(n);
               Real NdN = r * r;
+              PARTHENON_DEBUG_REQUIRE(NdN > 0., "NdN must be > 0 for division!");
               v(0, n) = v(0, n) - vdN / NdN * x(n);
               v(1, n) = v(1, n) - vdN / NdN * y(n);
               v(2, n) = v(2, n) - vdN / NdN * z(n);
@@ -426,6 +430,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
               // Normalize
               Real v_tmp =
                   sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
+              PARTHENON_DEBUG_REQUIRE(v_tmp > 0., "v_tmp must be > 0 for division!");
               for (int ii = 0; ii < 3; ii++) {
                 v(ii, n) *= vel / v_tmp;
               }
@@ -447,6 +452,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
         "TransportParticles", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
           if (swarm_d.IsActive(n)) {
             Real vel = sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
+            PARTHENON_DEBUG_REQUIRE(vel > 0., "vel must be > 0 for division!");
             while (t(n) < t0 + dt) {
               Real dt_cell = dx_push / vel;
               Real dt_end = t0 + dt - t(n);

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -90,9 +90,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::string swarm_name = "my particles";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None});
   pkg->AddSwarm(swarm_name, swarm_metadata);
-  Metadata real_swarmvalue_metadata({Metadata::Real, Metadata::Particle});
+  Metadata real_swarmvalue_metadata({Metadata::Real});
   pkg->AddSwarmValue("t", swarm_name, real_swarmvalue_metadata);
-  Metadata real_vec_swarmvalue_metadata({Metadata::Real, Metadata::Particle},
+  Metadata real_vec_swarmvalue_metadata({Metadata::Real},
                                         std::vector<int>{3});
   pkg->AddSwarmValue("v", swarm_name, real_vec_swarmvalue_metadata);
   pkg->AddSwarmValue("weight", swarm_name, real_swarmvalue_metadata);

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -1,5 +1,9 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// Parthenon performance portable AMR framework
+// Copyright(C) 2021-2022 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -88,7 +88,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   pkg->AddSwarm(swarm_name, swarm_metadata);
   Metadata real_swarmvalue_metadata({Metadata::Real, Metadata::Particle});
   pkg->AddSwarmValue("t", swarm_name, real_swarmvalue_metadata);
-  Metadata real_vec_swarmvalue_metadata({Metadata::Real, Metadata::Particle}, std::vector<int>{3});
+  Metadata real_vec_swarmvalue_metadata({Metadata::Real, Metadata::Particle},
+                                        std::vector<int>{3});
   pkg->AddSwarmValue("v", swarm_name, real_vec_swarmvalue_metadata);
   pkg->AddSwarmValue("weight", swarm_name, real_swarmvalue_metadata);
 
@@ -414,7 +415,8 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
               v(2, n) = v(2, n) - vdN / NdN * z(n);
 
               // Normalize
-              Real v_tmp = sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
+              Real v_tmp =
+                  sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
               for (int ii = 0; ii < 3; ii++) {
                 v(ii, n) *= vel / v_tmp;
               }

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -399,7 +399,7 @@ TaskStatus TransportParticles(MeshBlock *pmb, const StagedIntegrator *integrator
         "TransportOrbitingParticles", 0, max_active_index, KOKKOS_LAMBDA(const int n) {
           if (swarm_d.IsActive(n)) {
             Real vel = sqrt(v(0, n) * v(0, n) + v(1, n) * v(1, n) + v(2, n) * v(2, n));
-            PARTHENON_DEBUG_REQUIRE(vel > 1.e-10, "Speed must be > 0!");
+            PARTHENON_DEBUG_REQUIRE(vel > 0., "Speed must be > 0!");
             while (t(n) < t0 + dt) {
               Real dt_cell = dx_push / vel;
               Real dt_end = t0 + dt - t(n);

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -141,7 +141,7 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
       arrDims[i + 3] = shape[i];
     for (int i = N; i < 3; i++)
       arrDims[i + 3] = 1;
-  } else if (Where() == Particle) {
+  } else if (IsSet(Particle)) {
     assert(N >= 1 && N <= 5);
     arrDims[0] = 1; // To be updated by swarm based on pool size before allocation
     for (int i = 0; i < N; i++)

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -123,10 +123,6 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
   const auto &shape = shape_;
   const int N = shape.size();
 
-  printf("%s:%i\n", __FILE__, __LINE__);
-  printf("shape_.size(): %i\n", shape_.size());
-  printf("shape_[0] = %i\n", shape_[0]);
-
   if (IsMeshTied()) {
     // Let the FaceVariable, EdgeVariable, and NodeVariable
     // classes add the +1's where needed.  They all expect
@@ -146,7 +142,6 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
     for (int i = N; i < 3; i++)
       arrDims[i + 3] = 1;
   } else if (Where() == Particle) {
-    printf("%s:%i\n", __FILE__, __LINE__);
     assert(N >= 1 && N <= 5);
     arrDims[0] = 1; // To be updated by swarm based on pool size before allocation
     for (int i = 0; i < N; i++)
@@ -154,7 +149,6 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
     for (int i = N; i < 5; i++)
       arrDims[i + 1] = 1;
   } else {
-    printf("%s:%i\n", __FILE__, __LINE__);
     // This variable is not necessarily tied to any specific
     // mesh element, so dims will be used as the actual array
     // size in each dimension
@@ -165,7 +159,7 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
       arrDims[i] = 1;
   }
 
-  printf("arrDims: %i %i %i %i %i %i\n", arrDims[0], arrDims[1], arrDims[2], arrDims[3], arrDims[4], arrDims[5]);
+  printf("shape: %i %i %i %i %i %i\n", shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]);
 
   return arrDims;
 }

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -159,8 +159,6 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
       arrDims[i] = 1;
   }
 
-  printf("shape: %i %i %i %i %i %i\n", shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]);
-
   return arrDims;
 }
 

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -123,6 +123,10 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
   const auto &shape = shape_;
   const int N = shape.size();
 
+  printf("%s:%i\n", __FILE__, __LINE__);
+  printf("shape_.size(): %i\n", shape_.size());
+  printf("shape_[0] = %i\n", shape_[0]);
+
   if (IsMeshTied()) {
     // Let the FaceVariable, EdgeVariable, and NodeVariable
     // classes add the +1's where needed.  They all expect
@@ -141,7 +145,16 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
       arrDims[i + 3] = shape[i];
     for (int i = N; i < 3; i++)
       arrDims[i + 3] = 1;
+  } else if (Where() == Particle) {
+    printf("%s:%i\n", __FILE__, __LINE__);
+    assert(N >= 1 && N <= 5);
+    arrDims[0] = 1; // To be updated by swarm based on pool size before allocation
+    for (int i = 0; i < N; i++)
+      arrDims[i + 1] = shape[i];
+    for (int i = N; i < 5; i++)
+      arrDims[i + 1] = 1;
   } else {
+    printf("%s:%i\n", __FILE__, __LINE__);
     // This variable is not necessarily tied to any specific
     // mesh element, so dims will be used as the actual array
     // size in each dimension
@@ -151,6 +164,8 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
     for (int i = N; i < 6; i++)
       arrDims[i] = 1;
   }
+
+  printf("arrDims: %i %i %i %i %i %i\n", arrDims[0], arrDims[1], arrDims[2], arrDims[3], arrDims[4], arrDims[5]);
 
   return arrDims;
 }

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -365,7 +365,10 @@ class Metadata {
     PARTHENON_THROW("No role flag set");
   }
 
-  const std::vector<int> &Shape() const { printf("shape0: %i\n", shape_[0]); return shape_; }
+  const std::vector<int> &Shape() const {
+    printf("shape0: %i\n", shape_[0]);
+    return shape_;
+  }
 
   /*--------------------------------------------------------*/
   // Utility functions

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -366,7 +366,6 @@ class Metadata {
   }
 
   const std::vector<int> &Shape() const {
-    printf("shape0: %i\n", shape_[0]);
     return shape_;
   }
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -365,7 +365,7 @@ class Metadata {
     PARTHENON_THROW("No role flag set");
   }
 
-  const std::vector<int> &Shape() const { return shape_; }
+  const std::vector<int> &Shape() const { printf("shape0: %i\n", shape_[0]); return shape_; }
 
   /*--------------------------------------------------------*/
   // Utility functions

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -334,7 +334,7 @@ class Metadata {
     PARTHENON_THROW("No topology flag set");
   }
 
-  bool IsMeshTied() const { return (Where() != None && Where() != Particle); }
+  bool IsMeshTied() const { return (Where() != None); }
 
   /// returns the type of the variable
   MetadataFlag Type() const {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -365,9 +365,7 @@ class Metadata {
     PARTHENON_THROW("No role flag set");
   }
 
-  const std::vector<int> &Shape() const {
-    return shape_;
-  }
+  const std::vector<int> &Shape() const { return shape_; }
 
   /*--------------------------------------------------------*/
   // Utility functions

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -49,6 +49,8 @@
   PARTHENON_INTERNAL_FOR_FLAG(Edge)                                                      \
   /** node variable */                                                                   \
   PARTHENON_INTERNAL_FOR_FLAG(Node)                                                      \
+  /** particle variable */                                                               \
+  PARTHENON_INTERNAL_FOR_FLAG(Particle)                                                  \
   /************************************************/                                     \
   /** ROLE: Exactly one must be specified (default is Provides) */                       \
   /** Private to a package */                                                            \
@@ -325,6 +327,8 @@ class Metadata {
       return Edge;
     } else if (IsSet(Node)) {
       return Node;
+    } else if (IsSet(Particle)) {
+      return Particle;
     } else if (IsSet(None)) {
       return None;
     }
@@ -332,7 +336,7 @@ class Metadata {
     PARTHENON_THROW("No topology flag set");
   }
 
-  bool IsMeshTied() const { return Where() != None; }
+  bool IsMeshTied() const { return (Where() != None && Where() != Particle); }
 
   /// returns the type of the variable
   MetadataFlag Type() const {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -327,8 +327,6 @@ class Metadata {
       return Edge;
     } else if (IsSet(Node)) {
       return Node;
-    } else if (IsSet(Particle)) {
-      return Particle;
     } else if (IsSet(None)) {
       return None;
     }

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -226,13 +226,17 @@ class SwarmProvider : public VariableProvider {
 
 bool StateDescriptor::AddSwarmValue(const std::string &value_name,
                                     const std::string &swarm_name, const Metadata &m) {
+  // Swarm variables are always Metadata::Particle
+  Metadata newm(m);
+  newm.Set(Metadata::Particle);
+
   if (swarmMetadataMap_.count(swarm_name) == 0) {
     throw std::invalid_argument("Swarm " + swarm_name + " does not exist!");
   }
   if (swarmValueMetadataMap_[swarm_name].count(value_name) > 0) {
     throw std::invalid_argument("Swarm value " + value_name + " already exists!");
   }
-  swarmValueMetadataMap_[swarm_name][value_name] = m;
+  swarmValueMetadataMap_[swarm_name][value_name] = newm;
 
   return true;
 }

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -448,14 +448,18 @@ void Swarm::Defrag() {
         if (from_to_indices(n) >= 0) {
           for (int i = 0; i < real_vars_size; i++) {
             for (int j = 0; j < rpack_indices_shapes(1, i); j++) {
-              vreal(rpack_indices_shapes(0, i), j, from_to_indices(n)) =
-                  vreal(rpack_indices_shapes(0, i), j, n);
+              for (int k = 0; k < rpack_indices_shapes(2, i); k++) {
+                vreal(rpack_indices_shapes(0, i), k, j, from_to_indices(n)) =
+                    vreal(rpack_indices_shapes(0, i), k, j, n);
+              }
             }
           }
           for (int i = 0; i < int_vars_size; i++) {
             for (int j = 0; j < ipack_indices_shapes(1, i); j++) {
-              vint(ipack_indices_shapes(0, i), j, from_to_indices(n)) =
-                  vint(ipack_indices_shapes(0, i), j, n);
+              for (int k = 0; k < ipack_indices_shapes(2, i); j++) {
+                vint(ipack_indices_shapes(0, i), k, j, from_to_indices(n)) =
+                    vint(ipack_indices_shapes(0, i), k, j, n);
+              }
             }
           }
         }
@@ -981,16 +985,20 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
             swarm_d.MarkParticleForRemoval(sidx);
             for (int i = 0; i < real_vars_size; i++) {
               for (int j = 0; j < rpack_indices_shapes(1, i); j++) {
-                bdvar.send[bufid](buffer_index) =
-                    vreal(rpack_indices_shapes(0, i), j, sidx);
-                buffer_index++;
+                for (int k = 0; k < rpack_indices_shapes(2, i); k++) {
+                  bdvar.send[bufid](buffer_index) =
+                      vreal(rpack_indices_shapes(0, i), k, j, sidx);
+                  buffer_index++;
+                }
               }
             }
             for (int i = 0; i < int_vars_size; i++) {
               for (int j = 0; j < ipack_indices_shapes(1, i); j++) {
-                bdvar.send[bufid](buffer_index) =
-                    static_cast<Real>(vint(ipack_indices_shapes(0, i), j, sidx));
-                buffer_index++;
+                for (int k = 0; k < ipack_indices_shapes(2, i); k++) {
+                  bdvar.send[bufid](buffer_index) =
+                      static_cast<Real>(vint(ipack_indices_shapes(0, i), k, j, sidx));
+                  buffer_index++;
+                }
               }
             }
           }
@@ -1125,15 +1133,19 @@ void Swarm::UnloadBuffers_() {
           const int nbid = neighbor_buffer_index(nid);
           for (int i = 0; i < real_vars_size; i++) {
             for (int j = 0; j < rpack_indices_shapes(1, i); j++) {
-              vreal(rpack_indices_shapes(0, i), j, sid) = bdvar.recv[nbid](bid);
-              bid++;
+              for (int k = 0; k < rpack_indices_shapes(2, i); k++) {
+                vreal(rpack_indices_shapes(0, i), k, j, sid) = bdvar.recv[nbid](bid);
+                bid++;
+              }
             }
           }
           for (int i = 0; i < int_vars_size; i++) {
             for (int j = 0; j < ipack_indices_shapes(1, i); j++) {
-              vint(ipack_indices_shapes(0, i), j, sid) =
-                  static_cast<int>(bdvar.recv[nbid](bid));
-              bid++;
+              for (int k = 0; k < ipack_indices_shapes(1, i); k++) {
+                vint(ipack_indices_shapes(0, i), k, j, sid) =
+                    static_cast<int>(bdvar.recv[nbid](bid));
+                bid++;
+              }
             }
           }
         });

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -421,11 +421,12 @@ void Swarm::Defrag() {
 
   from_to_indices.DeepCopy(from_to_indices_h);
 
+  auto &mask = mask_;
   pmb->par_for(
       "Swarm::DefragMask", 0, max_active_index_, KOKKOS_LAMBDA(const int n) {
         if (from_to_indices(n) >= 0) {
-          mask_(from_to_indices(n)) = mask_(n);
-          mask_(n) = false;
+          mask(from_to_indices(n)) = mask(n);
+          mask(n) = false;
         }
       });
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -279,22 +279,14 @@ void Swarm::setPoolMax(const int nmax_pool) {
   auto &realMap_ = std::get<getType<Real>()>(Maps_);
   auto &realVector_ = std::get<getType<Real>()>(Vectors_);
 
-  for (int n = 0; n < intVector_.size(); n++) {
-    auto &data = intVector_[n]->data;
-    std::array<int, 6> dim;
-    for (int i = 0; i < 6; i++) {
-      dim[i] = data.GetDim(6 - i);
-    }
-    data.Resize(dim[0], dim[1], dim[2], dim[3], dim[4], nmax_pool);
+  for (auto &d : intVector_) {
+    d->data.Resize(d->data.GetDim(6), d->data.GetDim(5), d->data.GetDim(4),
+                   d->data.GetDim(3), d->data.GetDim(2), nmax_pool);
   }
 
-  for (int n = 0; n < realVector_.size(); n++) {
-    auto &data = realVector_[n]->data;
-    std::array<int, 6> dim;
-    for (int i = 0; i < 6; i++) {
-      dim[i] = data.GetDim(6 - i);
-    }
-    data.Resize(dim[0], dim[1], dim[2], dim[3], dim[4], nmax_pool);
+  for (auto &d : realVector_) {
+    d->data.Resize(d->data.GetDim(6), d->data.GetDim(5), d->data.GetDim(4),
+                   d->data.GetDim(3), d->data.GetDim(2), nmax_pool);
   }
 
   nmax_pool_ = nmax_pool;
@@ -436,8 +428,8 @@ void Swarm::Defrag() {
   PackIndexMap int_imap;
   ParArrayND<int> rpack_indices_shapes;
   ParArrayND<int> ipack_indices_shapes;
-  auto vreal = PackAllVariables<Real>(real_imap, rpack_indices_shapes);
-  auto vint = PackAllVariables<int>(int_imap, ipack_indices_shapes);
+  auto vreal = PackAllVariables_<Real>(real_imap, rpack_indices_shapes);
+  auto vint = PackAllVariables_<int>(int_imap, ipack_indices_shapes);
   int real_vars_size = realVector_.size();
   int int_vars_size = intVector_.size();
   auto real_map = real_imap.Map();
@@ -891,7 +883,6 @@ void Swarm::SetupPersistentMPI() {
 int Swarm::CountParticlesToSend_() {
   auto blockIndex_h = blockIndex_.GetHostMirrorAndCopy();
   auto mask_h = Kokkos::create_mirror_view_and_copy(HostMemSpace(), mask_);
-  // auto mask_h = mask_.data.GetHostMirrorAndCopy();
   auto swarm_d = GetDeviceContext();
   auto pmb = GetBlockPointer();
   const int nbmax = vbswarm->bd_var_.nbmax;
@@ -965,10 +956,13 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
   PackIndexMap int_imap;
   ParArrayND<int> rpack_indices_shapes;
   ParArrayND<int> ipack_indices_shapes;
-  auto vreal = PackAllVariables<Real>(real_imap, rpack_indices_shapes);
-  auto vint = PackAllVariables<int>(int_imap, ipack_indices_shapes);
+  auto vreal = PackAllVariables_<Real>(real_imap, rpack_indices_shapes);
+  auto vint = PackAllVariables_<int>(int_imap, ipack_indices_shapes);
   int real_vars_size = realVector_.size();
   int int_vars_size = intVector_.size();
+
+  // Pack index:
+  // [variable start] [dim2] [dim1] [swarm idx]
 
   auto &bdvar = vbswarm->bd_var_;
   auto num_particles_to_send = num_particles_to_send_;
@@ -1116,8 +1110,8 @@ void Swarm::UnloadBuffers_() {
     PackIndexMap int_imap;
     ParArrayND<int> rpack_indices_shapes;
     ParArrayND<int> ipack_indices_shapes;
-    auto vreal = PackAllVariables<Real>(real_imap, rpack_indices_shapes);
-    auto vint = PackAllVariables<int>(int_imap, ipack_indices_shapes);
+    auto vreal = PackAllVariables_<Real>(real_imap, rpack_indices_shapes);
+    auto vint = PackAllVariables_<int>(int_imap, ipack_indices_shapes);
     int real_vars_size = realVector_.size();
     int int_vars_size = intVector_.size();
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -70,9 +70,9 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
   PARTHENON_REQUIRE_THROWS(typeid(Coordinates_t) == typeid(UniformCartesian),
                            "SwarmDeviceContext only supports a uniform Cartesian mesh!");
 
-  Add("x", Metadata({Metadata::Real, Metadata::Particle}));
-  Add("y", Metadata({Metadata::Real, Metadata::Particle}));
-  Add("z", Metadata({Metadata::Real, Metadata::Particle}));
+  Add("x", Metadata({Metadata::Real}));
+  Add("y", Metadata({Metadata::Real}));
+  Add("z", Metadata({Metadata::Real}));
   num_active_ = 0;
   max_active_index_ = 0;
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -1071,8 +1071,12 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
               //buffer_index++;
             }
             for (int i = 0; i < int_vars_size; i++) {
-              bdvar.send[bufid](buffer_index) = static_cast<Real>(vint(i, sidx));
-              buffer_index++;
+              for (int j = 0; j < pack_indices_shapes(3, i); j++) {
+                bdvar.send[bufid](buffer_index) = static_cast<Real>(vint(pack_indices_shapes(2, i), j, sidx));
+                buffer_index++;
+              }
+              //bdvar.send[bufid](buffer_index) = static_cast<Real>(vint(i, sidx));
+              //buffer_index++;
             }
           }
         }

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -66,16 +66,16 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
     : label_(label), m_(metadata), nmax_pool_(nmax_pool_in),
       mask_("mask", nmax_pool_),
       marked_for_removal_("mfr", nmax_pool_),
-      neighbor_send_index_("nsi", nmax_pool_, Metadata({Metadata::Integer})),
+      neighbor_send_index_("nsi", nmax_pool_, Metadata({Metadata::Integer, Metadata::Particle})),
       blockIndex_("blockIndex_", nmax_pool_),
       neighborIndices_("neighborIndices_", 4, 4, 4),
       cellSorted_("cellSorted_", nmax_pool_), mpiStatus(true) {
   PARTHENON_REQUIRE_THROWS(typeid(Coordinates_t) == typeid(UniformCartesian),
                            "SwarmDeviceContext only supports a uniform Cartesian mesh!");
 
-  Add("x", Metadata({Metadata::Real}));
-  Add("y", Metadata({Metadata::Real}));
-  Add("z", Metadata({Metadata::Real}));
+  Add("x", Metadata({Metadata::Real, Metadata::Particle}));
+  Add("y", Metadata({Metadata::Real, Metadata::Particle}));
+  Add("z", Metadata({Metadata::Real, Metadata::Particle}));
   num_active_ = 0;
   max_active_index_ = 0;
 
@@ -193,9 +193,9 @@ void Swarm::Add(const std::string &label, const Metadata &metadata) {
   }
 
   if (metadata.Type() == Metadata::Integer) {
-    Add_<int>(label);
+    Add_<int>(label, metadata);
   } else if (metadata.Type() == Metadata::Real) {
-    Add_<Real>(label);
+    Add_<Real>(label, metadata);
   } else {
     throw std::invalid_argument("swarm variable " + label +
                                 " does not have a valid type during Add()");

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -420,19 +420,19 @@ void Swarm::Defrag() {
   pmb->par_for(
       "Swarm::DefragVariables", 0, max_active_index_, KOKKOS_LAMBDA(const int n) {
         if (from_to_indices(n) >= 0) {
-          for (int i = 0; i < real_vars_size; i++) {
-            for (int j = 0; j < rpack_indices_shapes(1, i); j++) {
-              for (int k = 0; k < rpack_indices_shapes(2, i); k++) {
-                vreal(rpack_indices_shapes(0, i), k, j, from_to_indices(n)) =
-                    vreal(rpack_indices_shapes(0, i), k, j, n);
+          for (int vidx = 0; vidx < real_vars_size; vidx++) {
+            for (int l = 0; l < rpack_indices_shapes(2, vidx); l++) {
+              for (int m = 0; m < rpack_indices_shapes(1, vidx); m++) {
+                vreal(rpack_indices_shapes(0, vidx), l, m, from_to_indices(n)) =
+                    vreal(rpack_indices_shapes(0, vidx), l, m, n);
               }
             }
           }
-          for (int i = 0; i < int_vars_size; i++) {
-            for (int j = 0; j < ipack_indices_shapes(1, i); j++) {
-              for (int k = 0; k < ipack_indices_shapes(2, i); k++) {
-                vint(ipack_indices_shapes(0, i), k, j, from_to_indices(n)) =
-                    vint(ipack_indices_shapes(0, i), k, j, n);
+          for (int vidx = 0; vidx < int_vars_size; vidx++) {
+            for (int l = 0; l < ipack_indices_shapes(2, vidx); l++) {
+              for (int m = 0; m < ipack_indices_shapes(1, vidx); m++) {
+                vint(ipack_indices_shapes(0, vidx), l, m, from_to_indices(n)) =
+                    vint(ipack_indices_shapes(0, vidx), l, m, n);
               }
             }
           }

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -510,7 +510,8 @@ void Swarm::SortParticlesByCell() {
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
         int cell_idx_1d = i + nx1 * (j + nx2 * k);
         // Find starting index, first by guessing
-        int start_index = static_cast<int>((cell_idx_1d * float(num_active) / ncells));
+        int start_index =
+            static_cast<int>((cell_idx_1d * static_cast<Real>(num_active) / ncells));
         int n = 0;
         while (true) {
           n++;

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -456,7 +456,7 @@ void Swarm::Defrag() {
           }
           for (int i = 0; i < int_vars_size; i++) {
             for (int j = 0; j < ipack_indices_shapes(1, i); j++) {
-              for (int k = 0; k < ipack_indices_shapes(2, i); j++) {
+              for (int k = 0; k < ipack_indices_shapes(2, i); k++) {
                 vint(ipack_indices_shapes(0, i), k, j, from_to_indices(n)) =
                     vint(ipack_indices_shapes(0, i), k, j, n);
               }

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -598,7 +598,7 @@ void Swarm::SetNeighborIndices1D_() {
   for (int k = 0; k < 4; k++) {
     for (int j = 0; j < 4; j++) {
       for (int i = 0; i < 4; i++) {
-        neighborIndices_h(k, j, i) = 0;
+        neighborIndices_h(k, j, i) = no_block_;
       }
     }
   }
@@ -647,7 +647,7 @@ void Swarm::SetNeighborIndices2D_() {
   for (int k = 0; k < 4; k++) {
     for (int j = 0; j < 4; j++) {
       for (int i = 0; i < 4; i++) {
-        neighborIndices_h(k, j, i) = 0;
+        neighborIndices_h(k, j, i) = no_block_;
       }
     }
   }
@@ -715,7 +715,7 @@ void Swarm::SetNeighborIndices3D_() {
   for (int k = 0; k < 4; k++) {
     for (int j = 0; j < 4; j++) {
       for (int i = 0; i < 4; i++) {
-        neighborIndices_h(k, j, i) = 0;
+        neighborIndices_h(k, j, i) = no_block_;
       }
     }
   }
@@ -879,13 +879,15 @@ void Swarm::SetupPersistentMPI() {
   neighbor_received_particles_.resize(nbmax);
 
   // Build device array mapping neighbor index to neighbor bufid
-  ParArrayND<int> neighbor_buffer_index("Neighbor buffer index", pmb->pbval->nneighbor);
-  auto neighbor_buffer_index_h = neighbor_buffer_index.GetHostMirror();
-  for (int n = 0; n < pmb->pbval->nneighbor; n++) {
-    neighbor_buffer_index_h(n) = pmb->pbval->neighbor[n].bufid;
+  if (pmb->pbval->nneighbor > 0) {
+    ParArrayND<int> neighbor_buffer_index("Neighbor buffer index", pmb->pbval->nneighbor);
+    auto neighbor_buffer_index_h = neighbor_buffer_index.GetHostMirror();
+    for (int n = 0; n < pmb->pbval->nneighbor; n++) {
+      neighbor_buffer_index_h(n) = pmb->pbval->neighbor[n].bufid;
+    }
+    neighbor_buffer_index.DeepCopy(neighbor_buffer_index_h);
+    neighbor_buffer_index_ = neighbor_buffer_index;
   }
-  neighbor_buffer_index.DeepCopy(neighbor_buffer_index_h);
-  neighbor_buffer_index_ = neighbor_buffer_index;
 }
 
 int Swarm::CountParticlesToSend_() {

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -519,12 +519,9 @@ void Swarm::SortParticlesByCell() {
   pmb->par_for(
       "Update per-cell arrays", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
       KOKKOS_LAMBDA(const int k, const int j, const int i) {
-        printf("k j i = %i %i %i nx1 = %i nx2 = %i\n", k, j, i, nx1, nx2);
         int cell_idx_1d = i + nx1 * (j + nx2 * k);
         // Find starting index, first by guessing
         int start_index = static_cast<int>((cell_idx_1d * float(num_active) / ncells));
-        printf("start_index: %i cell_idx_1d: %i num_active: %i ncells: %i\n",
-          start_index, cell_idx_1d, num_active, ncells);
         int n = 0;
         while (true) {
           n++;
@@ -544,17 +541,13 @@ void Swarm::SortParticlesByCell() {
               continue;
             }
           }
-          printf("[%i] start_index = %i cell_idx_1d = %i\n", __LINE__, start_index, cell_idx_1d);
-          printf("cellSorted(%i).cell_idx_1d_ = %i\n", start_index, cellSorted(start_index).cell_idx_1d_);
           if (cellSorted(start_index).cell_idx_1d_ >= cell_idx_1d) {
-          printf("[%i] start_index = %i cell_idx_1d = %i\n", __LINE__, start_index, cell_idx_1d);
             start_index--;
             if (start_index < 0) {
               start_index = -1;
               break;
             }
             if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
-          printf("[%i] start_index = %i cell_idx_1d = %i\n", __LINE__, start_index, cell_idx_1d);
               start_index = -1;
               break;
             }
@@ -562,8 +555,7 @@ void Swarm::SortParticlesByCell() {
           }
           if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
             start_index++;
-            if (start_index > max_active_index)
-            {
+            if (start_index > max_active_index) {
               start_index = -1;
               break;
             }
@@ -1034,7 +1026,8 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
                 // bdvar.send[bufid](buffer_index) = vreal(real_pack_indices(i), j, sidx);
                 bdvar.send[bufid](buffer_index) =
                     vreal(pack_indices_shapes(0, i), j, sidx);
-                printf("[%i %i] = %e\n", i, j, bdvar.send[bufid](buffer_index));
+                printf("[%i %i] = %e = vreal(%i %i %i)\n", i, j, bdvar.send[bufid](buffer_index),
+                  pack_indices_shapes(0, i), j, sidx);
                 buffer_index++;
               }
               // bdvar.send[bufid](buffer_index) = vreal(i, sidx);
@@ -1245,6 +1238,8 @@ void Swarm::UnloadBuffers_() {
               //bdvar.send[bufid](buffer_index) =
               //    static_cast<Real>(vint(pack_indices_shapes(2, i), j, sidx));
               vreal(pack_indices_shapes(0, i), j, sid) = bdvar.recv[nbid](bid);
+              printf("UNPACK [%i %i] = %e = vreal(%i %i %i)\n", i, j, bdvar.recv[nbid](bid),
+                pack_indices_shapes(0,i), j, sid);
               bid++;
             }
           }

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -268,19 +268,6 @@ void Swarm::setPoolMax(const int nmax_pool) {
     free_indices_.push_back(n + n_new_begin);
   }
 
-  // Resize and copy data
-  /*mask_.Get().Resize(nmax_pool);
-  auto mask_data = mask_.Get();
-  pmb->par_for(
-      "setPoolMax_mask", nmax_pool_, nmax_pool - 1,
-      KOKKOS_LAMBDA(const int n) { mask_data(n) = 0; });
-
-  marked_for_removal_.Get().Resize(nmax_pool);
-  auto marked_for_removal_data = marked_for_removal_.Get();
-  pmb->par_for(
-      "setPoolMax_marked_for_removal", nmax_pool_, nmax_pool - 1,
-      KOKKOS_LAMBDA(const int n) { marked_for_removal_data(n) = false; });*/
-
   Kokkos::resize(mask_, nmax_pool);
   Kokkos::resize(marked_for_removal_, nmax_pool);
   // TODO(BRR) Does Kokkos::resize already set these values to false?
@@ -302,32 +289,22 @@ void Swarm::setPoolMax(const int nmax_pool) {
   auto &realMap_ = std::get<getType<Real>()>(Maps_);
   auto &realVector_ = std::get<getType<Real>()>(Vectors_);
 
-  // TODO(BRR) Use ParticleVariable packs to reduce kernel launches
   for (int n = 0; n < intVector_.size(); n++) {
-    auto oldvar = intVector_[n];
-    auto newvar = std::make_shared<ParticleVariable<int>>(oldvar->label(), nmax_pool,
-                                                          oldvar->metadata());
-    auto oldvar_data = oldvar->data;
-    auto newvar_data = newvar->data;
-    pmb->par_for(
-        "setPoolMax_int", 0, nmax_pool_ - 1,
-        KOKKOS_LAMBDA(const int m) { newvar_data(m) = oldvar_data(m); });
-
-    intVector_[n] = newvar;
-    intMap_[oldvar->label()] = newvar;
+    auto &data = intVector_[n]->data;
+    std::array<int, 6> dim;
+    for (int i = 0; i < 6; i++) {
+      dim[i] = data.GetDim(6 - i);
+    }
+    data.Resize(dim[0], dim[1], dim[2], dim[3], dim[4], nmax_pool);
   }
 
   for (int n = 0; n < realVector_.size(); n++) {
-    auto oldvar = realVector_[n];
-    auto newvar = std::make_shared<ParticleVariable<Real>>(oldvar->label(), nmax_pool,
-                                                           oldvar->metadata());
-    auto oldvar_data = oldvar->data;
-    auto newvar_data = newvar->data;
-    pmb->par_for(
-        "setPoolMax_real", 0, nmax_pool_ - 1,
-        KOKKOS_LAMBDA(const int m) { newvar_data(m) = oldvar_data(m); });
-    realVector_[n] = newvar;
-    realMap_[oldvar->label()] = newvar;
+    auto &data = realVector_[n]->data;
+    std::array<int, 6> dim;
+    for (int i = 0; i < 6; i++) {
+      dim[i] = data.GetDim(6 - i);
+    }
+    data.Resize(dim[0], dim[1], dim[2], dim[3], dim[4], nmax_pool);
   }
 
   nmax_pool_ = nmax_pool;
@@ -343,19 +320,15 @@ ParArray1D<bool> Swarm::AddEmptyParticles(const int num_to_add,
   while (free_indices_.size() < num_to_add) {
     increasePoolMax();
   }
-  //auto host_cv = Kokkos::create_mirror_view(Kokkos::HostSpace(), cv_out);
 
   ParArray1D<bool> new_mask("Newly created particles", nmax_pool_);
   auto new_mask_h = Kokkos::create_mirror_view(HostMemSpace(), new_mask);
-  //auto new_mask_h = new_mask.GetHostMirror();
   for (int n = 0; n < nmax_pool_; n++) {
     new_mask_h(n) = false;
   }
 
   auto mask_h = Kokkos::create_mirror_view_and_copy(HostMemSpace(), mask_);
 
-  //auto mask_h = mask_.data.GetHostMirror();
-  //mask_h.DeepCopy(mask_.data);
   auto blockIndex_h = blockIndex_.GetHostMirrorAndCopy();
 
   auto free_index = free_indices_.begin();
@@ -380,8 +353,6 @@ ParArray1D<bool> Swarm::AddEmptyParticles(const int num_to_add,
 
   Kokkos::deep_copy(new_mask, new_mask_h);
   Kokkos::deep_copy(mask_, mask_h);
-  //new_mask.DeepCopy(new_mask_h);
-  //mask_.data.DeepCopy(mask_h);
   blockIndex_.DeepCopy(blockIndex_h);
 
   return new_mask;
@@ -393,9 +364,6 @@ ParArray1D<bool> Swarm::AddEmptyParticles(const int num_to_add,
 void Swarm::RemoveMarkedParticles() {
   auto mask_h = Kokkos::create_mirror_view_and_copy(HostMemSpace(), mask_);
   auto marked_for_removal_h = Kokkos::create_mirror_view_and_copy(HostMemSpace(), marked_for_removal_);
-  //auto mask_h = mask_.data.GetHostMirrorAndCopy();
-  //auto marked_for_removal_h = marked_for_removal_.data.GetHostMirror();
-  //marked_for_removal_h.DeepCopy(marked_for_removal_.data);
 
   // loop backwards to keep free_indices_ updated correctly
   for (int n = max_active_index_; n >= 0; n--) {
@@ -414,8 +382,6 @@ void Swarm::RemoveMarkedParticles() {
 
   Kokkos::deep_copy(mask_, mask_h);
   Kokkos::deep_copy(marked_for_removal_, marked_for_removal_h);
-  //mask_.data.DeepCopy(mask_h);
-  //marked_for_removal_.data.DeepCopy(marked_for_removal_h);
 }
 
 void Swarm::Defrag() {
@@ -993,6 +959,31 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
   int real_vars_size = realVector_.size();
   int int_vars_size = intVector_.size();
 
+  auto shape = rmap.GetShape("t");
+  auto has = rmap.Has("t");
+  auto first = rmap["t"].first;
+  auto second = rmap["t"].second;
+  printf("has: %i\n", static_cast<int>(has));
+  printf("first: %i second: %i\n", first, second);
+  printf("shape.size: %i\n", shape.size());
+  has = rmap.Has("v");
+  first = rmap["v"].first;
+  second = rmap["v"].second;
+  shape = rmap.GetShape("v");
+  printf("has: %i\n", static_cast<int>(has));
+  printf("first: %i second: %i\n", first, second);
+  printf("shape.size: %i\n", shape.size());
+  printf("shape[0] = %i\n", shape[0]);
+  //printf("%i %i %i %i %i %i\n", shape[0], shape[1], shape[2], shape[3], shape[4], shape[5]);
+  shape = rmap.GetShape("t");
+  printf("shape.size: %i\n", shape.size());
+  auto fi = rmap.GetFlatIdx("v");
+
+  auto &v = Get<Real>("v").Get();
+  printf("v(*, 0) = %e %e %e\n", v(0,0), v(1,0), v(2,0));
+  printf("vreal(v.first, *) = %e %e %e\n", vreal(first, 0), vreal(first, 1), vreal(first,2));
+  printf("vreal(*, v.first, 0) = %e %e %e\n", vreal(first, 0, 0), vreal(first, 1, 0), vreal(first, 2, 0));
+
   auto &bdvar = vbswarm->bd_var_;
   auto num_particles_to_send = num_particles_to_send_;
   auto particle_indices_to_send = particle_indices_to_send_;
@@ -1008,6 +999,8 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
             swarm_d.MarkParticleForRemoval(sidx);
             for (int i = 0; i < real_vars_size; i++) {
               bdvar.send[bufid](buffer_index) = vreal(i, sidx);
+              printf("val: %e\n", vreal(i, sidx));
+              //printf("val+1: %e\n", vreal(i, sidx+1));
               buffer_index++;
             }
             for (int i = 0; i < int_vars_size; i++) {
@@ -1017,6 +1010,7 @@ void Swarm::LoadBuffers_(const int max_indices_size) {
           }
         }
       });
+  exit(-1);
 
   RemoveMarkedParticles();
 }

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -192,7 +192,8 @@ class Swarm {
   bool FinalizeCommunicationIterative();
 
   template <class T>
-  SwarmVariablePack<T> PackAllVariables(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes);
+  SwarmVariablePack<T> PackAllVariables(PackIndexMap &vmap,
+                                        ParArrayND<int> &pack_indices_shapes);
 
   template <class T>
   SwarmVariablePack<T> PackVariables(const std::vector<std::string> &name,
@@ -294,7 +295,8 @@ inline SwarmVariablePack<T> Swarm::PackVariables(const std::vector<std::string> 
 }
 
 template <class T>
-inline SwarmVariablePack<T> Swarm::PackAllVariables(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes) {
+inline SwarmVariablePack<T>
+Swarm::PackAllVariables(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes) {
   std::vector<std::string> names;
   names.reserve(std::get<getType<T>()>(Vectors_).size());
   for (const auto &v : std::get<getType<T>()>(Vectors_)) {

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -307,24 +307,26 @@ Swarm::PackAllVariables(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes
   auto map = vmap.Map();
 
   // Get shape of packed variables
-  pack_indices_shapes = ParArrayND<int>("Pack indices and shapes", 6, names.size());
-  auto pack_indices_shapes_h = pack_indices_shapes.GetHostMirrorAndCopy();
-  int n = 0;
-  for (auto &m : map) {
-    pack_indices_shapes_h(0, n) = m.second.first;
-    for (int idx = 1; idx < 6; idx++) {
-      auto shape = vmap.GetShape(m.first);
-      PARTHENON_REQUIRE(shape.size() <= 2,
-                        "Flat packs only support 2 indices + swarm index!");
-      if (shape.size() >= idx) {
-        pack_indices_shapes_h(idx, n) = shape[idx - 1];
-      } else {
-        pack_indices_shapes_h(idx, n) = 1;
+  if (names.size() > 0) {
+    pack_indices_shapes = ParArrayND<int>("Pack indices and shapes", 6, names.size());
+    auto pack_indices_shapes_h = pack_indices_shapes.GetHostMirrorAndCopy();
+    int n = 0;
+    for (auto &m : map) {
+      pack_indices_shapes_h(0, n) = m.second.first;
+      for (int idx = 1; idx < 6; idx++) {
+        auto shape = vmap.GetShape(m.first);
+        PARTHENON_REQUIRE(shape.size() <= 2,
+                          "Flat packs only support 2 indices + swarm index!");
+        if (shape.size() >= idx) {
+          pack_indices_shapes_h(idx, n) = shape[idx - 1];
+        } else {
+          pack_indices_shapes_h(idx, n) = 1;
+        }
       }
+      n++;
     }
-    n++;
+    pack_indices_shapes.DeepCopy(pack_indices_shapes_h);
   }
-  pack_indices_shapes.DeepCopy(pack_indices_shapes_h);
 
   return ret;
 }

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -278,7 +278,6 @@ class Swarm {
 template <class T>
 inline vpack_types::SwarmVarList<T>
 Swarm::MakeVarList_(const std::vector<std::string> &names) {
-  int size = 0;
   vpack_types::SwarmVarList<T> vars;
   auto variables = std::get<getType<T>()>(Maps_);
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -248,6 +248,7 @@ class Swarm {
   ParArrayND<int> neighborIndices_; // Indexing of vbvar's neighbor array. -1 for same.
                                     // k,j indices unused in 3D&2D, 2D, respectively
 
+  constexpr static int no_block_ = -2;
   constexpr static int this_block_ = -1;
   constexpr static int unset_index_ = -1;
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -154,7 +154,7 @@ class Swarm {
   void RemoveMarkedParticles();
 
   /// Open up memory for new empty particles, return a mask to these particles
-  ParArrayND<bool> AddEmptyParticles(const int num_to_add, ParArrayND<int> &new_indices);
+  ParArray1D<bool> AddEmptyParticles(const int num_to_add, ParArrayND<int> &new_indices);
 
   /// Defragment the list by moving active particles so they are contiguous in
   /// memory
@@ -234,8 +234,10 @@ class Swarm {
   std::tuple<MapToParticle<int>, MapToParticle<Real>> Maps_;
 
   std::list<int> free_indices_;
-  ParticleVariable<bool> mask_;
-  ParticleVariable<bool> marked_for_removal_;
+  ParArray1D<bool> mask_;
+  ParArray1D<bool> marked_for_removal_;
+  //ParticleVariable<bool> mask_;
+  //ParticleVariable<bool> marked_for_removal_;
   ParticleVariable<int> neighbor_send_index_; // -1 means no send
   ParArrayND<int> neighborIndices_; // Indexing of vbvar's neighbor array. -1 for same.
                                     // k,j indices unused in 3D&2D, 2D, respectively

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -243,9 +243,6 @@ class Swarm {
   std::list<int> free_indices_;
   ParArray1D<bool> mask_;
   ParArray1D<bool> marked_for_removal_;
-  //ParticleVariable<bool> mask_;
-  //ParticleVariable<bool> marked_for_removal_;
-  ParticleVariable<int> neighbor_send_index_; // -1 means no send
   ParArrayND<int> blockIndex_; // Neighbor index for each particle. -1 for current block.
   ParArrayND<int> neighborIndices_; // Indexing of vbvar's neighbor array. -1 for same.
                                     // k,j indices unused in 3D&2D, 2D, respectively

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -213,6 +213,8 @@ class Swarm {
  private:
   template <class T>
   vpack_types::SwarmVarList<T> MakeVarListAll_();
+  template <class T>
+  vpack_types::SwarmVarList<T> MakeVarList_(const std::vector<std::string> &names);
 
   template <class BOutflow, class BPeriodic, int iFace>
   void AllocateBoundariesImpl_(MeshBlock *pmb);
@@ -275,6 +277,27 @@ class Swarm {
 };
 
 template <class T>
+inline vpack_types::SwarmVarList<T> Swarm::MakeVarList_(const std::vector<std::string> &names) {
+  int size = 0;
+  vpack_types::SwarmVarList<T> vars;
+  //auto variables = std::get<getType<T>()>(Vectors_);
+  auto variables = std::get<getType<T>()>(Maps_);
+
+  for (auto name : names) {
+     vars.push_front(variables[name]);
+     //size++;
+  }
+  return vars;
+
+ /* for (auto it = variables.rbegin(); it != variables.rend(); ++it) {
+    auto v = *it;
+    vars.push_front(v);
+    size++;
+  }
+  return vars;*/
+}
+
+template <class T>
 inline vpack_types::SwarmVarList<T> Swarm::MakeVarListAll_() {
   int size = 0;
   vpack_types::SwarmVarList<T> vars;
@@ -290,7 +313,7 @@ inline vpack_types::SwarmVarList<T> Swarm::MakeVarListAll_() {
 template <class T>
 inline SwarmVariablePack<T> Swarm::PackVariables(const std::vector<std::string> &names,
                                                  PackIndexMap &vmap) {
-  vpack_types::SwarmVarList<T> vars = MakeVarListAll_<T>();
+  vpack_types::SwarmVarList<T> vars = MakeVarList_<T>(names);
   auto pack = MakeSwarmPack<T>(vars, &vmap);
   SwarmPackIndxPair<T> value;
   value.pack = pack;

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -192,10 +192,6 @@ class Swarm {
   bool FinalizeCommunicationIterative();
 
   template <class T>
-  SwarmVariablePack<T> PackAllVariables(PackIndexMap &vmap,
-                                        ParArrayND<int> &pack_indices_shapes);
-
-  template <class T>
   SwarmVariablePack<T> PackVariables(const std::vector<std::string> &name,
                                      PackIndexMap &vmap);
 
@@ -226,6 +222,10 @@ class Swarm {
   void CountReceivedParticles_();
   void UpdateNeighborBufferReceiveIndices_(ParArrayND<int> &neighbor_index,
                                            ParArrayND<int> &buffer_index);
+
+  template <class T>
+  SwarmVariablePack<T> PackAllVariables_(PackIndexMap &vmap,
+                                         ParArrayND<int> &pack_indices_shapes);
 
   int debug = 0;
   std::weak_ptr<MeshBlock> pmy_block;
@@ -296,7 +296,7 @@ inline SwarmVariablePack<T> Swarm::PackVariables(const std::vector<std::string> 
 
 template <class T>
 inline SwarmVariablePack<T>
-Swarm::PackAllVariables(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes) {
+Swarm::PackAllVariables_(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes) {
   std::vector<std::string> names;
   names.reserve(std::get<getType<T>()>(Vectors_).size());
   for (const auto &v : std::get<getType<T>()>(Vectors_)) {
@@ -306,10 +306,21 @@ Swarm::PackAllVariables(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes
   auto ret = PackVariables<T>(names, vmap);
   auto map = vmap.Map();
 
+  // Pack variables in terms of
+  // [variable_start] [dim2] [dim1] [swarm idx]
+  // for conveniently looping over all variables to fill buffers.
+  // Note that this supports up to 2D ParticleVariable data.
+  // The structure of the pack is stored in pack_indices_shapes.
+  // pack_indices_shapes(0, n) is [variable_start] for the nth variable
+  // pack_indices_shapes(1, n) is [dim1] for the nth variable
+  // pack_indices_shapes(2, n) is [dim2] for the nth variable
+  // Currently, pack_indices_shapes([3,4,5], n) = 1 i.e. these dimensions are not used in
+  // ParticleVariables.
+
   // Get shape of packed variables
   if (names.size() > 0) {
     pack_indices_shapes = ParArrayND<int>("Pack indices and shapes", 6, names.size());
-    auto pack_indices_shapes_h = pack_indices_shapes.GetHostMirrorAndCopy();
+    auto pack_indices_shapes_h = pack_indices_shapes.GetHostMirror();
     int n = 0;
     for (auto &m : map) {
       pack_indices_shapes_h(0, n) = m.second.first;

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -229,8 +229,7 @@ class Swarm {
                                            ParArrayND<int> &buffer_index);
 
   template <class T>
-  SwarmVariablePack<T> PackAllVariables_(PackIndexMap &vmap,
-                                         ParArrayND<int> &pack_indices_shapes);
+  SwarmVariablePack<T> PackAllVariables_(PackIndexMap &vmap);
 
   int debug = 0;
   std::weak_ptr<MeshBlock> pmy_block;
@@ -277,24 +276,16 @@ class Swarm {
 };
 
 template <class T>
-inline vpack_types::SwarmVarList<T> Swarm::MakeVarList_(const std::vector<std::string> &names) {
+inline vpack_types::SwarmVarList<T>
+Swarm::MakeVarList_(const std::vector<std::string> &names) {
   int size = 0;
   vpack_types::SwarmVarList<T> vars;
-  //auto variables = std::get<getType<T>()>(Vectors_);
   auto variables = std::get<getType<T>()>(Maps_);
 
   for (auto name : names) {
-     vars.push_front(variables[name]);
-     //size++;
+    vars.push_front(variables[name]);
   }
   return vars;
-
- /* for (auto it = variables.rbegin(); it != variables.rend(); ++it) {
-    auto v = *it;
-    vars.push_front(v);
-    size++;
-  }
-  return vars;*/
 }
 
 template <class T>
@@ -322,8 +313,7 @@ inline SwarmVariablePack<T> Swarm::PackVariables(const std::vector<std::string> 
 }
 
 template <class T>
-inline SwarmVariablePack<T>
-Swarm::PackAllVariables_(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shapes) {
+inline SwarmVariablePack<T> Swarm::PackAllVariables_(PackIndexMap &vmap) {
   std::vector<std::string> names;
   names.reserve(std::get<getType<T>()>(Vectors_).size());
   for (const auto &v : std::get<getType<T>()>(Vectors_)) {
@@ -331,41 +321,6 @@ Swarm::PackAllVariables_(PackIndexMap &vmap, ParArrayND<int> &pack_indices_shape
   }
 
   auto ret = PackVariables<T>(names, vmap);
-  auto map = vmap.Map();
-
-  // Pack variables in terms of
-  // [variable_start] [dim2] [dim1] [swarm idx]
-  // for conveniently looping over all variables to fill buffers.
-  // Note that this supports up to 2D ParticleVariable data.
-  // The structure of the pack is stored in pack_indices_shapes.
-  // pack_indices_shapes(0, n) is [variable_start] for the nth variable
-  // pack_indices_shapes(1, n) is [dim1] for the nth variable
-  // pack_indices_shapes(2, n) is [dim2] for the nth variable
-  // Currently, pack_indices_shapes([3,4,5], n) = 1 i.e. these dimensions are not used in
-  // ParticleVariables.
-
-  // Get shape of packed variables
-  if (names.size() > 0) {
-    pack_indices_shapes = ParArrayND<int>("Pack indices and shapes", 6, names.size());
-    auto pack_indices_shapes_h = pack_indices_shapes.GetHostMirror();
-    int n = 0;
-    for (auto &m : map) {
-      pack_indices_shapes_h(0, n) = m.second.first;
-      for (int idx = 1; idx < 6; idx++) {
-        auto shape = vmap.GetShape(m.first);
-        PARTHENON_REQUIRE(shape.size() <= 2,
-                          "Flat packs only support 2 indices + swarm index!");
-        if (shape.size() >= idx) {
-          pack_indices_shapes_h(idx, n) = shape[idx - 1];
-        } else {
-          pack_indices_shapes_h(idx, n) = 1;
-        }
-      }
-      n++;
-    }
-    pack_indices_shapes.DeepCopy(pack_indices_shapes_h);
-  }
-
   return ret;
 }
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -172,7 +172,15 @@ class Swarm {
   // This is the particle data size for indexing boundary data buffers, for which
   // integers are cast as Reals.
   int GetParticleDataSize() {
-    return std::get<0>(Vectors_).size() + std::get<1>(Vectors_).size();
+    int size = 0;
+    for (auto &v : std::get<0>(Vectors_)) {
+      size += v->NumComponents();
+    }
+    for (auto &v : std::get<1>(Vectors_)) {
+      size += v->NumComponents();
+    }
+
+    return size;
   }
 
   void Send(BoundaryCommSubset phase);

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2021-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -137,6 +137,7 @@ class SwarmDeviceContext {
   int ndim_;
   friend class Swarm;
   constexpr static int this_block_ = -1; // Mirrors definition in Swarm class
+  constexpr static int no_block_ = -2;   // Mirrors definition in Swarm class
   int my_rank_;
   Coordinates_t coords_;
 };

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -127,8 +127,8 @@ class SwarmDeviceContext {
   Real y_max_global_;
   Real z_min_global_;
   Real z_max_global_;
-  ParArrayND<bool> marked_for_removal_;
-  ParArrayND<bool> mask_;
+  ParArray1D<bool> mask_;
+  ParArray1D<bool> marked_for_removal_;
   ParArrayND<int> blockIndex_;
   ParArrayND<int> neighborIndices_; // 4x4x4 array of possible block AMR regions
   ParArray1D<SwarmKey> cellSorted_;

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -270,6 +270,17 @@ std::string EdgeVariable<T>::info() {
 }
 
 template <typename T>
+ParticleVariable<T>::ParticleVariable(const std::string &label, const int npool,
+                                      const Metadata &metadata)
+    : m_(metadata), label_(label),
+      dims_(m_.GetArrayDims(std::weak_ptr<MeshBlock>(), false)),
+      data(label_, dims_[5], dims_[4], dims_[3], dims_[2], dims_[1], npool) {
+        dims_[0] = npool;
+  printf("dims: %i %i %i %i %i %i\n", dims_[5], dims_[4], dims_[3], dims_[2], dims_[1],
+         dims_[0]);
+}
+
+template <typename T>
 std::string ParticleVariable<T>::info() const {
   std::stringstream ss;
 
@@ -286,5 +297,8 @@ std::string ParticleVariable<T>::info() const {
 template class CellVariable<Real>;
 template class FaceVariable<Real>;
 template class EdgeVariable<Real>;
+template class ParticleVariable<Real>;
+template class ParticleVariable<int>;
+template class ParticleVariable<bool>;
 
 } // namespace parthenon

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -276,8 +276,6 @@ ParticleVariable<T>::ParticleVariable(const std::string &label, const int npool,
       dims_(m_.GetArrayDims(std::weak_ptr<MeshBlock>(), false)),
       data(label_, dims_[5], dims_[4], dims_[3], dims_[2], dims_[1], npool) {
   dims_[0] = npool;
-  printf("dims: %i %i %i %i %i %i\n", dims_[5], dims_[4], dims_[3], dims_[2], dims_[1],
-         dims_[0]);
 }
 
 template <typename T>

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -275,7 +275,7 @@ ParticleVariable<T>::ParticleVariable(const std::string &label, const int npool,
     : m_(metadata), label_(label),
       dims_(m_.GetArrayDims(std::weak_ptr<MeshBlock>(), false)),
       data(label_, dims_[5], dims_[4], dims_[3], dims_[2], dims_[1], npool) {
-        dims_[0] = npool;
+  dims_[0] = npool;
   printf("dims: %i %i %i %i %i %i\n", dims_[5], dims_[4], dims_[3], dims_[2], dims_[1],
          dims_[0]);
 }

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -220,12 +220,13 @@ class FaceVariable {
   inline bool IsSparse() const { return false; }
   inline int GetSparseID() const { return InvalidSparseID; }
 
-  FaceArray<T> data;
-
  private:
-  std::array<int, 6> dims_;
-  Metadata m_;
-  std::string label_;
+   Metadata m_;
+   std::string label_;
+   std::array<int, 6> dims_;
+
+ public:
+  FaceArray<T> data;
 };
 
 ///
@@ -300,12 +301,13 @@ class ParticleVariable {
   /// return information string
   std::string info() const;
 
-  ParArrayND<T> data;
-
  private:
   Metadata m_;
   std::string label_;
   std::array<int, 6> dims_;
+
+ public:
+  ParArrayND<T> data;
 };
 
 template <typename T>

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -223,9 +223,9 @@ class FaceVariable {
   FaceArray<T> data;
 
  private:
+  std::array<int, 6> dims_;
   Metadata m_;
   std::string label_;
-  std::array<int, 6> dims_;
 };
 
 ///

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -270,8 +270,7 @@ template <typename T>
 class ParticleVariable {
  public:
   /// Initialize a particle variable
-  ParticleVariable(const std::string &label, const int npool, const Metadata &metadata)
-      : data(label, npool), npool_(npool), m_(metadata), label_(label) {}
+  ParticleVariable(const std::string &label, const int npool, const Metadata &metadata);
 
   // accessors
   KOKKOS_FORCEINLINE_FUNCTION
@@ -282,7 +281,13 @@ class ParticleVariable {
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
-  auto GetDim(const int i) const { return data.GetDim(i); }
+  auto GetDim(const int i) const {
+    PARTHENON_REQUIRE(0 < i && i <= 6, "ParArrayNDGenerics are max 6D");
+    return dims_[i-1];
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  auto NumComponents() const { return dims_[5]*dims_[4]*dims_[3]*dims_[2]*dims_[1]; }
 
   ///< retrieve metadata for variable
   inline const Metadata metadata() const { return m_; }
@@ -298,9 +303,9 @@ class ParticleVariable {
   ParArrayND<T> data;
 
  private:
-  int npool_;
   Metadata m_;
   std::string label_;
+  std::array<int, 6> dims_;
 };
 
 template <typename T>

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -220,13 +220,12 @@ class FaceVariable {
   inline bool IsSparse() const { return false; }
   inline int GetSparseID() const { return InvalidSparseID; }
 
+  FaceArray<T> data;
+
  private:
   Metadata m_;
   std::string label_;
   std::array<int, 6> dims_;
-
- public:
-  FaceArray<T> data;
 };
 
 ///
@@ -283,7 +282,7 @@ class ParticleVariable {
 
   KOKKOS_FORCEINLINE_FUNCTION
   auto GetDim(const int i) const {
-    PARTHENON_REQUIRE(0 < i && i <= 6, "ParArrayNDGenerics are max 6D");
+    PARTHENON_DEBUG_REQUIRE(0 < i && i <= 6, "ParArrayNDGenerics are max 6D");
     return dims_[i - 1];
   }
 

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -221,9 +221,9 @@ class FaceVariable {
   inline int GetSparseID() const { return InvalidSparseID; }
 
  private:
-   Metadata m_;
-   std::string label_;
-   std::array<int, 6> dims_;
+  Metadata m_;
+  std::string label_;
+  std::array<int, 6> dims_;
 
  public:
   FaceArray<T> data;
@@ -284,11 +284,13 @@ class ParticleVariable {
   KOKKOS_FORCEINLINE_FUNCTION
   auto GetDim(const int i) const {
     PARTHENON_REQUIRE(0 < i && i <= 6, "ParArrayNDGenerics are max 6D");
-    return dims_[i-1];
+    return dims_[i - 1];
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
-  auto NumComponents() const { return dims_[5]*dims_[4]*dims_[3]*dims_[2]*dims_[1]; }
+  auto NumComponents() const {
+    return dims_[5] * dims_[4] * dims_[3] * dims_[2] * dims_[1];
+  }
 
   ///< retrieve metadata for variable
   inline const Metadata metadata() const { return m_; }

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -386,9 +386,7 @@ class SwarmVariablePack {
   ParArray1D<T> &operator()(const int n) const { return v_(n); }
 
   KOKKOS_FORCEINLINE_FUNCTION
-  T &operator()(const int n, const int i) const {
-    return v_(n)(i);
-  }
+  T &operator()(const int n, const int i) const { return v_(n)(i); }
 
   KOKKOS_FORCEINLINE_FUNCTION
   int GetDim(const int i) const {
@@ -588,8 +586,7 @@ void FillVarView(const CellVariableVector<T> &vars, bool coarse,
 
 template <typename T>
 void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars,
-                      ViewOfParArrays1D<T> &cv_out,
-                 PackIndexMap *pvmap) {
+                      ViewOfParArrays1D<T> &cv_out, PackIndexMap *pvmap) {
   using vpack_types::IndexPair;
 
   auto host_cv = Kokkos::create_mirror_view(Kokkos::HostSpace(), cv_out);
@@ -602,14 +599,14 @@ void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars,
         for (int n = 0; n < v->GetDim(4); n++) {
           for (int t = 0; t < v->GetDim(3); t++) {
             for (int u = 0; u < v->GetDim(2); u++) {
-              host_cv(vindex) = v->data.Get(l,m,n,t,u);
+              host_cv(vindex) = v->data.Get(l, m, n, t, u);
               vindex++;
             }
           }
         }
       }
     }
-    //host_cv(vindex++) = v->data.Get(0);
+    // host_cv(vindex++) = v->data.Get(0);
 
     std::vector<int> shape;
     auto mshape = v->metadata().Shape();
@@ -780,7 +777,6 @@ VariablePack<T> MakePack(const VarListWithLabels<T> &var_list, bool coarse,
 template <typename T>
 SwarmVariablePack<T> MakeSwarmPack(const vpack_types::SwarmVarList<T> &vars,
                                    PackIndexMap *pvmap = nullptr) {
-  {
   // count up the size
   int vsize = 0;
   for (const auto &v : vars) {
@@ -795,8 +791,7 @@ SwarmVariablePack<T> MakeSwarmPack(const vpack_types::SwarmVarList<T> &vars,
 
   std::array<int, 2> cv_size{0, 0};
   if (vsize > 0) {
-    // get dimension from first variable, they must all be the same
-    // TODO(JL): maybe verify this?
+    // Assume all variables have the same first dimension (same swarm pool)
     const auto &var = vars.front();
     cv_size[0] = var->GetDim(1);
     cv_size[1] = vsize;
@@ -805,45 +800,6 @@ SwarmVariablePack<T> MakeSwarmPack(const vpack_types::SwarmVarList<T> &vars,
   }
 
   return SwarmVariablePack<T>(cv, cv_size);
-  }
-/*
-  // count up the size
-  int vsize = 0;
-  for (const auto &v : vars) {
-    printf("label: %s\n", v->label().c_str());
-    vsize++;
-  }
-
-  // make the outer view
-  ViewOfParArrays<T> cv("MakeSwarmPack::cv", vsize);
-  ParArray1D<int> sparse_assoc("MakeSwarmPack::sparse_assoc", vsize); // Unused
-
-  FillSwarmVarView(vars, vmap, cv);
-
-  // If no vars, return empty pack
-  if (vars.empty()) {
-    return SwarmVariablePack<T>();
-  }
-
-  std::array<int, 4> cv_size{0, 0, 0, 0};
-  if (vsize > 0) {
-    // get dimension from first variable, they must all be the same
-    // TODO(JL): maybe verify this?
-    const auto &var = vars.front();
-    for (int i = 0; i < 3; ++i) {
-      cv_size[i] = var->GetDim(i + 1);
-    }
-    cv_size[3] = vsize;
-  }
-    for (auto &var : vars) {
-  printf("dim: %i %i %i %i %i %i\n", var->GetDim(1),
-    var->GetDim(2), var->GetDim(3), var->GetDim(4), var->GetDim(5), var->GetDim(6));
-  printf("cv_size: %i %i %i %i\n", cv_size[0], cv_size[1], cv_size[2], cv_size[3]);
- }
-
-  //auto fvar = vars.front()->data;
-  //std::array<int, 2> cv_size = {fvar.GetDim(1), vsize};
-  return SwarmVariablePack<T>(cv, cv_size);*/
 }
 
 } // namespace parthenon

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -376,6 +376,10 @@ class SwarmVariablePack {
   T &operator()(const int n, const int i) const { return v_(n)(0, 0, i); }
   KOKKOS_FORCEINLINE_FUNCTION
   T &operator()(const int n, const int j, const int i) const { return v_(n)(0, j, i); }
+  KOKKOS_FORCEINLINE_FUNCTION
+  T &operator()(const int n, const int k, const int j, const int i) const {
+    return v_(n)(k, j, i);
+  }
 
  private:
   ViewOfParArrays<T> v_;

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -786,7 +786,6 @@ SwarmVariablePack<T> MakeSwarmPack(const vpack_types::SwarmVarList<T> &vars,
 
   // make the outer view
   ViewOfParArrays1D<T> cv("MakePack::cv", vsize);
-  ParArray1D<int> sparse_id("MakePack::sparse_id", vsize);
 
   std::array<int, 2> cv_size{0, 0};
   if (vsize > 0) {

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -194,9 +194,6 @@ class PackIndexMap {
 
   void insert(std::string key, vpack_types::IndexPair val,
               vpack_types::Shape shape = vpack_types::Shape()) {
-    printf("inserting %s...\n", key.c_str());
-    printf("indexpair: %i %i\n", val.first, val.second);
-    printf("shape.size: %i\n", shape.size());
     map_.insert(std::pair<std::string, vpack_types::IndexPair>(key, val));
     shape_map_.insert(std::pair<std::string, vpack_types::Shape>(key, shape));
   }
@@ -578,13 +575,7 @@ void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars, PackIndexMap *vm
   int vindex = 0;
   int sparse_start;
   std::string sparse_name;
-  // TODO(BRR) Remove the logic for sparse variables
   for (const auto v : vars) {
-    //if (vmap != nullptr) {
-    //  // TODO(BRR) add shape!
-    //  vmap->insert(sparse_name, IndexPair(sparse_start, vindex - 1));
-    //  sparse_name = "";
-    //}
     int vstart = vindex;
     // Reusing ViewOfParArrays which expects 3D slices
     host_view(vindex++) = v->data.Get(0, 0, 0);
@@ -595,7 +586,6 @@ void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars, PackIndexMap *vm
     if (v->GetDim(4) > 1) shape.push_back(v->GetDim(4));
     if (v->GetDim(5) > 1) shape.push_back(v->GetDim(5));
     if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
-    printf("this shape.size: %i\n", shape.size());
 
     if (vmap != nullptr) {
       vmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -387,7 +387,6 @@ class SwarmVariablePack {
 
   KOKKOS_FORCEINLINE_FUNCTION
   T &operator()(const int n, const int i) const {
-    printf("dims: %i %i %i %i\n", dims_[0], dims_[1], dims_[2], dims_[3]);
     return v_(n)(i);
   }
 

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -606,7 +606,6 @@ void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars,
         }
       }
     }
-    // host_cv(vindex++) = v->data.Get(0);
 
     std::vector<int> shape;
     auto mshape = v->metadata().Shape();

--- a/src/parthenon_arrays.hpp
+++ b/src/parthenon_arrays.hpp
@@ -44,6 +44,8 @@ class ParArrayNDGeneric {
   ParArrayNDGeneric() = default;
   ParArrayNDGeneric(const std::string &label, int nx6, int nx5, int nx4, int nx3, int nx2,
                     int nx1) {
+    printf("label: %s\n", label.c_str());
+    printf("ns: %i %i %i %i %i %i\n", nx6, nx5, nx4, nx3, nx2, nx1);
     assert(nx6 > 0 && nx5 > 0 && nx4 > 0 && nx3 > 0 && nx2 > 0 && nx1 > 0);
     d6d_ = Data(label, nx6, nx5, nx4, nx3, nx2, nx1);
   }

--- a/src/parthenon_arrays.hpp
+++ b/src/parthenon_arrays.hpp
@@ -44,8 +44,6 @@ class ParArrayNDGeneric {
   ParArrayNDGeneric() = default;
   ParArrayNDGeneric(const std::string &label, int nx6, int nx5, int nx4, int nx3, int nx2,
                     int nx1) {
-    printf("label: %s\n", label.c_str());
-    printf("ns: %i %i %i %i %i %i\n", nx6, nx5, nx4, nx3, nx2, nx1);
     assert(nx6 > 0 && nx5 > 0 && nx4 > 0 && nx3 > 0 && nx2 > 0 && nx1 > 0);
     d6d_ = Data(label, nx6, nx5, nx4, nx3, nx2, nx1);
   }

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -88,7 +88,7 @@ TEST_CASE("Swarm memory management", "[Swarm]") {
   std::vector<std::string> labelVector(2);
   labelVector[0] = "i";
   labelVector[1] = "j";
-  Metadata m_integer({Metadata::Integer});
+  Metadata m_integer({Metadata::Integer, Metadata::Particle});
   swarm->Add(labelVector, m_integer);
 
   ParArrayND<int> new_indices;

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

We want to allow particles to transport vector quantities as well as scalar quantities. E.g. one `ParticleVariable` `v[3]` instead of three `ParticleVariable`s `vx`, `vy`, and `vz`, as well as vectors whose size can vary at runtime.

~~In some places~~ the code supports up to 5D quantities for a `ParticleVariable`~~, but elsewhere the dimensionality is restricted (e.g. when packing/unpacking particles for MPI communication, only 2D `ParticleVariable`s are supported due to `FlatIdx` only supporting up to 3 indices currently). I included a check in the `PackAllVariables` function,~~

This PR also replaces existing `ParticleVariable<bool>`s with `ParArray1D<bool>`s. 

Fixes #657

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
