### PR TITLE
Enable user boundary conditions for particles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 586]](https://github.com/lanl/parthenon/pull/586) Implement true sparse capability with automatic allocation and deallocation of sparse
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 655]](https://github.com/lanl/parthenon/pull/655) Add Mesh pointer to InitUserMeshData
 - [[PR 623]](https://github.com/lanl/parthenon/pull/623) Enable Params to optionally return non-const pointers
 - [[PR 604]](https://github.com/lanl/parthenon/pull/604) Allow modification of SimTime in PreStepUserWorkInLoop
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [[PR 586]](https://github.com/lanl/parthenon/pull/586) Implement true sparse capability with automatic allocation and deallocation of sparse
 
 ### Changed (changing behavior/API/variables/...)
-- [[PR 655]](https://github.com/lanl/parthenon/pull/655) Add Mesh pointer to InitUserMeshData
+- [[PR 655]](https://github.com/lanl/parthenon/pull/655) Enable user boundary conditions for particles
 - [[PR 623]](https://github.com/lanl/parthenon/pull/623) Enable Params to optionally return non-const pointers
 - [[PR 604]](https://github.com/lanl/parthenon/pull/604) Allow modification of SimTime in PreStepUserWorkInLoop
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -112,4 +112,5 @@ when they are in boundary regions are allocated depending on the boundary flags 
 in the input file. Currently, outflow and periodic boundaries are supported natively.
 User-specified boundary conditions must be set by specifying the "user" flag in the input
 parameter file and then updating the appropriate Swarm::bounds array entries to separately
-allocated boundary condition objects.
+allocated boundary condition objects. An example is given in the `particles` example when
+ix1 and ox1 are set to `user` in the input parameter file.

--- a/docs/particles.md
+++ b/docs/particles.md
@@ -111,6 +111,6 @@ classes containing boundary condition functions for updating particles or removi
 when they are in boundary regions are allocated depending on the boundary flags specified
 in the input file. Currently, outflow and periodic boundaries are supported natively.
 User-specified boundary conditions must be set by specifying the "user" flag in the input
-parameter file and then updating the appropriate Swarm::bounds array entries to separately
-allocated boundary condition objects. An example is given in the `particles` example when
-ix1 and ox1 are set to `user` in the input parameter file.
+parameter file and then updating the appropriate Swarm::bounds array entries to factory
+functions that allocate device-side boundary condition objects. An example is given in the
+`particles` example when ix1 and ox1 are set to `user` in the input parameter file.

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -38,10 +38,14 @@ int main(int argc, char *argv[]) {
   if (pman.pinput->GetString("parthenon/mesh", "ix1_bc") == "user") {
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] =
         parthenon::BoundaryFunction::OutflowInnerX1;
+    pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x1] =
+      particles_example::SetSwarmIx1UserBC;
   }
   if (pman.pinput->GetString("parthenon/mesh", "ox1_bc") == "user") {
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x1] =
         parthenon::BoundaryFunction::OutflowOuterX1;
+    pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x1] =
+      particles_example::SetSwarmOx1UserBC;
   }
   pman.ParthenonInitPackagesAndMesh();
 

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -35,12 +35,20 @@ int main(int argc, char *argv[]) {
   pman.app_input->ProcessPackages = particles_example::ProcessPackages;
   pman.app_input->ProblemGenerator = particles_example::ProblemGenerator;
   if (pman.pinput->GetString("parthenon/mesh", "ix1_bc") == "user") {
+    // In this case, we are setting a custom swarm boundary condition while still using
+    // a default parthenon boundary condition for cell variables. In general, one can
+    // provide both custom cell variable and swarm boundary conditions. However, to use
+    // custom boundary conditions for either cell variables or swarms, the parthenon
+    // boundary must be set to "user" and both cell variable and swarm boundaries provided
+    // as here.
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] =
         parthenon::BoundaryFunction::OutflowInnerX1;
     pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x1] =
         particles_example::SetSwarmIx1UserBC;
   }
   if (pman.pinput->GetString("parthenon/mesh", "ox1_bc") == "user") {
+    // Again, we use a default parthenon boundary condition for cell variables but a
+    // custom swarm boundary condition.
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x1] =
         parthenon::BoundaryFunction::OutflowOuterX1;
     pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x1] =

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -34,18 +34,17 @@ int main(int argc, char *argv[]) {
   // Redefine parthenon defaults
   pman.app_input->ProcessPackages = particles_example::ProcessPackages;
   pman.app_input->ProblemGenerator = particles_example::ProblemGenerator;
-  pman.app_input->InitUserMeshData = particles_example::InitUserMeshData;
   if (pman.pinput->GetString("parthenon/mesh", "ix1_bc") == "user") {
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] =
         parthenon::BoundaryFunction::OutflowInnerX1;
     pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x1] =
-      particles_example::SetSwarmIx1UserBC;
+        particles_example::SetSwarmIx1UserBC;
   }
   if (pman.pinput->GetString("parthenon/mesh", "ox1_bc") == "user") {
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x1] =
         parthenon::BoundaryFunction::OutflowOuterX1;
     pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x1] =
-      particles_example::SetSwarmOx1UserBC;
+        particles_example::SetSwarmOx1UserBC;
   }
   pman.ParthenonInitPackagesAndMesh();
 

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -44,7 +44,7 @@ int main(int argc, char *argv[]) {
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] =
         parthenon::BoundaryFunction::OutflowInnerX1;
     pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x1] =
-        particles_example::SetSwarmIx1UserBC;
+        particles_example::SetSwarmIX1UserBC;
   }
   if (pman.pinput->GetString("parthenon/mesh", "ox1_bc") == "user") {
     // Again, we use a default parthenon boundary condition for cell variables but a
@@ -52,7 +52,7 @@ int main(int argc, char *argv[]) {
     pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x1] =
         parthenon::BoundaryFunction::OutflowOuterX1;
     pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x1] =
-        particles_example::SetSwarmOx1UserBC;
+        particles_example::SetSwarmOX1UserBC;
   }
   pman.ParthenonInitPackagesAndMesh();
 

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -24,8 +24,8 @@ refinement = none
 nx1 = 16
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = user
+ox1_bc = user
 
 nx2 = 16
 x2min = -0.5

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -24,8 +24,8 @@ refinement = none
 nx1 = 16
 x1min = -0.5
 x1max = 0.5
-ix1_bc = user
-ox1_bc = user
+ix1_bc = periodic
+ox1_bc = periodic
 
 nx2 = 16
 x2min = -0.5

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -25,13 +25,14 @@
 // *************************************************//
 namespace particles_example {
 
-void InitUserMeshData(Mesh *mesh, ParameterInput *pin) {
-  if (pin->GetString("parthenon/mesh", "ix1_bc") == "user") {
-    mesh->swarm_bc_funcs[0] = SetSwarmIx1UserBC;
-  }
-  if (pin->GetString("parthenon/mesh", "ox1_bc") == "user") {
-    mesh->swarm_bc_funcs[1] = SetSwarmOx1UserBC;
-  }
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmIx1UserBC() {
+  return DeviceAllocate<ParticleBoundIX1Outflow>();
+}
+
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmOx1UserBC() {
+  return DeviceAllocate<ParticleBoundOX1Outflow>();
 }
 
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -26,12 +26,12 @@
 namespace particles_example {
 
 std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmIx1UserBC() {
+SetSwarmIX1UserBC() {
   return DeviceAllocate<ParticleBoundIX1User>();
 }
 
 std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmOx1UserBC() {
+SetSwarmOX1UserBC() {
   return DeviceAllocate<ParticleBoundOX1User>();
 }
 

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -25,6 +25,25 @@
 // *************************************************//
 namespace particles_example {
 
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmIx1UserBC() {
+  return DeviceAllocate<ParticleBoundIX1Outflow>();
+}
+
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmOx1UserBC() {
+  return DeviceAllocate<ParticleBoundOX1Outflow>();
+}
+
+void InitUserMeshData(Mesh *mesh, ParameterInput *pin) {
+  if (pin->GetString("parthenon/mesh", "ix1_bc") == "user") {
+    mesh->swarm_bc_funcs[0] = SetSwarmIx1UserBC;
+  }
+  if (pin->GetString("parthenon/mesh", "ox1_bc") == "user") {
+    mesh->swarm_bc_funcs[1] = SetSwarmOx1UserBC;
+  }
+}
+
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {
   Packages_t packages;
   packages.Add(particles_example::Particles::Initialize(pin.get()));

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -27,12 +27,12 @@ namespace particles_example {
 
 std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
 SetSwarmIx1UserBC() {
-  return DeviceAllocate<ParticleBoundIX1Outflow>();
+  return DeviceAllocate<ParticleBoundIX1User>();
 }
 
 std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
 SetSwarmOx1UserBC() {
-  return DeviceAllocate<ParticleBoundOX1Outflow>();
+  return DeviceAllocate<ParticleBoundOX1User>();
 }
 
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin) {

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -25,16 +25,6 @@
 // *************************************************//
 namespace particles_example {
 
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmIx1UserBC() {
-  return DeviceAllocate<ParticleBoundIX1Outflow>();
-}
-
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmOx1UserBC() {
-  return DeviceAllocate<ParticleBoundOX1Outflow>();
-}
-
 void InitUserMeshData(Mesh *mesh, ParameterInput *pin) {
   if (pin->GetString("parthenon/mesh", "ix1_bc") == "user") {
     mesh->swarm_bc_funcs[0] = SetSwarmIx1UserBC;

--- a/example/particles/particles.hpp
+++ b/example/particles/particles.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particles/particles.hpp
+++ b/example/particles/particles.hpp
@@ -45,6 +45,16 @@ void InitUserMeshData(Mesh *mesh, ParameterInput *pin);
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin);
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin);
 
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmIx1UserBC() {
+  return DeviceAllocate<ParticleBoundIX1Outflow>();
+}
+
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmOx1UserBC() {
+  return DeviceAllocate<ParticleBoundOX1Outflow>();
+}
+
 namespace Particles {
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);

--- a/example/particles/particles.hpp
+++ b/example/particles/particles.hpp
@@ -66,9 +66,9 @@ class ParticleDriver : public EvolutionDriver {
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin);
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin);
 
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>> SetSwarmIx1UserBC();
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>> SetSwarmIX1UserBC();
 
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>> SetSwarmOx1UserBC();
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>> SetSwarmOX1UserBC();
 
 namespace Particles {
 

--- a/example/particles/particles.hpp
+++ b/example/particles/particles.hpp
@@ -41,19 +41,12 @@ class ParticleDriver : public EvolutionDriver {
   StagedIntegrator integrator;
 };
 
-void InitUserMeshData(Mesh *mesh, ParameterInput *pin);
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin);
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin);
 
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmIx1UserBC() {
-  return DeviceAllocate<ParticleBoundIX1Outflow>();
-}
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>> SetSwarmIx1UserBC();
 
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmOx1UserBC() {
-  return DeviceAllocate<ParticleBoundOX1Outflow>();
-}
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>> SetSwarmOx1UserBC();
 
 namespace Particles {
 

--- a/example/particles/particles.hpp
+++ b/example/particles/particles.hpp
@@ -41,6 +41,7 @@ class ParticleDriver : public EvolutionDriver {
   StagedIntegrator integrator;
 };
 
+void InitUserMeshData(Mesh *mesh, ParameterInput *pin);
 void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin);
 Packages_t ProcessPackages(std::unique_ptr<ParameterInput> &pin);
 

--- a/example/particles/particles.hpp
+++ b/example/particles/particles.hpp
@@ -26,6 +26,28 @@ using namespace parthenon;
 
 namespace particles_example {
 
+// Duplicates of ParticleBoundIX1Outflow and ParticleBoundOX1Outflow to illustrate custom
+// particle boundary conditions
+class ParticleBoundIX1User : public ParticleBound {
+ public:
+  KOKKOS_INLINE_FUNCTION void Apply(const int n, double &x, double &y, double &z,
+                                    const SwarmDeviceContext &swarm_d) const override {
+    if (x < swarm_d.x_min_global_) {
+      swarm_d.MarkParticleForRemoval(n);
+    }
+  }
+};
+
+class ParticleBoundOX1User : public ParticleBound {
+ public:
+  KOKKOS_INLINE_FUNCTION void Apply(const int n, double &x, double &y, double &z,
+                                    const SwarmDeviceContext &swarm_d) const override {
+    if (x > swarm_d.x_max_global_) {
+      swarm_d.MarkParticleForRemoval(n);
+    }
+  }
+};
+
 typedef Kokkos::Random_XorShift64_Pool<> RNGPool;
 
 class ParticleDriver : public EvolutionDriver {

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -33,7 +33,7 @@ struct ApplicationInput {
   std::function<Packages_t(std::unique_ptr<ParameterInput> &)> ProcessPackages = nullptr;
 
   // Mesh functions
-  std::function<void(ParameterInput *)> InitUserMeshData = nullptr;
+  std::function<void(Mesh *, ParameterInput *)> InitUserMeshData = nullptr;
 
   std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepMeshUserWorkInLoop =
       nullptr;

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -46,8 +46,8 @@ struct ApplicationInput {
       PostStepDiagnosticsInLoop = nullptr;
 
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
-  BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr, nullptr, nullptr,
-                                                   nullptr, nullptr, nullptr};
+  BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr};
+  SBValFunc swarm_boundary_conditions[BOUNDARY_NFACES] = {nullptr};
 
   // MeshBlock functions
   std::function<std::unique_ptr<MeshBlockApplicationData>(MeshBlock *, ParameterInput *)>

--- a/src/bvals/boundary_conditions.hpp
+++ b/src/bvals/boundary_conditions.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/bvals/boundary_conditions.hpp
+++ b/src/bvals/boundary_conditions.hpp
@@ -21,12 +21,14 @@
 #include "basic_types.hpp"
 #include "interface/meshblock_data.hpp"
 #include "mesh/domain.hpp"
+#include "interface/swarm_boundaries.hpp"
 
 namespace parthenon {
 
 // Physical boundary conditions
 
 using BValFunc = std::function<void(std::shared_ptr<MeshBlockData<Real>> &, bool)>;
+using SBValFunc = std::function<std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>()>;
 
 TaskStatus ProlongateBoundaries(std::shared_ptr<MeshBlockData<Real>> &rc);
 

--- a/src/bvals/boundary_conditions.hpp
+++ b/src/bvals/boundary_conditions.hpp
@@ -20,15 +20,16 @@
 
 #include "basic_types.hpp"
 #include "interface/meshblock_data.hpp"
-#include "mesh/domain.hpp"
 #include "interface/swarm_boundaries.hpp"
+#include "mesh/domain.hpp"
 
 namespace parthenon {
 
 // Physical boundary conditions
 
 using BValFunc = std::function<void(std::shared_ptr<MeshBlockData<Real>> &, bool)>;
-using SBValFunc = std::function<std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>()>;
+using SBValFunc = std::function<
+    std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>()>;
 
 TaskStatus ProlongateBoundaries(std::shared_ptr<MeshBlockData<Real>> &rc);
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -103,8 +103,8 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[0] == BoundaryFlag::periodic) {
     bounds_uptrs[0] = DeviceAllocate<ParticleBoundIX1Periodic>();
   } else if (bcs[0] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->swarm_bc_funcs[0] != nullptr) {
-      bounds_uptrs[0] = pmb->pmy_mesh->swarm_bc_funcs[0]();
+    if (pmb->pmy_mesh->SwarmBndryFnctn[0] != nullptr) {
+      bounds_uptrs[0] = pmb->pmy_mesh->SwarmBndryFnctn[0]();
     } else {
       msg << "ix1 user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);
@@ -119,8 +119,8 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[1] == BoundaryFlag::periodic) {
     bounds_uptrs[1] = DeviceAllocate<ParticleBoundOX1Periodic>();
   } else if (bcs[1] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->swarm_bc_funcs[1] != nullptr) {
-      bounds_uptrs[1] = pmb->pmy_mesh->swarm_bc_funcs[1]();
+    if (pmb->pmy_mesh->SwarmBndryFnctn[1] != nullptr) {
+      bounds_uptrs[1] = pmb->pmy_mesh->SwarmBndryFnctn[1]();
     } else {
       msg << "ox1 user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);
@@ -135,8 +135,8 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[2] == BoundaryFlag::periodic) {
     bounds_uptrs[2] = DeviceAllocate<ParticleBoundIX2Periodic>();
   } else if (bcs[2] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->swarm_bc_funcs[2] != nullptr) {
-      bounds_uptrs[2] = pmb->pmy_mesh->swarm_bc_funcs[2]();
+    if (pmb->pmy_mesh->SwarmBndryFnctn[2] != nullptr) {
+      bounds_uptrs[2] = pmb->pmy_mesh->SwarmBndryFnctn[2]();
     } else {
       msg << "ix2 user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);
@@ -151,8 +151,8 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[3] == BoundaryFlag::periodic) {
     bounds_uptrs[3] = DeviceAllocate<ParticleBoundOX2Periodic>();
   } else if (bcs[3] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->swarm_bc_funcs[3] != nullptr) {
-      bounds_uptrs[3] = pmb->pmy_mesh->swarm_bc_funcs[3]();
+    if (pmb->pmy_mesh->SwarmBndryFnctn[3] != nullptr) {
+      bounds_uptrs[3] = pmb->pmy_mesh->SwarmBndryFnctn[3]();
     } else {
       msg << "ox2 user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);
@@ -167,8 +167,8 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[4] == BoundaryFlag::periodic) {
     bounds_uptrs[4] = DeviceAllocate<ParticleBoundIX3Periodic>();
   } else if (bcs[4] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->swarm_bc_funcs[4] != nullptr) {
-      bounds_uptrs[4] = pmb->pmy_mesh->swarm_bc_funcs[4]();
+    if (pmb->pmy_mesh->SwarmBndryFnctn[4] != nullptr) {
+      bounds_uptrs[4] = pmb->pmy_mesh->SwarmBndryFnctn[4]();
     } else {
       msg << "ix3 user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);
@@ -183,8 +183,8 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[5] == BoundaryFlag::periodic) {
     bounds_uptrs[5] = DeviceAllocate<ParticleBoundOX3Periodic>();
   } else if (bcs[5] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->swarm_bc_funcs[5] != nullptr) {
-      bounds_uptrs[5] = pmb->pmy_mesh->swarm_bc_funcs[5]();
+    if (pmb->pmy_mesh->SwarmBndryFnctn[5] != nullptr) {
+      bounds_uptrs[5] = pmb->pmy_mesh->SwarmBndryFnctn[5]();
     } else {
       msg << "ox3 user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -182,7 +182,7 @@ void Swarm::AllocateBoundaries() {
     bounds_uptrs[5] = DeviceAllocate<ParticleBoundOX3Outflow>();
   } else if (bcs[5] == BoundaryFlag::periodic) {
     bounds_uptrs[5] = DeviceAllocate<ParticleBoundOX3Periodic>();
-  } else if (bcs[5] != BoundaryFlag::user) {
+  } else if (bcs[5] == BoundaryFlag::user) {
     if (pmb->pmy_mesh->swarm_bc_funcs[5] != nullptr) {
       bounds_uptrs[5] = pmb->pmy_mesh->swarm_bc_funcs[5]();
     } else {

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -102,7 +102,14 @@ void Swarm::AllocateBoundaries() {
     bounds_uptrs[0] = DeviceAllocate<ParticleBoundIX1Outflow>();
   } else if (bcs[0] == BoundaryFlag::periodic) {
     bounds_uptrs[0] = DeviceAllocate<ParticleBoundIX1Periodic>();
-  } else if (bcs[0] != BoundaryFlag::user) {
+  } else if (bcs[0] == BoundaryFlag::user) {
+    if (pmb->pmy_mesh->swarm_bc_funcs[0] != nullptr) {
+      bounds_uptrs[0] = pmb->pmy_mesh->swarm_bc_funcs[0]();
+    } else {
+      msg << "ix1 user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
     msg << "ix1 boundary flag " << static_cast<int>(bcs[0]) << " not supported!";
     PARTHENON_THROW(msg);
   }
@@ -111,7 +118,14 @@ void Swarm::AllocateBoundaries() {
     bounds_uptrs[1] = DeviceAllocate<ParticleBoundOX1Outflow>();
   } else if (bcs[1] == BoundaryFlag::periodic) {
     bounds_uptrs[1] = DeviceAllocate<ParticleBoundOX1Periodic>();
-  } else if (bcs[1] != BoundaryFlag::user) {
+  } else if (bcs[1] == BoundaryFlag::user) {
+    if (pmb->pmy_mesh->swarm_bc_funcs[1] != nullptr) {
+      bounds_uptrs[1] = pmb->pmy_mesh->swarm_bc_funcs[1]();
+    } else {
+      msg << "ox1 user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
     msg << "ox1 boundary flag " << static_cast<int>(bcs[1]) << " not supported!";
     PARTHENON_THROW(msg);
   }
@@ -120,7 +134,14 @@ void Swarm::AllocateBoundaries() {
     bounds_uptrs[2] = DeviceAllocate<ParticleBoundIX2Outflow>();
   } else if (bcs[2] == BoundaryFlag::periodic) {
     bounds_uptrs[2] = DeviceAllocate<ParticleBoundIX2Periodic>();
-  } else if (bcs[2] != BoundaryFlag::user) {
+  } else if (bcs[2] == BoundaryFlag::user) {
+    if (pmb->pmy_mesh->swarm_bc_funcs[2] != nullptr) {
+      bounds_uptrs[2] = pmb->pmy_mesh->swarm_bc_funcs[2]();
+    } else {
+      msg << "ix2 user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
     msg << "ix2 boundary flag " << static_cast<int>(bcs[2]) << " not supported!";
     PARTHENON_THROW(msg);
   }
@@ -129,7 +150,14 @@ void Swarm::AllocateBoundaries() {
     bounds_uptrs[3] = DeviceAllocate<ParticleBoundOX2Outflow>();
   } else if (bcs[3] == BoundaryFlag::periodic) {
     bounds_uptrs[3] = DeviceAllocate<ParticleBoundOX2Periodic>();
-  } else if (bcs[3] != BoundaryFlag::user) {
+  } else if (bcs[3] == BoundaryFlag::user) {
+    if (pmb->pmy_mesh->swarm_bc_funcs[3] != nullptr) {
+      bounds_uptrs[3] = pmb->pmy_mesh->swarm_bc_funcs[3]();
+    } else {
+      msg << "ox2 user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
     msg << "ox2 boundary flag " << static_cast<int>(bcs[3]) << " not supported!";
     PARTHENON_THROW(msg);
   }
@@ -138,7 +166,14 @@ void Swarm::AllocateBoundaries() {
     bounds_uptrs[4] = DeviceAllocate<ParticleBoundIX3Outflow>();
   } else if (bcs[4] == BoundaryFlag::periodic) {
     bounds_uptrs[4] = DeviceAllocate<ParticleBoundIX3Periodic>();
-  } else if (bcs[4] != BoundaryFlag::user) {
+  } else if (bcs[4] == BoundaryFlag::user) {
+    if (pmb->pmy_mesh->swarm_bc_funcs[4] != nullptr) {
+      bounds_uptrs[4] = pmb->pmy_mesh->swarm_bc_funcs[4]();
+    } else {
+      msg << "ix3 user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
     msg << "ix3 boundary flag " << static_cast<int>(bcs[4]) << " not supported!";
     PARTHENON_THROW(msg);
   }
@@ -148,6 +183,13 @@ void Swarm::AllocateBoundaries() {
   } else if (bcs[5] == BoundaryFlag::periodic) {
     bounds_uptrs[5] = DeviceAllocate<ParticleBoundOX3Periodic>();
   } else if (bcs[5] != BoundaryFlag::user) {
+    if (pmb->pmy_mesh->swarm_bc_funcs[5] != nullptr) {
+      bounds_uptrs[5] = pmb->pmy_mesh->swarm_bc_funcs[5]();
+    } else {
+      msg << "ox3 user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
     msg << "ox3 boundary flag " << static_cast<int>(bcs[5]) << " not supported!";
     PARTHENON_THROW(msg);
   }
@@ -556,6 +598,10 @@ void Swarm::SortParticlesByCell() {
 
           if (cellSorted(start_index).cell_idx_1d_ >= cell_idx_1d) {
             start_index--;
+            if (start_index < 0) {
+              start_index = -1;
+              break;
+            }
             if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
               start_index = -1;
               break;
@@ -564,6 +610,10 @@ void Swarm::SortParticlesByCell() {
           }
           if (cellSorted(start_index).cell_idx_1d_ < cell_idx_1d) {
             start_index++;
+            if (start_index > max_active_index) {
+              start_index = -1;
+              break;
+            }
             if (cellSorted(start_index).cell_idx_1d_ > cell_idx_1d) {
               start_index = -1;
               break;

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -92,107 +92,47 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
   marked_for_removal_.data.DeepCopy(marked_for_removal_h);
 }
 
+template <class BOutflow, class BPeriodic, int iFace>
+void Swarm::AllocateBoundariesImpl_(MeshBlock *pmb) {
+  std::stringstream msg;
+  auto &bcs = pmb->pmy_mesh->mesh_bcs;
+  if (bcs[iFace] == BoundaryFlag::outflow) {
+    bounds_uptrs[iFace] = DeviceAllocate<BOutflow>();
+  } else if (bcs[iFace] == BoundaryFlag::periodic) {
+    bounds_uptrs[iFace] = DeviceAllocate<BPeriodic>();
+  } else if (bcs[iFace] == BoundaryFlag::user) {
+    if (pmb->pmy_mesh->SwarmBndryFnctn[iFace] != nullptr) {
+      bounds_uptrs[iFace] = pmb->pmy_mesh->SwarmBndryFnctn[iFace]();
+    } else {
+      msg << "ix" << iFace + 1
+          << " user boundary requested but provided function is null!";
+      PARTHENON_THROW(msg);
+    }
+  } else {
+    msg << "ix" << iFace + 1 << " boundary flag " << static_cast<int>(bcs[iFace])
+        << " not supported!";
+    PARTHENON_THROW(msg);
+  }
+}
+
 void Swarm::AllocateBoundaries() {
   auto pmb = GetBlockPointer();
   std::stringstream msg;
 
   auto &bcs = pmb->pmy_mesh->mesh_bcs;
 
-  if (bcs[0] == BoundaryFlag::outflow) {
-    bounds_uptrs[0] = DeviceAllocate<ParticleBoundIX1Outflow>();
-  } else if (bcs[0] == BoundaryFlag::periodic) {
-    bounds_uptrs[0] = DeviceAllocate<ParticleBoundIX1Periodic>();
-  } else if (bcs[0] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[0] != nullptr) {
-      bounds_uptrs[0] = pmb->pmy_mesh->SwarmBndryFnctn[0]();
-    } else {
-      msg << "ix1 user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << "ix1 boundary flag " << static_cast<int>(bcs[0]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
-
-  if (bcs[1] == BoundaryFlag::outflow) {
-    bounds_uptrs[1] = DeviceAllocate<ParticleBoundOX1Outflow>();
-  } else if (bcs[1] == BoundaryFlag::periodic) {
-    bounds_uptrs[1] = DeviceAllocate<ParticleBoundOX1Periodic>();
-  } else if (bcs[1] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[1] != nullptr) {
-      bounds_uptrs[1] = pmb->pmy_mesh->SwarmBndryFnctn[1]();
-    } else {
-      msg << "ox1 user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << "ox1 boundary flag " << static_cast<int>(bcs[1]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
-
-  if (bcs[2] == BoundaryFlag::outflow) {
-    bounds_uptrs[2] = DeviceAllocate<ParticleBoundIX2Outflow>();
-  } else if (bcs[2] == BoundaryFlag::periodic) {
-    bounds_uptrs[2] = DeviceAllocate<ParticleBoundIX2Periodic>();
-  } else if (bcs[2] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[2] != nullptr) {
-      bounds_uptrs[2] = pmb->pmy_mesh->SwarmBndryFnctn[2]();
-    } else {
-      msg << "ix2 user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << "ix2 boundary flag " << static_cast<int>(bcs[2]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
-
-  if (bcs[3] == BoundaryFlag::outflow) {
-    bounds_uptrs[3] = DeviceAllocate<ParticleBoundOX2Outflow>();
-  } else if (bcs[3] == BoundaryFlag::periodic) {
-    bounds_uptrs[3] = DeviceAllocate<ParticleBoundOX2Periodic>();
-  } else if (bcs[3] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[3] != nullptr) {
-      bounds_uptrs[3] = pmb->pmy_mesh->SwarmBndryFnctn[3]();
-    } else {
-      msg << "ox2 user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << "ox2 boundary flag " << static_cast<int>(bcs[3]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
-
-  if (bcs[4] == BoundaryFlag::outflow) {
-    bounds_uptrs[4] = DeviceAllocate<ParticleBoundIX3Outflow>();
-  } else if (bcs[4] == BoundaryFlag::periodic) {
-    bounds_uptrs[4] = DeviceAllocate<ParticleBoundIX3Periodic>();
-  } else if (bcs[4] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[4] != nullptr) {
-      bounds_uptrs[4] = pmb->pmy_mesh->SwarmBndryFnctn[4]();
-    } else {
-      msg << "ix3 user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << "ix3 boundary flag " << static_cast<int>(bcs[4]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
-
-  if (bcs[5] == BoundaryFlag::outflow) {
-    bounds_uptrs[5] = DeviceAllocate<ParticleBoundOX3Outflow>();
-  } else if (bcs[5] == BoundaryFlag::periodic) {
-    bounds_uptrs[5] = DeviceAllocate<ParticleBoundOX3Periodic>();
-  } else if (bcs[5] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[5] != nullptr) {
-      bounds_uptrs[5] = pmb->pmy_mesh->SwarmBndryFnctn[5]();
-    } else {
-      msg << "ox3 user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << "ox3 boundary flag " << static_cast<int>(bcs[5]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
+  AllocateBoundariesImpl_<ParticleBoundIX1Outflow, ParticleBoundIX1Periodic, 0>(
+      pmb.get());
+  AllocateBoundariesImpl_<ParticleBoundOX1Outflow, ParticleBoundOX1Periodic, 1>(
+      pmb.get());
+  AllocateBoundariesImpl_<ParticleBoundIX2Outflow, ParticleBoundIX2Periodic, 2>(
+      pmb.get());
+  AllocateBoundariesImpl_<ParticleBoundOX2Outflow, ParticleBoundOX2Periodic, 3>(
+      pmb.get());
+  AllocateBoundariesImpl_<ParticleBoundIX3Outflow, ParticleBoundIX3Periodic, 4>(
+      pmb.get());
+  AllocateBoundariesImpl_<ParticleBoundOX3Outflow, ParticleBoundOX3Periodic, 5>(
+      pmb.get());
 
   for (int n = 0; n < 6; n++) {
     bounds_d.bounds[n] = bounds_uptrs[n].get();

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -210,6 +210,9 @@ class Swarm {
   template <class T>
   vpack_types::SwarmVarList<T> MakeVarListAll_();
 
+  template <class BOutflow, class BPeriodic, int iFace>
+  void AllocateBoundariesImpl_(MeshBlock *pmb);
+
   void SetNeighborIndices1D_();
   void SetNeighborIndices2D_();
   void SetNeighborIndices3D_();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -968,7 +968,7 @@ void Mesh::EnrollBndryFncts_(ApplicationInput *app_in) {
       } else {
         std::stringstream msg;
         msg << "A user boundary condition for face " << f
-            << " was requested, but not swarm condition was enrolled." << std::endl;
+            << " was requested, but no swarm condition was enrolled." << std::endl;
         PARTHENON_THROW(msg);
       }
       break;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -290,7 +290,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
     max_level = 63;
   }
 
-  InitUserMeshData(pin);
+  InitUserMeshData(this, pin);
 
   if (multilevel) {
     if (block_size.nx1 % 2 == 1 || (block_size.nx2 % 2 == 1 && (ndim >= 2)) ||
@@ -675,7 +675,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
     max_level = 63;
   }
 
-  InitUserMeshData(pin);
+  InitUserMeshData(this, pin);
 
   // Populate logical locations
   auto lx123 = rr.ReadDataset<int64_t>("/Blocks/loc.lx123");

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -960,6 +960,21 @@ void Mesh::EnrollBndryFncts_(ApplicationInput *app_in) {
     default: // periodic/block BCs handled elsewhere.
       break;
     }
+
+    switch (mesh_bcs[f]) {
+    case BoundaryFlag::user:
+      if (app_in->swarm_boundary_conditions[f] != nullptr) {
+        SwarmBndryFnctn[f] = app_in->swarm_boundary_conditions[f];
+      } else {
+        std::stringstream msg;
+        msg << "A user boundary condition for face " << f
+            << " was requested, but not swarm condition was enrolled." << std::endl;
+        PARTHENON_THROW(msg);
+      }
+      break;
+    default: // Default BCs handled elsewhere
+      break;
+    }
   }
 }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -140,6 +140,7 @@ class Mesh {
 
   // Boundary Functions
   BValFunc MeshBndryFnctn[6];
+  SBValFunc SwarmBndryFnctn[6];
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   static void UserWorkAfterLoopDefault(Mesh *mesh, ParameterInput *pin,

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -92,6 +92,8 @@ class Mesh {
   bool modified;
   RegionSize mesh_size;
   BoundaryFlag mesh_bcs[BOUNDARY_NFACES];
+  std::function<std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>()>
+      swarm_bc_funcs[BOUNDARY_NFACES] = {nullptr};
   const int ndim; // number of dimensions
   const bool adaptive, multilevel;
   int nbtotal, nbnew, nbdel;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -243,8 +243,9 @@ class Mesh {
   void FinishRecvCoarseToFineAMR(MeshBlock *pb, BufArray1D<Real> &recvbuf);
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
-  static void InitUserMeshDataDefault(ParameterInput *pin);
-  std::function<void(ParameterInput *)> InitUserMeshData = InitUserMeshDataDefault;
+  static void InitUserMeshDataDefault(Mesh *mesh, ParameterInput *pin);
+  std::function<void(Mesh *, ParameterInput *)> InitUserMeshData =
+      InitUserMeshDataDefault;
 
   void EnrollBndryFncts_(ApplicationInput *app_in);
   void EnrollUserMeshGenerator(CoordinateDirection dir, MeshGenFunc my_mg);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -92,8 +92,6 @@ class Mesh {
   bool modified;
   RegionSize mesh_size;
   BoundaryFlag mesh_bcs[BOUNDARY_NFACES];
-  std::function<std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>()>
-      swarm_bc_funcs[BOUNDARY_NFACES] = {nullptr};
   const int ndim; // number of dimensions
   const bool adaptive, multilevel;
   int nbtotal, nbnew, nbdel;

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -39,7 +39,7 @@ namespace parthenon {
 //  functions in this file.  Called in Mesh constructor.
 //========================================================================================
 
-void Mesh::InitUserMeshDataDefault(ParameterInput *pin) {
+void Mesh::InitUserMeshDataDefault(Mesh *, ParameterInput *) {
   // do nothing
   return;
 }

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -24,6 +24,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "bvals/bvals_interfaces.hpp"
 #include "interface/swarm.hpp"
 #include "mesh/mesh.hpp"
 
@@ -32,6 +33,7 @@
 
 using Real = double;
 using parthenon::ApplicationInput;
+using parthenon::BoundaryFlag;
 using parthenon::Mesh;
 using parthenon::MeshBlock;
 using parthenon::Metadata;
@@ -61,10 +63,14 @@ TEST_CASE("Swarm memory management", "[Swarm]") {
   Packages_t packages;
   auto meshblock = std::make_shared<MeshBlock>(1, 1);
   auto mesh = std::make_shared<Mesh>(pin.get(), app_in.get(), packages, 1);
+  for (int i = 0; i < 6; i++) {
+    mesh->mesh_bcs[i] = BoundaryFlag::outflow;
+  }
   meshblock->pmy_mesh = mesh.get();
   Metadata m;
   auto swarm = std::make_shared<Swarm>("test swarm", m, NUMINIT);
   swarm->SetBlockPointer(meshblock);
+  swarm->AllocateBoundaries();
   auto swarm_d = swarm->GetDeviceContext();
   REQUIRE(swarm->GetNumActive() == 0);
   REQUIRE(swarm->GetMaxActiveIndex() == 0);

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -34,16 +34,35 @@
 using Real = double;
 using parthenon::ApplicationInput;
 using parthenon::BoundaryFlag;
+using parthenon::DeviceAllocate;
+using parthenon::DeviceDeleter;
 using parthenon::Mesh;
 using parthenon::MeshBlock;
 using parthenon::Metadata;
 using parthenon::Packages_t;
 using parthenon::ParameterInput;
 using parthenon::ParArrayND;
+using parthenon::ParticleBound;
 using parthenon::Swarm;
+using parthenon::SwarmDeviceContext;
 using std::endl;
 
 constexpr int NUMINIT = 10;
+
+class ParticleBoundIX1User : public ParticleBound {
+ public:
+  KOKKOS_INLINE_FUNCTION void Apply(const int n, double &x, double &y, double &z,
+                                    const SwarmDeviceContext &swarm_d) const override {
+    if (x < swarm_d.x_min_global_) {
+      swarm_d.MarkParticleForRemoval(n);
+    }
+  }
+};
+
+std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
+SetSwarmIX1UserBC() {
+  return DeviceAllocate<ParticleBoundIX1User>();
+}
 
 TEST_CASE("Swarm memory management", "[Swarm]") {
   std::stringstream is;
@@ -63,7 +82,9 @@ TEST_CASE("Swarm memory management", "[Swarm]") {
   Packages_t packages;
   auto meshblock = std::make_shared<MeshBlock>(1, 1);
   auto mesh = std::make_shared<Mesh>(pin.get(), app_in.get(), packages, 1);
-  for (int i = 0; i < 6; i++) {
+  mesh->mesh_bcs[0] = BoundaryFlag::user;
+  mesh->SwarmBndryFnctn[0] = SetSwarmIX1UserBC;
+  for (int i = 1; i < 6; i++) {
     mesh->mesh_bcs[i] = BoundaryFlag::outflow;
   }
   meshblock->pmy_mesh = mesh.get();


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Particle swarms are intended to support user-provided boundary conditions, but there was a bit of connectivity missing between the user-side application inputs and the Swarms themselves; specifically, we were checking for correct particle boundaries before user boundaries could be set.

On an earlier attempt at making this change I noticed that `InitUserMeshData` is (I think) not very useful right now because application-specified functions can't access the `Mesh` variables. In particular, I need to be able to set `Swarm` boundary conditions to application-specific `user` values at this point in the mesh setup. I don't use `InitUserMeshData` here but I assume we want this change?

All this PR does is add the `this` pointer to the `Mesh` calls to `InitUserMeshData`. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
