### PR TITLE
Fixed mpi/serial logic in extended CI tests

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -66,7 +66,7 @@ jobs:
           name: log-and-convergence-${{ matrix.device }}-${{ matrix.parallel }}
           path: |
             build/CMakeFiles/CMakeOutput.log
-            build/tst/regression/outputs/advection_convergence/advection-errors.dat
-            build/tst/regression/outputs/advection_convergence/advection-errors.png
+            build/tst/regression/outputs/advection_convergence*/advection-errors.dat
+            build/tst/regression/outputs/advection_convergence*/advection-errors.png
           retention-days: 3
 

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -20,7 +20,7 @@ env:
   OMPI_MCA_mpi_common_cuda_event_max: 1000
 
 jobs:
-  unit:
+  perf-and-regression:
     strategy:
       matrix:
         device: ['cuda', 'host']
@@ -59,7 +59,7 @@ jobs:
       - name: Regression tests
         run: |
           cd build
-          ctest -L regression -LE "${{ matrix.parallel }}|perf-reg" --timeout 3600
+          ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       - uses: actions/upload-artifact@v3
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - [[PR 595]](https://github.com/lanl/parthenon/pull/595) Fix build options so that non-MPI builds cannot be paired with an MPI HDF5 lib
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 703]](https://github.com/lanl/parthenon/pull/703) Fixed mpi/serial logic in extended CI tests
 - [[PR 700]](https://github.com/lanl/parthenon/pull/700) Moved CI testing from GitLab mirror to GitHub Actions
 - [[PR 698]](https://github.com/lanl/parthenon/pull/698) Remove matplotlib from required python libraries and make desired instead
 - [[PR 686]](https://github.com/lanl/parthenon/pull/686) Remove coverage CI stage and add key features to README


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Quick bugfix:

Good news: the scheduled extended tests using GitHub Actions worked as planned after the merge into `develop`
Bad news: I got the logic wrong way round when setting up with tests (labels) to include and which to exclude in the text matrix.
Good news2: Fix is straightforward. Multiple `-L` work as `AND` for selecting tests with the `ctest` command.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
