### PR TITLE
Add concepts lite (small)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 694]](https://github.com/lanl/parthenon/pull/690) Add C++11 implementation of concepts lite
 - [[PR 690]](https://github.com/lanl/parthenon/pull/690) Use power9 partition for Darwin CI
 - [[PR 689]](https://github.com/lanl/parthenon/pull/689) Add `Mesh::ProblemGenerator` (allows reductions during init)
 - [[PR 667]](https://github.com/lanl/parthenon/pull/667) Add parallel scan

--- a/docs/concepts_lite.md
+++ b/docs/concepts_lite.md
@@ -1,0 +1,3 @@
+# C++11 Style Concepts Implementation 
+
+*This documentation needs to be written (see issue #695), but there are extensive comments in src/utlils/concepts_lite.hpp and examples of useage in tst/unit/test_concepts_lite.hpp*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -200,6 +200,7 @@ add_library(parthenon
   utils/buffer_utils.hpp
   utils/change_rundir.cpp
   utils/cleantypes.hpp
+  utils/concepts_lite.hpp
   utils/error_checking.hpp
   utils/error_checking.cpp
   utils/mpi_types.hpp

--- a/src/utils/concepts_lite.hpp
+++ b/src/utils/concepts_lite.hpp
@@ -1,0 +1,134 @@
+//========================================================================================
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef UTILS_CONCEPTS_LITE_HPP_
+#define UTILS_CONCEPTS_LITE_HPP_
+
+#include <type_traits>
+
+#define REQUIRES(...) typename std::enable_if<(__VA_ARGS__), int>::type = 0
+
+// This is a variadic template class that accepts any set of types
+// and is always equal to void as long as the types are well formed.
+// Although it seems simple, it is the basis of the SFINAE "void_t
+// trick" from Walter Brown. Probably just easiest to google it for
+// a better description than I can give, there are some nice talks
+// by Walter Brown about it on YouTube.
+
+template <class... Ts>
+using void_t = void;
+
+// implements is a template struct for checking if type T implements a particular
+// concept, which here simply means that it conforms to some interface.
+// (I think people call this concepts lite, since there are more
+// powerful things that concepts can do in C++20 and the compiler error
+// messages from this type of implementation can be kind of crazy). This cleaner
+// interface for using the void_t trick is partly inspired by Stackoverflow 26513095
+
+// General template that is accepted if the specialization below
+// is not well formed, inherits from false type so that implements<...>()
+// will return false. The default parameter for the second template argument
+// means that when you write implements<T>, the compiler inteprets this as
+// implements<T, void> and then looks to see if there is a specialization that
+// matches this pattern
+
+template <class T, class = void>
+struct implements : std::false_type {};
+
+// Specialization of implements that is chosen if all of the template
+// arguments to void_t are well formed, since in that case void_t = void
+// and this specialization matches the defined template pattern. Note that
+// pattern Concept(Ts...) is interpreted as a function taking types Ts...
+// and returning type Concept, but such a function doesn't get used for anything
+// we are doing. It is just a clean way of deducing multiple types from a single
+// input type Concept(Ts...) to the base template.
+
+template <class Concept, class... Ts>
+struct implements<Concept(Ts...), void_t<decltype(std::declval<Concept>().requires_(
+                                      std::declval<Ts>()...))>> : std::true_type {};
+
+//---------------------------
+// Various concepts are implemented below. The general useage of a
+// concept would be:
+//
+// template<class T, REQUIRES(implements<my_concept(T)>::value)>
+// void foo(T& in){ implementation when T conforms to my_concept}
+//
+// template<class T, REQUIRES(!implements<my_concept(T)>::value)>
+// void foo(T& in){ implementation when T doesn't conform to my_concept}
+//
+// Strangely, for some compilers, replacing implements<my_concept(T)>::value
+// with implements<my_concept(T)>() causes the code not to compile, so
+// we use value everywhere even though it is slightly more verbose.
+//---------------------------
+
+// Concept for a general container, not necessarily with
+// contiguous data storage
+struct container {
+  // requires_ should be well formed if the object T matches the
+  // concept of the struct (in this case a contiguous container).
+  // We just use void_t here since it is a variadic template that
+  // can accept any number of types and we don't care about the
+  // actual return type of requires_. Of course for it to be specialized,
+  // all of the type parameters should be well formed. Including
+  // the typename in front of the member type is important, since if
+  // it is not included T::value_type will not be interpreted as a
+  // type even if exists in T, void_t<...> will not be well formed
+  // since it only accepts types, the definition of requires_ will
+  // fail silently, implements<contiguous_container(T)> will always
+  // inherit from false_type (even if T is a contiguous container),
+  // and you will be left wondering what the hell is going on.
+  template <class T>
+  auto requires_(T &&x) -> void_t<decltype(x.size()), typename T::value_type>;
+};
+
+// Concept defining the interface of a container with continuous
+// storage. Also defines helper functions for treating single
+// objects as contiguous containers of size one
+struct contiguous_container {
+  template <class T>
+  auto requires_(T &&x)
+      -> void_t<decltype(x.size()), decltype(x.data()), typename T::value_type>;
+
+  // Below are helper functions and types for treating both
+  // contiguous containers and single objects as contiguous
+  // containers. Note that this should fail for objects that
+  // are containers but not contiguous_containers, since there
+  // isn't a (easy) way to treat them as contiguous
+  template <class T, REQUIRES(implements<contiguous_container(T)>::value)>
+  static std::size_t size(const T &x) {
+    return x.size();
+  }
+
+  template <class T, REQUIRES(!implements<container(T)>::value)>
+  static std::size_t size(const T &x) {
+    return 1;
+  }
+
+  template <class T, REQUIRES(implements<contiguous_container(T)>::value)>
+  static typename T::value_type *data(T &x) {
+    return x.data();
+  }
+
+  template <class T, REQUIRES(!implements<container(T)>::value)>
+  static T *data(T &x) {
+    return &x;
+  }
+
+  template <class T, REQUIRES(implements<contiguous_container(T)>::value)>
+  static typename T::value_type value_type(T &);
+
+  template <class T, REQUIRES(!implements<container(T)>::value)>
+  static T value_type(T &);
+};
+
+#endif // UTILS_CONCEPTS_LITE_HPP_

--- a/src/utils/concepts_lite.hpp
+++ b/src/utils/concepts_lite.hpp
@@ -75,7 +75,7 @@ struct implements<Concept(Ts...), void_t<decltype(std::declval<Concept>().requir
 // Concept for a general container, not necessarily with
 // contiguous data storage
 struct container {
-  // Every concept needs a requires_ method declaration, no 
+  // Every concept needs a requires_ method declaration, no
   // implementation of requires_ is necessary though.
   // requires_ should be well formed if the object T matches the
   // concept of the struct (in this case a contiguous container).

--- a/src/utils/concepts_lite.hpp
+++ b/src/utils/concepts_lite.hpp
@@ -15,6 +15,7 @@
 
 #include <type_traits>
 
+// This macro is just to make code more readable and self-explanatory
 #define REQUIRES(...) typename std::enable_if<(__VA_ARGS__), int>::type = 0
 
 // This is a variadic template class that accepts any set of types
@@ -74,6 +75,8 @@ struct implements<Concept(Ts...), void_t<decltype(std::declval<Concept>().requir
 // Concept for a general container, not necessarily with
 // contiguous data storage
 struct container {
+  // Every concept needs a requires_ method declaration, no 
+  // implementation of requires_ is necessary though.
   // requires_ should be well formed if the object T matches the
   // concept of the struct (in this case a contiguous container).
   // We just use void_t here since it is a variadic template that

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -17,6 +17,7 @@
 ##========================================================================================
 
 list(APPEND unit_tests_SOURCES
+    test_concepts_lite.cpp    
     test_data_collection.cpp
     test_taskid.cpp
     test_tasklist.cpp

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -38,10 +38,13 @@ bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, int size_in) {
 
 TEST_CASE("Check that the contiguous container concept works", "") {
   GIVEN("Some containers and some data") {
-    int SIZE = 10;
+    constexpr const int SIZE = 10;
     int val = 2;
 
     int my_int = val;
+    int my_c_array[SIZE];
+    for (int i = 0; i < SIZE; ++i)
+      my_c_array[i] = val;
     std::vector<int> my_vec(SIZE, val);
     // This should also work fine for objects defined on device, but
     // it is more work to write a generic function for checking values
@@ -58,6 +61,7 @@ TEST_CASE("Check that the contiguous container concept works", "") {
     }
 
     REQUIRE(SatisfiesContainerRequirements(my_int, val, 1));
+    REQUIRE(SatisfiesContainerRequirements(my_c_array, val, SIZE));
     REQUIRE(SatisfiesContainerRequirements(my_vec, val, SIZE));
     REQUIRE(SatisfiesContainerRequirements(my_view, val, SIZE));
     REQUIRE(SatisfiesContainerRequirements(my_pararr, val, SIZE));

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -29,7 +29,7 @@ bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, size_t size_in) {
   test = test && (size == size_in);
 
   // Check that we can access the data and they all have value val
-  int *pin = contiguous_container::data(in);
+  VAL_TYPE *pin = contiguous_container::data(in);
   for (auto i = 0; i < size; ++i)
     test = test && (val == pin[i]);
 

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -55,7 +55,11 @@ TEST_CASE("Check that the contiguous container concept works", "") {
     // interface
     parthenon::ParArray1D<int>::host_mirror_type my_pararr("Test", SIZE);
 
+    // We do not expect standard map to conform to contiguous_container
+    std::map<int, int> my_map;
+
     for (int i = 0; i < SIZE; ++i) {
+      my_map[i] = val;
       my_pararr(i) = val;
       my_view(i) = val;
     }
@@ -65,5 +69,9 @@ TEST_CASE("Check that the contiguous container concept works", "") {
     REQUIRE(SatisfiesContainerRequirements(my_vec, val, SIZE));
     REQUIRE(SatisfiesContainerRequirements(my_view, val, SIZE));
     REQUIRE(SatisfiesContainerRequirements(my_pararr, val, SIZE));
+    // Uncommenting the line below should cause compilation to fail
+    // since my_map should not work with the contiguous_container
+    // helper functions. When I have tested, it does cause a compilation failure (LFR).
+    // SatisfiesContainerRequirements(my_map, val, SIZE);
   }
 }

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -30,7 +30,7 @@ bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, int size_in) {
 
   // Check that we can access the data and they all have value val
   int *pin = contiguous_container::data(in);
-  for (int i = 0; i < size; ++i)
+  for (auto i = 0; i < size; ++i)
     test = test && (val == pin[i]);
 
   return test;

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -1,0 +1,65 @@
+//========================================================================================
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#include <type_traits>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include "kokkos_abstraction.hpp"
+#include "utils/concepts_lite.hpp"
+
+template <class T, class VAL_TYPE>
+bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, int size_in) {
+  // Check that the value_type of the container is what we would expect
+  using cont_val_type = decltype(contiguous_container::value_type(in));
+  bool test = std::is_same<cont_val_type, VAL_TYPE>::value;
+
+  int size = contiguous_container::size(in);
+  test = test && (size == size_in);
+
+  // Check that we can access the data and they all have value val
+  int *pin = contiguous_container::data(in);
+  for (int i = 0; i < size; ++i)
+    test = test && (val == pin[i]);
+
+  return test;
+}
+
+TEST_CASE("Check that the contiguous container concept works", "") {
+  GIVEN("Some containers and some data") {
+    int SIZE = 10;
+    int val = 2;
+
+    int my_int = val;
+    std::vector<int> my_vec(SIZE, val);
+    // This should also work fine for objects defined on device, but
+    // it is more work to write a generic function for checking values
+    // via pointer on device and on host
+    Kokkos::View<int *, parthenon::LayoutWrapper, parthenon::HostMemSpace> my_view("Test",
+                                                                                   SIZE);
+    // We expect that ParArrays should also conform to the contiguous_container
+    // interface
+    parthenon::ParArray1D<int>::host_mirror_type my_pararr("Test", SIZE);
+
+    for (int i = 0; i < SIZE; ++i) {
+      my_pararr(i) = val;
+      my_view(i) = val;
+    }
+
+    REQUIRE(SatisfiesContainerRequirements(my_int, val, 1));
+    REQUIRE(SatisfiesContainerRequirements(my_vec, val, SIZE));
+    REQUIRE(SatisfiesContainerRequirements(my_view, val, SIZE));
+    REQUIRE(SatisfiesContainerRequirements(my_pararr, val, SIZE));
+  }
+}

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -25,7 +25,7 @@ bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, int size_in) {
   using cont_val_type = decltype(contiguous_container::value_type(in));
   bool test = std::is_same<cont_val_type, VAL_TYPE>::value;
 
-  int size = contiguous_container::size(in);
+  size_t size = contiguous_container::size(in);
   test = test && (size == size_in);
 
   // Check that we can access the data and they all have value val

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -20,7 +20,7 @@
 #include "utils/concepts_lite.hpp"
 
 template <class T, class VAL_TYPE>
-bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, int size_in) {
+bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, size_t size_in) {
   // Check that the value_type of the container is what we would expect
   using cont_val_type = decltype(contiguous_container::value_type(in));
   bool test = std::is_same<cont_val_type, VAL_TYPE>::value;

--- a/tst/unit/test_concepts_lite.cpp
+++ b/tst/unit/test_concepts_lite.cpp
@@ -38,7 +38,7 @@ bool SatisfiesContainerRequirements(T &&in, VAL_TYPE val, size_t size_in) {
 
 TEST_CASE("Check that the contiguous container concept works", "") {
   GIVEN("Some containers and some data") {
-    constexpr const int SIZE = 10;
+    constexpr const size_t SIZE = 10;
     int val = 2;
 
     int my_int = val;


### PR DESCRIPTION
## PR Summary
Adds a relatively clean implementation of concepts to Parthenon as well as a test that the implementation is working. It is probably easiest to look at the comments in the code for the implementation and the test code for how to use it, but the general idea is that one would be able to write a function with different implementations depending on whether or not the input type implements a particular concept. For example:
```c++
template<class T, REQUIRES(implements<my_concept(T)>::value)>
void foo(T& in){ /*implementation when T conforms to my_concept*/ }

template<class T, REQUIRES(!implements<my_concept(T)>::value && implements<my_other_concept(T)>::value)>
void foo(T& in){ /*implementation when T conforms to my_other_concept but not my concept*/ }

template<class T, REQUIRES(!implements<my_concept(T)>::value && !implements<my_other_concept(T)>::value)>
void foo(T& in){ /*default implementation*/ }
```
where the correct implementation is chosen via SFINAE. 

The main impetus for this addition is that in a few places in the code there are templates that take a class that must conform to a particular concept. Most notably, the type passed to `parthenon::ReductionBase` must logically be a contiguous container to be used in MPI calls. A contiguous container essentially has to have methods `size()` and `data()`, and internal type `value_type` (`std::array`, `std::vector`, and `Kokkos::view` all conform to this concept and `ParthenonArray*` should conform to this) or be a type that just stores a single value (so that its size is always one and its `data()` pointer is just a pointer to itself). This was enforced in a way in `reductions.hpp` that broke when `ParArray*` was refactored in #681. Similarly, the `CommunicationBuffer` defined in #663 has to be templated on a type that conforms to the contiguous container concept. In addition to the general framework for concepts, this PR introduces a `contiguous_container` concept and some helper functions for generically getting the size of an object and data pointer of an object, whether it is a contiguous container or a single object (and which also fail to compile if they are passed a non-contiguous container).  

Concepts are of course more general than this, so I am guessing there will be other concepts that we want to define and use in other places in the code. For instance, there may be a way to define a concept that distinguishes between objects that correspond to a single block and objects that correspond to a list of blocks which may allow writing more generic code for dealing with `MeshData` vs `MeshBlockData`. 

This PR does not actually make any changes to the main code. I will make the necessary changes `reductions.hpp` and `communication_buffer.hpp` in #663 and #681 respectively after this PR is merged and before those two PRs are merged. 

## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] (@lanl.gov employees) Update copyright on changed files
