### PR TITLE
Handle case of multidim var labeling for output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 679]](https://github.com/lanl/parthenon/pull/679) Handle case of multidim var labeling for output
 - [[PR 678]](https://github.com/lanl/partheon/pull/678) Fix FlatIdx packing for size-1 dimensions
 - [[PR 677]](https://github.com/lanl/partheon/pull/677) Fix restart without `SparseInfo` object
 - [[PR 670]](https://github.com/lanl/partheon/pull/670) Fix typo in `parse_value` for non-hdf5 builds

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -31,6 +31,21 @@ CellVariable<T>::CellVariable(const std::string &base_name, const Metadata &meta
                               int sparse_id, std::weak_ptr<MeshBlock> wpmb)
     : m_(metadata), base_name_(base_name), sparse_id_(sparse_id),
       dims_(m_.GetArrayDims(wpmb, false)), coarse_dims_(m_.GetArrayDims(wpmb, true)) {
+        if (base_name == "one_minus_sqrt_one_minus_advected_sq") {
+        printf("%s:%i\n", __FILE__, __LINE__);
+        printf("base_name: %s\n", base_name.c_str());
+        printf("sparse_id: %i\n", sparse_id);
+        auto labels = metadata.getComponentLabels();
+        printf("labels size: %i\n", labels.size());
+        for (auto label : labels) {
+          printf("  %s\n", label.c_str());
+        }
+        auto shape = metadata.Shape();
+        printf("shape size: %i\n", shape.size());
+        for (auto num : shape) {
+          printf("  %i\n", num);
+        }
+        }
   PARTHENON_REQUIRE_THROWS(m_.IsSet(Metadata::Real),
                            "Only Real data type is currently supported for CellVariable");
 

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -31,21 +31,6 @@ CellVariable<T>::CellVariable(const std::string &base_name, const Metadata &meta
                               int sparse_id, std::weak_ptr<MeshBlock> wpmb)
     : m_(metadata), base_name_(base_name), sparse_id_(sparse_id),
       dims_(m_.GetArrayDims(wpmb, false)), coarse_dims_(m_.GetArrayDims(wpmb, true)) {
-        if (base_name == "one_minus_sqrt_one_minus_advected_sq") {
-        printf("%s:%i\n", __FILE__, __LINE__);
-        printf("base_name: %s\n", base_name.c_str());
-        printf("sparse_id: %i\n", sparse_id);
-        auto labels = metadata.getComponentLabels();
-        printf("labels size: %i\n", labels.size());
-        for (auto label : labels) {
-          printf("  %s\n", label.c_str());
-        }
-        auto shape = metadata.Shape();
-        printf("shape size: %i\n", shape.size());
-        for (auto num : shape) {
-          printf("  %i\n", num);
-        }
-        }
   PARTHENON_REQUIRE_THROWS(m_.IsSet(Metadata::Real),
                            "Only Real data type is currently supported for CellVariable");
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -170,6 +170,7 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
     // we only make one entry, because either vlen == 1, or we write this as a vector
     names.push_back(name);
   } else {
+    nentries = vlen;
     for (int i = 0; i < vlen; i++) {
       names.push_back(component_labels[i]);
     }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -106,7 +106,8 @@ struct VarInfo {
       PARTHENON_FAIL(msg);
     }
 
-    component_labels = {} for (int i = 0; i < vlen; i++) {
+    component_labels = {};
+    for (int i = 0; i < vlen; i++) {
       component_labels.push_back(
           label + "_" +
           (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -85,28 +85,31 @@ using namespace HDF5;
 // Helper struct containing some information about a variable
 struct VarInfo {
   std::string label;
-  std::vector<std::string> component_labels;
   int vlen;
   int nx6;
   int nx5;
   int nx4;
   bool is_sparse;
   bool is_vector;
+  std::vector<std::string> component_labels;
 
   VarInfo() = delete;
 
-  VarInfo(const std::string &label, const std::vector<std::string> &component_labels,
+  VarInfo(const std::string &label, const std::vector<std::string> &component_labels_,
           int vlen, int nx6, int nx5, int nx4, bool is_sparse, bool is_vector)
-      : label(label),
-        component_labels(component_labels.size() > 0 ? component_labels
-                                                     : std::vector<std::string>{label}),
-        vlen(vlen), nx6(nx6), nx5(nx5), nx4(nx4), is_sparse(is_sparse),
+      : label(label), vlen(vlen), nx6(nx6), nx5(nx5), nx4(nx4), is_sparse(is_sparse),
         is_vector(is_vector) {
     if (vlen <= 0) {
       std::stringstream msg;
       msg << "### ERROR: Got variable " << label << " with length " << vlen
           << ". vlen must be greater than 0" << std::endl;
       PARTHENON_FAIL(msg);
+    }
+
+    component_labels = {} for (int i = 0; i < vlen; i++) {
+      component_labels.push_back(
+          label + "_" +
+          (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));
     }
   }
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -119,8 +119,6 @@ struct VarInfo {
     if (vlen == 1 || is_vector) {
       component_labels.push_back(label);
     } else {
-      PARTHENON_DEBUG_REQUIRE(vlen == component_labels_.size(),
-                              "Component labels provided but in an incorrect amount!");
       for (int i = 0; i < vlen; i++) {
         component_labels.push_back(
             label + "_" +
@@ -168,8 +166,13 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
   // writes a slab reference to file
   std::vector<std::string> names;
   int nentries = 1;
-  for (int i = 0; i < vlen; i++) {
-    names.push_back(component_labels[i]);
+  if (vlen == 1 || isVector) {
+    // we only make one entry, because either vlen == 1, or we write this as a vector
+    names.push_back(name);
+  } else {
+    for (int i = 0; i < vlen; i++) {
+      names.push_back(component_labels[i]);
+    }
   }
   const int vector_size = isVector ? vlen : 1;
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -158,9 +158,7 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
   } else {
     nentries = vlen;
     for (int i = 0; i < vlen; i++) {
-      names.push_back(
-          name + "_" +
-          (component_labels.empty() ? std::to_string(i) : component_labels[i]));
+      names.push_back(component_labels[i]);
     }
   }
   const int vector_size = isVector ? vlen : 1;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -106,12 +106,41 @@ struct VarInfo {
       PARTHENON_FAIL(msg);
     }
 
+    printf("label: %s\n", label.c_str());
+    printf("vlen: %i\n", vlen);
+    printf("component_labels_.size() = %i\n", component_labels_.size());
+    for (auto &newlabel : component_labels_) {
+      printf("  %s\n", newlabel.c_str());
+    }
+
+    printf("NEW\n");
+    // Note that this logic does not subscript components without component_labels if there is only
+    // one component. Component names will be e.g.
+    //   my_scalar
+    // or
+    //   my_vector_0
+    //   my_vector_1
+    // Note that this means the subscript will be dropped for vector quantities if their Nx6, Nx5, Nx4
+    // are set to 1 at runtime.
     component_labels = {};
-    for (int i = 0; i < vlen; i++) {
+    if (component_labels.empty() && vlen == 1) {
+      component_labels.push_back(label);
+      printf("  %s\n", label.c_str());
+    } else {
+      PARTHENON_DEBUG_REQUIRE(vlen == component_labels_.size(), "Component labels provided but in an incorrect amount!");
+      for (int i = 0; i < vlen; i++) {
+        component_labels.push_back(
+            label + "_" +
+            (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));
+      printf("  %s\n", (label + "_" +                                                                              (component_labels_.empty() ? std::to_string(i) : component_labels_[i])).c_str());
+      }
+    }
+    /*for (int i = 0; i < vlen; i++) {
       component_labels.push_back(
           label + "_" +
           (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));
-    }
+      printf("  %s\n", (label + "_" +                                                                              (component_labels_.empty() ? std::to_string(i) : component_labels_[i])).c_str());
+    }*/
   }
 
   explicit VarInfo(const std::shared_ptr<CellVariable<Real>> &var)
@@ -160,6 +189,7 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
     nentries = vlen;
     for (int i = 0; i < vlen; i++) {
       names.push_back(component_labels[i]);
+      printf("names: %s\n", component_labels[i].c_str());
     }
   }
   const int vector_size = isVector ? vlen : 1;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -106,43 +106,27 @@ struct VarInfo {
       PARTHENON_FAIL(msg);
     }
 
-    printf("label: %s\n", label.c_str());
-    printf("vlen: %i\n", vlen);
-    printf("component_labels_.size() = %i\n", component_labels_.size());
-    for (auto &newlabel : component_labels_) {
-      printf("  %s\n", newlabel.c_str());
-    }
-    printf("is_vector: %i\n", is_vector);
-
-    printf("NEW\n");
-    // Note that this logic does not subscript components without component_labels if there is only
-    // one component. Component names will be e.g.
+    // Note that this logic does not subscript components without component_labels if
+    // there is only one component. Component names will be e.g.
     //   my_scalar
     // or
-    //   my_vector_0
-    //   my_vector_1
-    // Note that this means the subscript will be dropped for vector quantities if their Nx6, Nx5, Nx4
-    // are set to 1 at runtime.
+    //   my_non-vector_set_0
+    //   my_non-vector_set_1
+    // Note that this means the subscript will be dropped for multidim quantities if their
+    // Nx6, Nx5, Nx4 are set to 1 at runtime e.g.
+    //   my_non-vector_set
     component_labels = {};
-    //if (component_labels.empty() && vlen == 1) {
     if (vlen == 1 || is_vector) {
       component_labels.push_back(label);
-      printf("  %s\n", label.c_str());
     } else {
-      PARTHENON_DEBUG_REQUIRE(vlen == component_labels_.size(), "Component labels provided but in an incorrect amount!");
+      PARTHENON_DEBUG_REQUIRE(vlen == component_labels_.size(),
+                              "Component labels provided but in an incorrect amount!");
       for (int i = 0; i < vlen; i++) {
         component_labels.push_back(
             label + "_" +
             (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));
-      printf("  %s\n", (label + "_" +                                                                              (component_labels_.empty() ? std::to_string(i) : component_labels_[i])).c_str());
       }
     }
-    /*for (int i = 0; i < vlen; i++) {
-      component_labels.push_back(
-          label + "_" +
-          (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));
-      printf("  %s\n", (label + "_" +                                                                              (component_labels_.empty() ? std::to_string(i) : component_labels_[i])).c_str());
-    }*/
   }
 
   explicit VarInfo(const std::shared_ptr<CellVariable<Real>> &var)
@@ -184,19 +168,8 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
   // writes a slab reference to file
   std::vector<std::string> names;
   int nentries = 1;
-  /*if (vlen == 1 || isVector) {
-    // we only make one entry, because either vlen == 1, or we write this as a vector
-    names.push_back(name);
-  } else {
-    nentries = vlen;
-    for (int i = 0; i < vlen; i++) {
-      names.push_back(component_labels[i]);
-      printf("names: %s\n", component_labels[i].c_str());
-    }
-  }*/
   for (int i = 0; i < vlen; i++) {
     names.push_back(component_labels[i]);
-    printf("names: %s\n", component_labels[i].c_str());
   }
   const int vector_size = isVector ? vlen : 1;
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -112,6 +112,7 @@ struct VarInfo {
     for (auto &newlabel : component_labels_) {
       printf("  %s\n", newlabel.c_str());
     }
+    printf("is_vector: %i\n", is_vector);
 
     printf("NEW\n");
     // Note that this logic does not subscript components without component_labels if there is only
@@ -123,7 +124,8 @@ struct VarInfo {
     // Note that this means the subscript will be dropped for vector quantities if their Nx6, Nx5, Nx4
     // are set to 1 at runtime.
     component_labels = {};
-    if (component_labels.empty() && vlen == 1) {
+    //if (component_labels.empty() && vlen == 1) {
+    if (vlen == 1 || is_vector) {
       component_labels.push_back(label);
       printf("  %s\n", label.c_str());
     } else {
@@ -182,7 +184,7 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
   // writes a slab reference to file
   std::vector<std::string> names;
   int nentries = 1;
-  if (vlen == 1 || isVector) {
+  /*if (vlen == 1 || isVector) {
     // we only make one entry, because either vlen == 1, or we write this as a vector
     names.push_back(name);
   } else {
@@ -191,6 +193,10 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
       names.push_back(component_labels[i]);
       printf("names: %s\n", component_labels[i].c_str());
     }
+  }*/
+  for (int i = 0; i < vlen; i++) {
+    names.push_back(component_labels[i]);
+    printf("names: %s\n", component_labels[i].c_str());
   }
   const int vector_size = isVector ? vlen : 1;
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -117,7 +117,8 @@ struct VarInfo {
     //   my_non-vector_set
     component_labels = {};
     if (vlen == 1 || is_vector) {
-      component_labels.push_back(label);
+      component_labels = component_labels_.size() > 0 ? component_labels_
+                                                      : std::vector<std::string>({label});
     } else {
       for (int i = 0; i < vlen; i++) {
         component_labels.push_back(


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

For greater-than-scalar cell variables without `component_label` arrays, parthenon's xdmf output was creating a one-element `component_label` array out of the variable `label` in the `VarInfo` constructor. This PR moves the logic in `writeXdmfSlabVariableRef` that autogenerates indexed `component_label` names into the `VarInfo` constructor. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
