### PR TITLE
Add `*pmb` to `MeshBlockUserWorkBeforeOutput`. Remove unused `MeshBlockUserWorkInLoop`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR 586]](https://github.com/lanl/parthenon/pull/586) Implement true sparse capability with automatic allocation and deallocation of sparse
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 685]](https://github.com/lanl/parthenon/pull/685) Add `*pmb` to `MeshBlockUserWorkBeforeOutput`. Remove unused `MeshBlockUserWorkInLoop`.
 - [[PR 676]](https://github.com/lanl/parthenon/pull/662) Remove broken swarm user boundary check
 - [[PR 662]](https://github.com/lanl/parthenon/pull/662) Remove SetPrecise
 - [[PR 673]](https://github.com/lanl/parthenon/pull/673) Remove smallest meshblock case from advection_performance

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,14 +108,14 @@ be redefined by an application. Currently, these functions are, by class:
 
 #### Mesh
 * `InitUserMeshData`
-* `MeshUserWorkInLoop`
+* `PreStepUserWorkInLoop`
+* `PostStepUserWorkInLoop`
 * `UserWorkAfterLoop`
 
 #### MeshBlock
 * `InitApplicationMeshBlockData`
 * `InitMeshBlockUserData`
 * `ProblemGenerator`
-* `MeshBlockUserWorkInLoop`
 * `UserWorkBeforeOutput`
 
 To redefine these functions, the user sets the respective function pointers in the

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -54,8 +54,8 @@ struct ApplicationInput {
       InitApplicationMeshBlockData = nullptr;
   std::function<void(MeshBlock *, ParameterInput *)> InitMeshBlockUserData = nullptr;
   std::function<void(MeshBlock *, ParameterInput *)> ProblemGenerator = nullptr;
-  std::function<void()> MeshBlockUserWorkInLoop = nullptr;
-  std::function<void(ParameterInput *)> UserWorkBeforeOutput = nullptr;
+  std::function<void(MeshBlock *, ParameterInput *)> MeshBlockUserWorkBeforeOutput =
+      nullptr;
 };
 
 } // namespace parthenon

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1018,7 +1018,7 @@ void Mesh::EnrollUserMeshGenerator(CoordinateDirection dir, MeshGenFunc my_mg) {
 
 void Mesh::ApplyUserWorkBeforeOutput(ParameterInput *pin) {
   for (auto &pmb : block_list) {
-    pmb->UserWorkBeforeOutput(pin);
+    pmb->UserWorkBeforeOutput(pmb.get(), pin);
   }
 }
 

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -111,11 +111,8 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   if (app_in->ProblemGenerator != nullptr) {
     ProblemGenerator = app_in->ProblemGenerator;
   }
-  if (app_in->MeshBlockUserWorkInLoop != nullptr) {
-    UserWorkInLoop = app_in->MeshBlockUserWorkInLoop;
-  }
-  if (app_in->UserWorkBeforeOutput != nullptr) {
-    UserWorkBeforeOutput = app_in->UserWorkBeforeOutput;
+  if (app_in->MeshBlockUserWorkBeforeOutput != nullptr) {
+    UserWorkBeforeOutput = app_in->MeshBlockUserWorkBeforeOutput;
   }
 
   // (probably don't need to preallocate space for references in these vectors)

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -264,11 +264,10 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   static void
-  UserWorkBeforeOutputDefault(ParameterInput *pin); // called in Mesh fn (friend class)
-  std::function<void(ParameterInput *)> UserWorkBeforeOutput =
+  UserWorkBeforeOutputDefault(MeshBlock *pmb,
+                              ParameterInput *pin); // called in Mesh fn (friend class)
+  std::function<void(MeshBlock *, ParameterInput *)> UserWorkBeforeOutput =
       &UserWorkBeforeOutputDefault;
-  static void UserWorkInLoopDefault(); // called in TimeIntegratorTaskList
-  std::function<void()> UserWorkInLoop = &UserWorkInLoopDefault;
   void SetBlockTimestep(const Real dt) { new_block_dt_ = dt; }
   void SetAllowedDt(const Real dt) { new_block_dt_ = dt; }
   Real NewDt() const { return new_block_dt_; }

--- a/src/pgen/default_pgen.cpp
+++ b/src/pgen/default_pgen.cpp
@@ -46,7 +46,9 @@ void Mesh::InitUserMeshDataDefault(Mesh *, ParameterInput *) {
 
 //========================================================================================
 //! \fn void Mesh::UserWorkInLoopDefault()
-//  \brief Function called once every time step for user-defined work.
+//  \brief Dummy function that is set by default as PreStepMeshUserWorkInLoop and
+//  PostStepMeshUserWorkInLoop. One should set the latter separately (or only one) instead
+//  of redefining this function.
 //========================================================================================
 
 void Mesh::UserWorkInLoopDefault(Mesh *, ParameterInput *, SimTime const &) {
@@ -119,21 +121,11 @@ void MeshBlock::ProblemGeneratorDefault(MeshBlock *pmb, ParameterInput *pin) {
 }
 
 //========================================================================================
-//! \fn void MeshBlock::UserWorkInLoopDefault()
-//  \brief Function called once every time step for user-defined work.
-//========================================================================================
-
-void MeshBlock::UserWorkInLoopDefault() {
-  // do nothing
-  return;
-}
-
-//========================================================================================
-//! \fn void MeshBlock::UserWorkBeforeOutputDefault(ParameterInput *pin)
+//! \fn void MeshBlock::UserWorkBeforeOutputDefault(MeshBlock *pmb, ParameterInput *pin)
 //  \brief Function called before generating output files
 //========================================================================================
 
-void MeshBlock::UserWorkBeforeOutputDefault(ParameterInput *pin) {
+void MeshBlock::UserWorkBeforeOutputDefault(MeshBlock *pmb, ParameterInput *pin) {
   // do nothing
   return;
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`MeshBlockUserWorkBeforeOutput` didn't have a `*pmb` which required this function to actually be defined as `MeshBlock::UserWorkBeforeOutput` and, thus, preventing it from being defined in a separate (e.g., pgen specific) namespace.
All other callback functions already contained a `*pmb` (or `*pmesh`) so this is just in line with existing changes.

I also fixed the documentation for `MeshWorkInLoop` and removed the `MeshBlockUserWorkInLoop` which didn't exist anymore in the current driver design (leftover of original Athena++ code).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
