### PR TITLE
Do not require matplotlib 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 698]](https://github.com/lanl/parthenon/pull/698) Remove matplotlib from required python libraries and make desired instead
 - [[PR 686]](https://github.com/lanl/parthenon/pull/686) Remove coverage CI stage and add key features to README
 - [[PR 669]](https://github.com/lanl/parthenon/pull/669) Bump clang-format version (and checks) to >=11.0
 - [[PR 661]](https://github.com/lanl/parthenon/pull/661) Replaced ids in MPI tags with separate `MPI_Comms` for each variable/swarm

--- a/cmake/PythonModuleCheck.cmake
+++ b/cmake/PythonModuleCheck.cmake
@@ -13,12 +13,13 @@
 
 # Function will check that the specified modules are available to the python interpreter
 # If they are not cmake will throw an error indicating which module not available
-function(required_python_modules_found module_list)
+function(python_modules_found required_module_list desired_module_list)
 
   unset(MISSING_MODULES)
+  unset(MISSING_DESIRED_MODULES)
   if(${Python3_Interpreter_FOUND})
     set(IMPORT_ERROR 0)
-    foreach(module IN LISTS module_list )
+    foreach(module IN LISTS required_module_list )
       execute_process(COMMAND ${Python3_EXECUTABLE} -c "import ${module}"
         RESULT_VARIABLE IMPORT_MODULE ERROR_QUIET)
     
@@ -27,9 +28,24 @@ function(required_python_modules_found module_list)
         list(APPEND MISSING_MODULES ${module})
       endif()
     endforeach()
+  
+    set(IMPORT_WARN 0)
+    foreach(module IN LISTS desired_module_list )
+      execute_process(COMMAND ${Python3_EXECUTABLE} -c "import ${module}"
+        RESULT_VARIABLE IMPORT_MODULE ERROR_QUIET)
+    
+      if(NOT ${IMPORT_MODULE} EQUAL 0)
+        set(IMPORT_WARN 1)
+        list(APPEND MISSING_DESIRED_MODULES ${module})
+      endif()
+    endforeach()
 
     if (IMPORT_ERROR)
       message(FATAL_ERROR "Required python module(s) ${MISSING_MODULES} not found.") 
+    endif()
+    
+    if (IMPORT_WARN)
+      message(WARNING "Desired python module(s) ${MISSING_DESIRED_MODULES} not found. Continuing.") 
     endif()
   endif()
 endfunction()

--- a/cmake/PythonModuleCheck.cmake
+++ b/cmake/PythonModuleCheck.cmake
@@ -1,5 +1,5 @@
 #=========================================================================================
-# (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/cmake/TestSetup.cmake
+++ b/cmake/TestSetup.cmake
@@ -29,7 +29,7 @@ endif()
 if (PARTHENON_ENABLE_PYTHON_MODULE_CHECK)
   # Ensure all required packages are present
   include(${parthenon_SOURCE_DIR}/cmake/PythonModuleCheck.cmake)
-  required_python_modules_found("${REQUIRED_PYTHON_MODULES}")
+  python_modules_found("${REQUIRED_PYTHON_MODULES}" "${DESIRED_PYTHON_MODULES}")
 endif()
 
 # Adds the drivers used in the regression tests to a global cmake property: DRIVERS_USED_IN_TESTS

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -126,7 +126,8 @@ endif()
 
 # Any external modules that are required by python can be added to REQUIRED_PYTHON_MODULES
 # list variable, before including TestSetup.cmake.
-list(APPEND REQUIRED_PYTHON_MODULES matplotlib numpy)
+list(APPEND REQUIRED_PYTHON_MODULES numpy)
+list(APPEND DESIRED_PYTHON_MODULES matplotlib)
 
 # Include test setup functions, and check for python interpreter and modules
 #  setup_test_serial

--- a/tst/regression/test_suites/advection_convergence/advection_convergence.py
+++ b/tst/regression/test_suites/advection_convergence/advection_convergence.py
@@ -18,16 +18,19 @@
 # Modules
 import math
 import numpy as np
-try:
-  import matplotlib
 
-  matplotlib.use("agg")
-  import matplotlib.pylab as plt
-  have_matplotlib = True
+try:
+    import matplotlib
+
+    matplotlib.use("agg")
+    import matplotlib.pylab as plt
+
+    have_matplotlib = True
 except ImportError:
-  import warnings
-  warnings.warn("Matplotlib not found, not making plots.") 
-  have_matplotlib = False
+    import warnings
+
+    warnings.warn("Matplotlib not found, not making plots.")
+    have_matplotlib = False
 
 import sys
 import os
@@ -462,46 +465,46 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         # Plot results
         if have_matplotlib:
-          data = np.genfromtxt(
-              os.path.join(parameters.output_path, "advection-errors.dat")
-          )
+            data = np.genfromtxt(
+                os.path.join(parameters.output_path, "advection-errors.dat")
+            )
 
-          n_res = 5
-          sym = "xo+"
+            n_res = 5
+            sym = "xo+"
 
-          for i, x in enumerate("xyz"):
-              plt.plot(
-                  data[i * n_res : (i + 1) * n_res, 0 + i],
-                  data[i * n_res : (i + 1) * n_res, 4],
-                  marker=sym[i],
-                  label=x + "-dir (vary res)",
-              )
-              plt.plot(
-                  data[3 * n_res + i, 0 + i],
-                  data[3 * n_res + i, 4],
-                  lw=0,
-                  marker=sym[i],
-                  label=x + "-dir (same res)",
-                  alpha=0.5,
-              )
+            for i, x in enumerate("xyz"):
+                plt.plot(
+                    data[i * n_res : (i + 1) * n_res, 0 + i],
+                    data[i * n_res : (i + 1) * n_res, 4],
+                    marker=sym[i],
+                    label=x + "-dir (vary res)",
+                )
+                plt.plot(
+                    data[3 * n_res + i, 0 + i],
+                    data[3 * n_res + i, 4],
+                    lw=0,
+                    marker=sym[i],
+                    label=x + "-dir (same res)",
+                    alpha=0.5,
+                )
 
-          plt.plot(
-              data[3 * n_res + 3 : 3 * n_res + 3 + 2, 0],
-              data[3 * n_res + 3 : 3 * n_res + 3 + 2, 4],
-              marker="^",
-              label="oblique",
-          )
+            plt.plot(
+                data[3 * n_res + 3 : 3 * n_res + 3 + 2, 0],
+                data[3 * n_res + 3 : 3 * n_res + 3 + 2, 4],
+                marker="^",
+                label="oblique",
+            )
 
-          plt.plot([32, 512], [3e-7, 3e-7 / (512 / 32)], "--", label="first order")
+            plt.plot([32, 512], [3e-7, 3e-7 / (512 / 32)], "--", label="first order")
 
-          plt.legend()
-          plt.xscale("log")
-          plt.yscale("log")
-          plt.ylabel("L1 err")
-          plt.xlabel("Linear resolution")
-          plt.savefig(
-              os.path.join(parameters.output_path, "advection-errors.png"),
-              bbox_inches="tight",
-          )
+            plt.legend()
+            plt.xscale("log")
+            plt.yscale("log")
+            plt.ylabel("L1 err")
+            plt.xlabel("Linear resolution")
+            plt.savefig(
+                os.path.join(parameters.output_path, "advection-errors.png"),
+                bbox_inches="tight",
+            )
 
         return analyze_status

--- a/tst/regression/test_suites/advection_convergence/advection_convergence.py
+++ b/tst/regression/test_suites/advection_convergence/advection_convergence.py
@@ -3,7 +3,7 @@
 # Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/regression/test_suites/advection_convergence/advection_convergence.py
+++ b/tst/regression/test_suites/advection_convergence/advection_convergence.py
@@ -18,10 +18,17 @@
 # Modules
 import math
 import numpy as np
-import matplotlib
+try:
+  import matplotlib
 
-matplotlib.use("agg")
-import matplotlib.pylab as plt
+  matplotlib.use("agg")
+  import matplotlib.pylab as plt
+  have_matplotlib = True
+except ImportError:
+  import warnings
+  warnings.warn("Matplotlib not found, not making plots.") 
+  have_matplotlib = False
+
 import sys
 import os
 import utils.test_case
@@ -454,46 +461,47 @@ class TestCase(utils.test_case.TestCaseAbs):
             analyze_status = False
 
         # Plot results
-        data = np.genfromtxt(
-            os.path.join(parameters.output_path, "advection-errors.dat")
-        )
+        if have_matplotlib:
+          data = np.genfromtxt(
+              os.path.join(parameters.output_path, "advection-errors.dat")
+          )
 
-        n_res = 5
-        sym = "xo+"
+          n_res = 5
+          sym = "xo+"
 
-        for i, x in enumerate("xyz"):
-            plt.plot(
-                data[i * n_res : (i + 1) * n_res, 0 + i],
-                data[i * n_res : (i + 1) * n_res, 4],
-                marker=sym[i],
-                label=x + "-dir (vary res)",
-            )
-            plt.plot(
-                data[3 * n_res + i, 0 + i],
-                data[3 * n_res + i, 4],
-                lw=0,
-                marker=sym[i],
-                label=x + "-dir (same res)",
-                alpha=0.5,
-            )
+          for i, x in enumerate("xyz"):
+              plt.plot(
+                  data[i * n_res : (i + 1) * n_res, 0 + i],
+                  data[i * n_res : (i + 1) * n_res, 4],
+                  marker=sym[i],
+                  label=x + "-dir (vary res)",
+              )
+              plt.plot(
+                  data[3 * n_res + i, 0 + i],
+                  data[3 * n_res + i, 4],
+                  lw=0,
+                  marker=sym[i],
+                  label=x + "-dir (same res)",
+                  alpha=0.5,
+              )
 
-        plt.plot(
-            data[3 * n_res + 3 : 3 * n_res + 3 + 2, 0],
-            data[3 * n_res + 3 : 3 * n_res + 3 + 2, 4],
-            marker="^",
-            label="oblique",
-        )
+          plt.plot(
+              data[3 * n_res + 3 : 3 * n_res + 3 + 2, 0],
+              data[3 * n_res + 3 : 3 * n_res + 3 + 2, 4],
+              marker="^",
+              label="oblique",
+          )
 
-        plt.plot([32, 512], [3e-7, 3e-7 / (512 / 32)], "--", label="first order")
+          plt.plot([32, 512], [3e-7, 3e-7 / (512 / 32)], "--", label="first order")
 
-        plt.legend()
-        plt.xscale("log")
-        plt.yscale("log")
-        plt.ylabel("L1 err")
-        plt.xlabel("Linear resolution")
-        plt.savefig(
-            os.path.join(parameters.output_path, "advection-errors.png"),
-            bbox_inches="tight",
-        )
+          plt.legend()
+          plt.xscale("log")
+          plt.yscale("log")
+          plt.ylabel("L1 err")
+          plt.xlabel("Linear resolution")
+          plt.savefig(
+              os.path.join(parameters.output_path, "advection-errors.png"),
+              bbox_inches="tight",
+          )
 
         return analyze_status

--- a/tst/regression/test_suites/advection_performance/advection_performance.py
+++ b/tst/regression/test_suites/advection_performance/advection_performance.py
@@ -18,16 +18,19 @@
 # Modules
 import math
 import numpy as np
-try:
-  import matplotlib
 
-  matplotlib.use("agg")
-  import matplotlib.pylab as plt
-  have_matplotlib = True
+try:
+    import matplotlib
+
+    matplotlib.use("agg")
+    import matplotlib.pylab as plt
+
+    have_matplotlib = True
 except ImportError:
-  import warnings
-  warnings.warn("Matplotlib not found, not making plots.") 
-  have_matplotlib = False
+    import warnings
+
+    warnings.warn("Matplotlib not found, not making plots.")
+    have_matplotlib = False
 
 import sys
 import os
@@ -102,19 +105,20 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         # Plot results
         if have_matplotlib:
-          fig, p = plt.subplots(2, 1, figsize=(4, 8), sharex=True)
+            fig, p = plt.subplots(2, 1, figsize=(4, 8), sharex=True)
 
-          p[0].loglog(mb_sizes, perfs, label="$256^3$ Mesh")
-          p[1].loglog(mb_sizes, perfs[0] / perfs)
+            p[0].loglog(mb_sizes, perfs, label="$256^3$ Mesh")
+            p[1].loglog(mb_sizes, perfs[0] / perfs)
 
-          for i in range(2):
-              p[i].grid()
-          p[0].legend()
-          p[0].set_ylabel("zone-cycles/s")
-          p[1].set_ylabel("normalized overhead")
-          p[1].set_xlabel("Meshblock size")
-          fig.savefig(
-              os.path.join(parameters.output_path, "performance.png"), bbox_inches="tight"
-          )
+            for i in range(2):
+                p[i].grid()
+            p[0].legend()
+            p[0].set_ylabel("zone-cycles/s")
+            p[1].set_ylabel("normalized overhead")
+            p[1].set_xlabel("Meshblock size")
+            fig.savefig(
+                os.path.join(parameters.output_path, "performance.png"),
+                bbox_inches="tight",
+            )
 
         return True

--- a/tst/regression/test_suites/advection_performance/advection_performance.py
+++ b/tst/regression/test_suites/advection_performance/advection_performance.py
@@ -18,10 +18,17 @@
 # Modules
 import math
 import numpy as np
-import matplotlib
+try:
+  import matplotlib
 
-matplotlib.use("agg")
-import matplotlib.pylab as plt
+  matplotlib.use("agg")
+  import matplotlib.pylab as plt
+  have_matplotlib = True
+except ImportError:
+  import warnings
+  warnings.warn("Matplotlib not found, not making plots.") 
+  have_matplotlib = False
+
 import sys
 import os
 import utils.test_case
@@ -94,19 +101,20 @@ class TestCase(utils.test_case.TestCaseAbs):
                 )
 
         # Plot results
-        fig, p = plt.subplots(2, 1, figsize=(4, 8), sharex=True)
+        if have_matplotlib:
+          fig, p = plt.subplots(2, 1, figsize=(4, 8), sharex=True)
 
-        p[0].loglog(mb_sizes, perfs, label="$256^3$ Mesh")
-        p[1].loglog(mb_sizes, perfs[0] / perfs)
+          p[0].loglog(mb_sizes, perfs, label="$256^3$ Mesh")
+          p[1].loglog(mb_sizes, perfs[0] / perfs)
 
-        for i in range(2):
-            p[i].grid()
-        p[0].legend()
-        p[0].set_ylabel("zone-cycles/s")
-        p[1].set_ylabel("normalized overhead")
-        p[1].set_xlabel("Meshblock size")
-        fig.savefig(
-            os.path.join(parameters.output_path, "performance.png"), bbox_inches="tight"
-        )
+          for i in range(2):
+              p[i].grid()
+          p[0].legend()
+          p[0].set_ylabel("zone-cycles/s")
+          p[1].set_ylabel("normalized overhead")
+          p[1].set_xlabel("Meshblock size")
+          fig.savefig(
+              os.path.join(parameters.output_path, "performance.png"), bbox_inches="tight"
+          )
 
         return True


### PR DESCRIPTION
## PR Summary

Make python library `matplotlib` optional instead of required, but warn if it is not present. I was running into some issues with getting `matplotlib` installed on a particular platform, so rather than fight with that it seemed easier to just make `matplotlib` optional since the tests don't really require it. Tests that use `matplotlib` have been updated to check if `matplotlib` is present and only make plots if it is.

## PR Checklist

- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
