### PR TITLE
Remove coverage CI stage and add key features to README

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ variables:
 stages:
   - short
   - performance_and_regression
-  - coverage
   - style
 
 style-check:
@@ -243,26 +242,4 @@ parthenon-cpu-performance_and_regression-mpi:
       - build-perf-mpi/CMakeFiles/CMakeOutput.log
       - build-perf-mpi/tst/regression/outputs/advection_convergence_mpi/advection-errors.dat
       - build-perf-mpi/tst/regression/outputs/advection_convergence_mpi/advection-errors.png
-
-# run unit suite on CPUs with code coverage
-parthenon-cpu-coverage:
-  only:
-    - schedules
-    - develop
-    - web
-  tags:
-    - cpu
-  stage: coverage
-  script:
-    - mkdir build-debug-coverage
-    - cd build-debug-coverage
-    - cmake -DCMAKE_BUILD_TYPE=Debug
-      -DCODE_COVERAGE=ON
-      -DMACHINE_VARIANT=mpi
-      ../ && make -j${J} && make coverage && make coverage-upload
-  artifacts:
-    when: always
-    expire_in: 3 days
-    paths:
-      - build-debug-coverage/CMakeFiles/CMakeOutput.log
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 686]](https://github.com/lanl/parthenon/pull/686) Remove coverage CI stage and add key features to README
 - [[PR 669]](https://github.com/lanl/parthenon/pull/669) Bump clang-format version (and checks) to >=11.0
 - [[PR 661]](https://github.com/lanl/parthenon/pull/661) Replaced ids in MPI tags with separate `MPI_Comms` for each variable/swarm
 - [[PR 651]](https://github.com/lanl/parthenon/pull/651) Bump Catch2 version due to GCC11.2 incompatibility

--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# parthenon
+# Parthenon
 
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/3c7f326d05b34929a847657a9674f524)](https://app.codacy.com/gh/lanl/parthenon?utm_source=github.com&utm_medium=referral&utm_content=lanl/parthenon&utm_campaign=Badge_Grade)
-[![deepcode](https://www.deepcode.ai/api/gh/badge?key=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJwbGF0Zm9ybTEiOiJnaCIsIm93bmVyMSI6ImxhbmwiLCJyZXBvMSI6InBhcnRoZW5vbiIsImluY2x1ZGVMaW50IjpmYWxzZSwiYXV0aG9ySWQiOjE2MzAxLCJpYXQiOjE2MjM5NjA4Njh9.7W8akiFnSjPx7tPq5Ra6NqnJUOLq0sKnwaHEpD0_YH0)](https://www.deepcode.ai/app/gh/lanl/parthenon/_/dashboard?utm_content=gh%2Flanl%2Fparthenon)
-[![codecov](https://codecov.io/gh/lanl/parthenon/branch/master/graph/badge.svg)](https://codecov.io/gh/lanl/parthenon)
 [![testing](https://gitlab.com/theias/hpc/jmstone/athena-parthenon/parthenon-ci-mirror/badges/develop/pipeline.svg)](https://gitlab.com/theias/hpc/jmstone/athena-parthenon/parthenon-ci-mirror/-/commits/develop)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Matrix chat](https://img.shields.io/matrix/parthenon-general:matrix.org)](https://app.element.io/#/room/#parthenon-general:matrix.org)
 
-Parthenon performance portable AMR framework
+Parthenon -- a performance portable block-structured adaptive mesh refinement framework
+
+# Key features
+
+* High performance by
+  * device first/device resident approach (work data only in device memory to prevent expensive transfers between host and device)
+  * transparent packing of data across blocks (to reduce/hide kernel launch latency)
+  * direct device-to-device communication via asynchronous, one-sided  MPI communication
+* Intermediate abstraction layer to hide complexity of device kernel launches
+* Flexible, plug-in package system
+* Abstract variables controlled via metadata flags
+* Support for particles
+* Multi-stage drivers/integrators with support for task-based parallelism
 
 # Community
 * [Chat room on matrix.org](https://app.element.io/#/room/#parthenon-general:matrix.org)
@@ -32,7 +42,7 @@ Parthenon performance portable AMR framework
 * numpy (for regression tests)
 * matplotlib (for regression tests)
 
-# Installation
+# Quick start guide
 
 For detailed instructions for a given system, see our [build doc](docs/building.md).
 
@@ -96,7 +106,7 @@ or to build for NVIDIA V100 GPUs (using `nvcc` compiler for GPU code, which is a
 or to build for AMD MI100 GPUs (using `hipcc` compiler)
 
     mkdir build-hip-mi100 && cd build-hip-mi100
-    cmake -DKokkos_ENABLE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DKokkos_ARCH_VOLTA70=ON ../
+    cmake -DKokkos_ENABLE_HIP=ON -DCMAKE_CXX_COMPILER=hipcc -DKokkos_ARCH_Vega908=ON ../
 
 # Developing/Contributing
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As discussed during the last call, this disabled the coverage stage that currently times out on the CI system.
I also added the key features of parthenon to the README.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
