### PR TITLE
Add option for returning FlatIdx when requested variable doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 654]](https://github.com/lanl/parthenon/pull/654) Add option for returning FlatIdx when requested variable doesn't exist
 - [[PR 622]](https://github.com/lanl/parthenon/pull/622) Extend reduction framework to support more general data types. Now uses PR 623.
 - [[PR 619]](https://github.com/lanl/parthenon/pull/619) Sort particles by cell
 - [[PR 605]](https://github.com/lanl/parthenon/pull/605) Add output triggering by signaling.

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -83,8 +83,7 @@ class FlatIdx {
 
   KOKKOS_FORCEINLINE_FUNCTION
   bool IsValid() const {
-    if (offset_ >= 0) return true;
-    return false;
+    return (offset_ >= 0);
   }
 
   KOKKOS_FORCEINLINE_FUNCTION

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -80,10 +80,10 @@ class FlatIdx {
     rng.e = shape_[iDim - 1] - 1;
     return rng;
   }
-  
-  KOKKOS_FORCEINLINE_FUNCTION 
-  bool IsValid() const { 
-    if (offset_ >= 0) return true; 
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  bool IsValid() const {
+    if (offset_ >= 0) return true;
     return false;
   }
 
@@ -204,15 +204,15 @@ class PackIndexMap {
     shape_map_.insert(std::pair<std::string, vpack_types::Shape>(key, shape));
   }
 
-  vpack_types::FlatIdx GetFlatIdx(const std::string &key, 
-                                  bool ThrowInvalidKeyError = true ) {
+  vpack_types::FlatIdx GetFlatIdx(const std::string &key,
+                                  bool ThrowInvalidKeyError = true) {
     // Make sure the key exists
     auto itr = map_.find(key);
     auto itr_shape = shape_map_.find(key);
     if ((itr == map_.end()) || (itr_shape == shape_map_.end())) {
       if (ThrowInvalidKeyError) {
         PARTHENON_THROW("Key " + key + " does not exist.");
-      } else { 
+      } else {
         return vpack_types::FlatIdx({}, -1);
       }
     }

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -82,9 +82,7 @@ class FlatIdx {
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
-  bool IsValid() const {
-    return (offset_ >= 0);
-  }
+  bool IsValid() const { return (offset_ >= 0); }
 
   KOKKOS_FORCEINLINE_FUNCTION
   int operator()() const {
@@ -204,12 +202,12 @@ class PackIndexMap {
   }
 
   vpack_types::FlatIdx GetFlatIdx(const std::string &key,
-                                  bool ThrowInvalidKeyError = true) {
+                                  bool throw_invalid_key_error = true) {
     // Make sure the key exists
     auto itr = map_.find(key);
     auto itr_shape = shape_map_.find(key);
     if ((itr == map_.end()) || (itr_shape == shape_map_.end())) {
-      if (ThrowInvalidKeyError) {
+      if (throw_invalid_key_error) {
         PARTHENON_THROW("Key " + key + " does not exist.");
       } else {
         return vpack_types::FlatIdx({}, -1);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -80,6 +80,12 @@ class FlatIdx {
     rng.e = shape_[iDim - 1] - 1;
     return rng;
   }
+  
+  KOKKOS_FORCEINLINE_FUNCTION 
+  bool IsValid() const { 
+    if (offset_ >= 0) return true; 
+    return false;
+  }
 
   KOKKOS_FORCEINLINE_FUNCTION
   int operator()() const {
@@ -198,12 +204,17 @@ class PackIndexMap {
     shape_map_.insert(std::pair<std::string, vpack_types::Shape>(key, shape));
   }
 
-  vpack_types::FlatIdx GetFlatIdx(const std::string &key) {
+  vpack_types::FlatIdx GetFlatIdx(const std::string &key, 
+                                  bool ThrowInvalidKeyError = true ) {
     // Make sure the key exists
     auto itr = map_.find(key);
     auto itr_shape = shape_map_.find(key);
     if ((itr == map_.end()) || (itr_shape == shape_map_.end())) {
-      PARTHENON_THROW("Key " + key + " does not exist.");
+      if (ThrowInvalidKeyError) {
+        PARTHENON_THROW("Key " + key + " does not exist.");
+      } else { 
+        return vpack_types::FlatIdx({}, -1);
+      }
     }
     return vpack_types::FlatIdx(itr_shape->second, itr->second.first);
   }

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -520,6 +520,14 @@ TEST_CASE("Get the correct access pattern when using FlatIdx", "[FlatIdx]") {
 
         REQUIRE(err3 == 0.0);
       }
+
+      THEN("We can ask for FlatIdxs of fields that don't exist in the pack") {
+        PackIndexMap imap;
+        auto v = pmbd->PackVariables(std::vector<std::string>{"v2", "v3"}, imap);
+        auto idx_v4 = imap.GetFlatIdx("v4", false);
+        REQUIRE(idx_v4() == -1);
+        REQUIRE(!idx_v4.IsValid());
+      }
     }
   }
 }


### PR DESCRIPTION
## PR Summary

Previously, `PackIndexMap::GetFlatIdx(string key)` would throw an error if the requested `key` was not present in the index map. Now, an option to return a `FlatIdx` object with an invalid offset instead is included. The default behavior of `GetFlatIdx` is unchanged. Included at the request of @brryan. 


## PR Checklist

- [x] Code passes cpplint
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
