### PR TITLE
Use power9 partition for Darwin CI

### DIFF
--- a/.gitlab-ci-darwin.yml
+++ b/.gitlab-ci-darwin.yml
@@ -67,7 +67,7 @@
 # is designed to test the performance we have opted for a release build.
 #
 variables:
-  SCHEDULER_PARAMETERS: '--nodes=1 --partition=power9-eap-ci'
+  SCHEDULER_PARAMETERS: '--nodes=1 --partition=power9'
   GIT_SUBMODULE_STRATEGY: recursive
   CMAKE_CXX_COMPILER: ${CI_PROJECT_DIR}/external/Kokkos/bin/nvcc_wrapper
   CMAKE_BUILD_TYPE: 'Release'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 690]](https://github.com/lanl/parthenon/pull/690) Use power9 partition for Darwin CI
 - [[PR 689]](https://github.com/lanl/parthenon/pull/689) Add `Mesh::ProblemGenerator` (allows reductions during init)
 - [[PR 667]](https://github.com/lanl/parthenon/pull/667) Add parallel scan
 - [[PR 654]](https://github.com/lanl/parthenon/pull/654) Add option for returning FlatIdx when requested variable doesn't exist


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`power9-eap-ci` is a computing resource on Darwin with access only for EAP devs, so for some Parthenon folks this Darwin CI will fail because they lack the required permissions. It's probably more appropriate to run this CI in the `power9` Darwin partition.

@jonahm-LANL @JoshuaSBrown 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
