### PR TITLE
Fix FlatIdx packing for size-1 dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 678]](https://github.com/lanl/partheon/pull/678) Fix FlatIdx packing for size-1 dimensions
 - [[PR 677]](https://github.com/lanl/partheon/pull/677) Fix restart without `SparseInfo` object
 - [[PR 670]](https://github.com/lanl/partheon/pull/670) Fix typo in `parse_value` for non-hdf5 builds
 - [[PR 656]](https://github.com/lanl/partheon/pull/656) Extend CC bvars to 5-, 6-D ParArrays

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -487,9 +487,10 @@ void AppendSparseBaseMap(const CellVariableVector<T> &vars, PackIndexMap *pvmap)
       int sparse_id = v->GetSparseID();
       if (sparse_id != InvalidSparseID) {
         std::vector<int> shape;
-        if (v->GetDim(4) > 1) shape.push_back(v->GetDim(4));
-        if (v->GetDim(5) > 1) shape.push_back(v->GetDim(5));
-        if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
+        auto mshape = v->metadata().Shape();
+        if (mshape.size() > 0) shape.push_back(v->GetDim(4));
+        if (mshape.size() > 1) shape.push_back(v->GetDim(5));
+        if (mshape.size() > 2) shape.push_back(v->GetDim(6));
         auto &pair = pvmap->get(v->label());
         start = pair.first;
         stop = pair.second;
@@ -552,9 +553,10 @@ void FillVarView(const CellVariableVector<T> &vars, bool coarse,
     }
 
     std::vector<int> shape;
-    if (v->GetDim(4) > 1) shape.push_back(v->GetDim(4));
-    if (v->GetDim(5) > 1) shape.push_back(v->GetDim(5));
-    if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
+    auto mshape = v->metadata().Shape();
+    if (mshape.size() > 0) shape.push_back(v->GetDim(4));
+    if (mshape.size() > 1) shape.push_back(v->GetDim(5));
+    if (mshape.size() > 2) shape.push_back(v->GetDim(6));
 
     if (pvmap != nullptr) {
       pvmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);
@@ -629,9 +631,10 @@ void FillFluxViews(const CellVariableVector<T> &vars, const int ndim,
     }
 
     std::vector<int> shape;
-    if (v->GetDim(4) > 1) shape.push_back(v->GetDim(4));
-    if (v->GetDim(5) > 1) shape.push_back(v->GetDim(5));
-    if (v->GetDim(6) > 1) shape.push_back(v->GetDim(6));
+    auto mshape = v->metadata().Shape();
+    if (mshape.size() > 0) shape.push_back(v->GetDim(4));
+    if (mshape.size() > 1) shape.push_back(v->GetDim(5));
+    if (mshape.size() > 2) shape.push_back(v->GetDim(6));
 
     if (pvmap != nullptr) {
       pvmap->insert(v->label(), IndexPair(vstart, vindex - 1), shape);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

`FlatIdx`s were incorrectly packing higher-dimensional variables when one of the higher dimensions was size 1. This PR changes the relevant `shape` calculation to use the relevant `Metadata`'s `shape_` rather than relying on whether `v->GetDim(4-6)` is greater than `1`.  

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
