### PR TITLE
Fix hanging compilation for sort unit test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 680]](https://github.com/lanl/partheon/pull/680) Fix hanging compilation for sort unit test
 - [[PR 678]](https://github.com/lanl/partheon/pull/678) Fix FlatIdx packing for size-1 dimensions
 - [[PR 677]](https://github.com/lanl/partheon/pull/677) Fix restart without `SparseInfo` object
 - [[PR 670]](https://github.com/lanl/partheon/pull/670) Fix typo in `parse_value` for non-hdf5 builds

--- a/src/utils/sort.hpp
+++ b/src/utils/sort.hpp
@@ -34,10 +34,8 @@ namespace parthenon {
 template <class Key, class KeyComparator>
 void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx,
           size_t max_idx) {
-  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0),
-                          "Invalid minimum sort index!");
-  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0),
-                          "Invalid maximum sort index!");
+  PARTHENON_DEBUG_REQUIRE(min_idx < data.extent(0), "Invalid minimum sort index!");
+  PARTHENON_DEBUG_REQUIRE(max_idx < data.extent(0), "Invalid maximum sort index!");
 #ifdef KOKKOS_ENABLE_CUDA
 #ifdef __clang__
   PARTHENON_FAIL("sort is using thrust and there exists an incompatibility with clang, "
@@ -64,10 +62,8 @@ void sort(ParArray1D<Key> data, KeyComparator comparator, size_t min_idx,
 
 template <class Key>
 void sort(ParArray1D<Key> data, size_t min_idx, size_t max_idx) {
-  PARTHENON_DEBUG_REQUIRE(min_idx >= 0 && min_idx < data.extent(0),
-                          "Invalid minimum sort index!");
-  PARTHENON_DEBUG_REQUIRE(max_idx >= 0 && max_idx < data.extent(0),
-                          "Invalid maximum sort index!");
+  PARTHENON_DEBUG_REQUIRE(min_idx < data.extent(0), "Invalid minimum sort index!");
+  PARTHENON_DEBUG_REQUIRE(max_idx < data.extent(0), "Invalid maximum sort index!");
 #ifdef KOKKOS_ENABLE_CUDA
 #ifdef __clang__
   PARTHENON_FAIL("sort is using thrust and there exists an incompatibility with clang, "

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -28,7 +28,6 @@ using parthenon::ParArray1D;
 using parthenon::sort;
 
 constexpr int N = 100;
-constexpr int STRLEN = 1024;
 
 struct Key {
   KOKKOS_INLINE_FUNCTION

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2021-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/unit/test_unit_sort.cpp
+++ b/tst/unit/test_unit_sort.cpp
@@ -34,14 +34,10 @@ struct Key {
   KOKKOS_INLINE_FUNCTION
   Key() {}
   KOKKOS_INLINE_FUNCTION
-  Key(const int key, const char value[STRLEN]) : key_(key) {
-    for (int n = 0; n < STRLEN; n++) {
-      value_[n] = value[n];
-    }
-  }
+  Key(const int key, const int value) : key_(key), value_(value) {}
 
   int key_;
-  char value_[STRLEN];
+  int value_;
 };
 struct KeyComparator {
   KOKKOS_INLINE_FUNCTION
@@ -75,15 +71,15 @@ TEST_CASE("Sorting", "[sort]") {
         parthenon::loop_pattern_flatrange_tag, "initial data", parthenon::DevExecSpace(),
         0, 5 - 1, KOKKOS_LAMBDA(const int n) {
           if (n == 0) {
-            data(n) = Key(5, "test.");
+            data(n) = Key(5, 5);
           } else if (n == 1) {
-            data(n) = Key(4, "a");
+            data(n) = Key(4, 4);
           } else if (n == 3) {
-            data(n) = Key(3, "is");
+            data(n) = Key(3, 3);
           } else if (n == 2) {
-            data(n) = Key(2, "sentence");
+            data(n) = Key(2, 2);
           } else if (n == 4) {
-            data(n) = Key(1, "This");
+            data(n) = Key(1, 1);
           }
         });
 
@@ -92,11 +88,11 @@ TEST_CASE("Sorting", "[sort]") {
     auto data_h = Kokkos::create_mirror_view(data);
     Kokkos::deep_copy(data_h, data);
 
-    REQUIRE(data_h(0).value_ == std::string("This"));
-    REQUIRE(data_h(1).value_ == std::string("sentence"));
-    REQUIRE(data_h(2).value_ == std::string("is"));
-    REQUIRE(data_h(3).value_ == std::string("a"));
-    REQUIRE(data_h(4).value_ == std::string("test."));
+    REQUIRE(data_h(0).value_ == 1);
+    REQUIRE(data_h(1).value_ == 2);
+    REQUIRE(data_h(2).value_ == 3);
+    REQUIRE(data_h(3).value_ == 4);
+    REQUIRE(data_h(4).value_ == 5);
   }
 #endif // !defined(KOKKOS_ENABLE_HIP)
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Compilation of `test_unit_sort.cpp` hangs on some platforms (see #672). Switching the value in the key-value pair for this test from `char[STRLEN]` to `int` resolves this issue for me on the power9 archiecture when compiling with CUDA. The test still tests the same behavior.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
