### PR TITLE
Add `Mesh::ProblemGenerator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 689]](https://github.com/lanl/parthenon/pull/689) Add `Mesh::ProblemGenerator` (allows reductions during init)
 - [[PR 667]](https://github.com/lanl/parthenon/pull/667) Add parallel scan
 - [[PR 654]](https://github.com/lanl/parthenon/pull/654) Add option for returning FlatIdx when requested variable doesn't exist
 - [[PR 653]](https://github.com/lanl/parthenon/pull/653) Allow for multi-D particle variables

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,6 +109,7 @@ be redefined by an application. Currently, these functions are, by class:
 #### Mesh
 * `InitUserMeshData`
 * `MeshUserWorkInLoop`
+* `ProblemGenerator`
 * `UserWorkAfterLoop`
 
 #### MeshBlock
@@ -121,6 +122,15 @@ be redefined by an application. Currently, these functions are, by class:
 To redefine these functions, the user sets the respective function pointers in the
 ApplicationInput member app_input of the ParthenonManager class prior to calling
 `ParthenonInit`. This is demonstrated in the `main()` functions in the examples.
+
+Note that the `ProblemGenerator`s of `Mesh` and `MeshBlock` are mutually exclusive.
+Moreover, the `Mesh` one requires `parthenon/mesh/pack_size=-1` during initialization,
+i.e., all blocks on a rank need to be in a single pack.
+This allows to use MPI reductions inside the function, for example, to globally
+normalize quantities.
+The `parthenon/mesh/pack_size=-1` exists only during problem inititalization, i.e.,
+simulations can be restarted with an arbitrary `pack_size`.
+For an example of the `Mesh` version, see the [Poisson example](../example/poisson/parthenon_app_inputs.cpp).
 
 ### Error checking
 

--- a/example/poisson/main.cpp
+++ b/example/poisson/main.cpp
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
 
   // Redefine parthenon defaults
   pman.app_input->ProcessPackages = poisson_example::ProcessPackages;
-  pman.app_input->ProblemGenerator = poisson_example::ProblemGenerator;
+  pman.app_input->MeshProblemGenerator = poisson_example::ProblemGenerator;
 
   // call ParthenonInit to initialize MPI and Kokkos, parse the input deck, and set up
   auto manager_status = pman.ParthenonInit(argc, argv);

--- a/example/poisson/parthenon_app_inputs.cpp
+++ b/example/poisson/parthenon_app_inputs.cpp
@@ -30,8 +30,8 @@ using namespace parthenon;
 
 namespace poisson_example {
 
-void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
-  auto &data = pmb->meshblock_data.Get();
+void ProblemGenerator(Mesh *pm, ParameterInput *pin, MeshData<Real> *md) {
+  auto pmb = md->GetBlockData(0)->GetBlockPointer();
 
   Real x0 = pin->GetOrAddReal("poisson", "x0", 0.0);
   Real y0 = pin->GetOrAddReal("poisson", "y0", 0.0);
@@ -43,16 +43,17 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   IndexRange jb = cellbounds.GetBoundsJ(IndexDomain::entire);
   IndexRange kb = cellbounds.GetBoundsK(IndexDomain::entire);
 
-  auto coords = pmb->coords;
   PackIndexMap imap;
   const std::vector<std::string> vars({"density", "potential"});
-  const auto &q = data->PackVariables(vars, imap);
+  const auto &q_bpack = md->PackVariables(vars, imap);
   const int irho = imap["density"].first;
   const int iphi = imap["potential"].first;
 
   pmb->par_for(
-      "Poisson::ProblemGenerator", kb.s, kb.e, jb.s, jb.e, ib.s, ib.e,
-      KOKKOS_LAMBDA(const int k, const int j, const int i) {
+      "Poisson::ProblemGenerator", 0, q_bpack.GetDim(5) - 1, kb.s, kb.e, jb.s, jb.e, ib.s,
+      ib.e, KOKKOS_LAMBDA(const int b, const int k, const int j, const int i) {
+        const auto &coords = q_bpack.GetCoords(b);
+        auto &q = q_bpack(b);
         Real dist2 = std::pow(coords.x1v(i) - x0, 2) + std::pow(coords.x2v(j) - y0, 2) +
                      std::pow(coords.x3v(k) - z0, 2);
         if (dist2 < radius * radius) {

--- a/example/poisson/poisson_driver.hpp
+++ b/example/poisson/poisson_driver.hpp
@@ -52,7 +52,7 @@ class PoissonDriver : public Driver {
   // We reduce a view too, but it's stored as a param.
 };
 
-void ProblemGenerator(MeshBlock *pmb, parthenon::ParameterInput *pin);
+void ProblemGenerator(Mesh *pm, parthenon::ParameterInput *pin, MeshData<Real> *md);
 parthenon::Packages_t ProcessPackages(std::unique_ptr<parthenon::ParameterInput> &pin);
 
 } // namespace poisson_example

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -34,6 +34,8 @@ struct ApplicationInput {
 
   // Mesh functions
   std::function<void(Mesh *, ParameterInput *)> InitUserMeshData = nullptr;
+  std::function<void(Mesh *, ParameterInput *, MeshData<Real> *)> MeshProblemGenerator =
+      nullptr;
 
   std::function<void(Mesh *, ParameterInput *, SimTime &)> PreStepMeshUserWorkInLoop =
       nullptr;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -138,6 +138,8 @@ class Mesh {
   SBValFunc SwarmBndryFnctn[6];
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
+  std::function<void(Mesh *, ParameterInput *, MeshData<Real> *)> ProblemGenerator =
+      nullptr;
   static void UserWorkAfterLoopDefault(Mesh *mesh, ParameterInput *pin,
                                        SimTime &tm); // called in main loop
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop =

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -110,6 +110,9 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   }
   if (app_in->ProblemGenerator != nullptr) {
     ProblemGenerator = app_in->ProblemGenerator;
+    // Only set default block pgen when no mesh pgen is set
+  } else if (app_in->MeshProblemGenerator == nullptr) {
+    ProblemGenerator = &ProblemGeneratorDefault;
   }
   if (app_in->MeshBlockUserWorkInLoop != nullptr) {
     UserWorkInLoop = app_in->MeshBlockUserWorkInLoop;

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -259,8 +259,6 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
     pbval->SearchAndSetNeighbors(tree, ranklist, nslist);
   }
 
-  void ResetToIC() { ProblemGenerator(nullptr, nullptr); }
-
   // inform MeshBlock which arrays contained in member Field, Particles,
   // ... etc. classes are the "primary" representations of a quantity. when registered,
   // that data are used for (1) load balancing (2) (future) dumping to restart file
@@ -420,8 +418,7 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   static void ProblemGeneratorDefault(MeshBlock *pmb, ParameterInput *pin);
-  std::function<void(MeshBlock *, ParameterInput *)> ProblemGenerator =
-      &ProblemGeneratorDefault;
+  std::function<void(MeshBlock *, ParameterInput *)> ProblemGenerator = nullptr;
   static pMeshBlockApplicationData_t
   InitApplicationMeshBlockDataDefault(MeshBlock *, ParameterInput *pin);
   std::function<pMeshBlockApplicationData_t(MeshBlock *, ParameterInput *)>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

We talked about capabilities to do reduction during initialization and this seemed to me the least intrusive method.
No API change (the MeshBlock one is still the default one) so should not break downstream codes.
I also modified the poisson example to use the Mesh version and the test suite passes.

If people think this is not a good idea, I'm also open to alternatives.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
