### PR TITLE
Fix restart without `SparseInfo` object. Fixes #648

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 677]](https://github.com/lanl/partheon/pull/677) Fix restart without `SparseInfo` object
 - [[PR 670]](https://github.com/lanl/partheon/pull/670) Fix typo in `parse_value` for non-hdf5 builds
 - [[PR 656]](https://github.com/lanl/partheon/pull/656) Extend CC bvars to 5-, 6-D ParArrays
 - [[PR 629]](https://github.com/lanl/parthenon/pull/629) Fix HIP backend (config and tests) and extend build coverage

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -59,7 +59,7 @@ RestartReader::SparseInfo RestartReader::GetSparseInfo() const {
 
   // check if SparseInfo exists, if not, return the default-constructed SparseInfo
   // instance
-  auto status = PARTHENON_HDF5_CHECK(H5Oexists_by_name(fh_, "SparseInfo", H5P_DEFAULT));
+  auto status = PARTHENON_HDF5_CHECK(H5Lexists(fh_, "SparseInfo", H5P_DEFAULT));
   if (status > 0) {
     // SparseInfo exists, read its contents
     auto hdl = OpenDataset<bool>("SparseInfo");


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Background:

`H5Oexists_by_name`" verifies only that the target object exists. If name includes either a relative path or an absolute path to the target link, intermediate steps along the path must be verified before the existence of the target link can be safely checked", see https://docs.hdfgroup.org/hdf5/develop/group___h5_o.html#title16
With [H5Lexists()](https://docs.hdfgroup.org/hdf5/develop/group___h5_l.html#ga171be6e41dc1a464edc402df0ebdf801) we can check if the link exits (independent of whether it's an object, etc.).
We're only interested in the latter ("do we have a `SparseInfo` entry or not), so I decided to just to this check and not continue with additional checks on what's behind the "link"

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
