### PR TITLE
Remove broken swarm user boundary check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 586]](https://github.com/lanl/parthenon/pull/586) Implement true sparse capability with automatic allocation and deallocation of sparse
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 676]](https://github.com/lanl/parthenon/pull/662) Remove broken swarm user boundary check
 - [[PR 662]](https://github.com/lanl/parthenon/pull/662) Remove SetPrecise
 - [[PR 673]](https://github.com/lanl/parthenon/pull/673) Remove smallest meshblock case from advection_performance
 - [[PR 655]](https://github.com/lanl/parthenon/pull/655) Enable user boundary conditions for particles

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -967,6 +967,8 @@ void Mesh::EnrollBndryFncts_(ApplicationInput *app_in) {
     switch (mesh_bcs[f]) {
     case BoundaryFlag::user:
       if (app_in->swarm_boundary_conditions[f] != nullptr) {
+        // This is checked to be non-null later in Swarm::AllocateBoundaries, in case user
+        // boundaries are requested but no swarms are used.
         SwarmBndryFnctn[f] = app_in->swarm_boundary_conditions[f];
       }
       break;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -968,11 +968,6 @@ void Mesh::EnrollBndryFncts_(ApplicationInput *app_in) {
     case BoundaryFlag::user:
       if (app_in->swarm_boundary_conditions[f] != nullptr) {
         SwarmBndryFnctn[f] = app_in->swarm_boundary_conditions[f];
-      } else {
-        std::stringstream msg;
-        msg << "A user boundary condition for face " << f
-            << " was requested, but no swarm condition was enrolled." << std::endl;
-        PARTHENON_THROW(msg);
       }
       break;
     default: // Default BCs handled elsewhere


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

@pgrete noticed that I recently introduced a bug where, if `user` boundary conditions were requested, `parthenon` required that a `Swarm` user boundary condition be provided even for applications that contain no particles. This small PR removes that broken check, which was actually unnecessary since the boundary condition existence is checked by the `Swarm` itself during setup in `Swarm::AllocateBoundaries`. 

Fixes #675 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
