### PR TITLE
Restore component labels for multicomponent non-vector field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [[PR 617]](https://github.com/lanl/parthenon/pull/617) Unify the coordinates API for MeshBlockPack and VariablePack
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 688]](https://github.com/lanl/parthenon/pull/688) Restore component labels for multicomponent non-vector field
 - [[PR 679]](https://github.com/lanl/parthenon/pull/679) Handle case of multidim var labeling for output
 - [[PR 680]](https://github.com/lanl/partheon/pull/680) Fix hanging compilation for sort unit test
 - [[PR 678]](https://github.com/lanl/partheon/pull/678) Fix FlatIdx packing for size-1 dimensions

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -115,15 +115,17 @@ struct VarInfo {
     // Note that this means the subscript will be dropped for multidim quantities if their
     // Nx6, Nx5, Nx4 are set to 1 at runtime e.g.
     //   my_non-vector_set
+    // Similarly, if component labels are given for all components, those will be used
+    // without the prefixed label.
     component_labels = {};
     if (vlen == 1 || is_vector) {
       component_labels = component_labels_.size() > 0 ? component_labels_
                                                       : std::vector<std::string>({label});
+    } else if (component_labels_.size() == vlen) {
+      component_labels = component_labels_;
     } else {
       for (int i = 0; i < vlen; i++) {
-        component_labels.push_back(
-            label + "_" +
-            (component_labels_.empty() ? std::to_string(i) : component_labels_[i]));
+        component_labels.push_back(label + "_" + std::to_string(i));
       }
     }
   }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes #684 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
