### PR TITLE
Remove SetPrecise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 586]](https://github.com/lanl/parthenon/pull/586) Implement true sparse capability with automatic allocation and deallocation of sparse
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 662]](https://github.com/lanl/parthenon/pull/662) Remove SetPrecise
 - [[PR 623]](https://github.com/lanl/parthenon/pull/623) Enable Params to optionally return non-const pointers
 - [[PR 604]](https://github.com/lanl/parthenon/pull/604) Allow modification of SimTime in PreStepUserWorkInLoop
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -64,11 +64,11 @@ class EvolutionDriver : public Driver {
  public:
   EvolutionDriver(ParameterInput *pin, ApplicationInput *app_in, Mesh *pm)
       : Driver(pin, app_in, pm) {
-    Real start_time = pinput->GetOrAddPrecise("parthenon/time", "start_time", 0.0);
-    Real tstop = pinput->GetOrAddPrecise("parthenon/time", "tlim",
-                                         std::numeric_limits<Real>::infinity());
+    Real start_time = pinput->GetOrAddReal("parthenon/time", "start_time", 0.0);
+    Real tstop = pinput->GetOrAddReal("parthenon/time", "tlim",
+                                      std::numeric_limits<Real>::infinity());
     Real dt =
-        pinput->GetOrAddPrecise("parthenon/time", "dt", std::numeric_limits<Real>::max());
+        pinput->GetOrAddReal("parthenon/time", "dt", std::numeric_limits<Real>::max());
     const auto ncycle = pinput->GetOrAddInteger("parthenon/time", "ncycle", 0);
     const auto nmax = pinput->GetOrAddInteger("parthenon/time", "nlim", -1);
     const auto nout = pinput->GetOrAddInteger("parthenon/time", "ncycle_out", 1);

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -688,6 +688,8 @@ Real ParameterInput::GetOrAddReal(const std::string &block, const std::string &n
     ret = static_cast<Real>(atof(val.c_str()));
   } else {
     pb = FindOrAddBlock(block);
+    static_assert(sizeof(Real) <= sizeof(double), "Real is greater than double!");
+    ss_value.precision(std::numeric_limits<double>::max_digits10);
     ss_value << def_value;
     AddParameter(pb, name, ss_value.str(), "# Default value added at run time");
     ret = def_value;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -715,7 +715,7 @@ Real ParameterInput::GetOrAddPrecise(const std::string &block, const std::string
     std::string val = pl->param_value;
     ret = static_cast<Real>(atof(val.c_str()));
   } else {
-    ret = SetPrecise(block, name, def_value);
+    ret = SetReal(block, name, def_value);
   }
   return ret;
 }
@@ -798,28 +798,12 @@ int ParameterInput::SetInteger(const std::string &block, const std::string &name
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real ParameterInput::SetReal(const std::string & block, const std::string & name,
-//! Real value)
-//  \brief updates a real parameter; creates it if it does not exist
-
-Real ParameterInput::SetReal(const std::string &block, const std::string &name,
-                             Real value) {
-  InputBlock *pb;
-  std::stringstream ss_value;
-
-  pb = FindOrAddBlock(block);
-  ss_value << value;
-  AddParameter(pb, name, ss_value.str(), "# Updated during run time");
-  return value;
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn Real ParameterInput::SetPrecise(const std::string & block, const std::string &
+//! \fn Real ParameterInput::SetReal(const std::string & block, const std::string &
 //! name, Real value)
 //  \brief updates a real parameter with full precision; creates it if it does not exist
 
-Real ParameterInput::SetPrecise(const std::string &block, const std::string &name,
-                                Real value) {
+Real ParameterInput::SetReal(const std::string &block, const std::string &name,
+                             Real value) {
   InputBlock *pb;
   std::stringstream ss_value;
 

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -696,31 +696,6 @@ Real ParameterInput::GetOrAddReal(const std::string &block, const std::string &n
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn Real ParameterInput::GetOrAddPrecise(const std::string & block, const std::string
-//! & name,
-//    Real def_value)
-//  \brief returns real value stored in block/name if it exists, or creates and sets
-//  value to def_value if it does not exist.  Value is read with full precision.
-
-Real ParameterInput::GetOrAddPrecise(const std::string &block, const std::string &name,
-                                     Real def_value) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream ss_value;
-  Real ret;
-
-  if (DoesParameterExist(block, name)) {
-    pb = GetPtrToBlock(block);
-    pl = pb->GetPtrToLine(name);
-    std::string val = pl->param_value;
-    ret = static_cast<Real>(atof(val.c_str()));
-  } else {
-    ret = SetReal(block, name, def_value);
-  }
-  return ret;
-}
-
-//----------------------------------------------------------------------------------------
 //! \fn bool ParameterInput::GetOrAddBoolean(const std::string & block, const std::string
 //! & name,
 //    bool def_value)
@@ -808,6 +783,7 @@ Real ParameterInput::SetReal(const std::string &block, const std::string &name,
   std::stringstream ss_value;
 
   pb = FindOrAddBlock(block);
+  static_assert(sizeof(Real) <= sizeof(double), "Real is greater than double!");
   ss_value.precision(std::numeric_limits<double>::max_digits10);
   ss_value << value;
   AddParameter(pb, name, ss_value.str(), "# Updated during run time");

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -94,7 +94,6 @@ class ParameterInput {
   int SetInteger(const std::string &block, const std::string &name, int value);
   Real GetReal(const std::string &block, const std::string &name);
   Real GetOrAddReal(const std::string &block, const std::string &name, Real value);
-  Real GetOrAddPrecise(const std::string &block, const std::string &name, Real value);
   Real SetReal(const std::string &block, const std::string &name, Real value);
   bool GetBoolean(const std::string &block, const std::string &name);
   bool GetOrAddBoolean(const std::string &block, const std::string &name, bool value);

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -96,7 +96,6 @@ class ParameterInput {
   Real GetOrAddReal(const std::string &block, const std::string &name, Real value);
   Real GetOrAddPrecise(const std::string &block, const std::string &name, Real value);
   Real SetReal(const std::string &block, const std::string &name, Real value);
-  Real SetPrecise(const std::string &block, const std::string &name, Real value);
   bool GetBoolean(const std::string &block, const std::string &name);
   bool GetOrAddBoolean(const std::string &block, const std::string &name, bool value);
   bool SetBoolean(const std::string &block, const std::string &name, bool value);

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -156,10 +156,10 @@ void ParthenonManager::ParthenonInitPackagesAndMesh() {
 
     // Read simulation time and cycle from restart file and set in input
     Real tNow = restartReader->GetAttr<Real>("Info", "Time");
-    pinput->SetPrecise("parthenon/time", "start_time", tNow);
+    pinput->SetReal("parthenon/time", "start_time", tNow);
 
     Real dt = restartReader->GetAttr<Real>("Info", "dt");
-    pinput->SetPrecise("parthenon/time", "dt", dt);
+    pinput->SetReal("parthenon/time", "dt", dt);
 
     int ncycle = restartReader->GetAttr<int>("Info", "NCycle");
     pinput->SetInteger("parthenon/time", "ncycle", ncycle);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

`ParameterInput::SetReal` only stores a floating point representation of the `Real` type; while we do provide a `SetPrecise` function which stores the full `Real`, given that I just got tripped up by this and I don't right now see a use case for storing `Real`s as `float`s, I just removed `SetPrecise`. 

If we want to keep the original behavior, I would advocate that we rename `SetReal` to the more descriptive `SetRealAsFloat` and `SetPrecise` to `SetReal`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
