### PR TITLE
Rename flux correction routines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 711]](https://github.com/lanl/parthenon/pull/711) Rename flux correction routines.
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)

--- a/docs/sparse_boundary_communication.md
+++ b/docs/sparse_boundary_communication.md
@@ -125,7 +125,7 @@ In each cache, we build a `std::vector<CommBuffer<....>*> send_buf_vec, recv_buf
 
 ### Flux Correction Tasks 
 The flux correction routines mirror the boundary routines, except that they do not accept a `BoundaryType` template parameter since the flux corrections are limited to fine-to-coarse boundaries (which is its own `BoundaryType`). Cacheing and the "in one" machinery has not been implemented here yet and it probably does not have a big impact on performance, but it should be very straightforward to switch to cacheing if desired.   
-- **`StartReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>>&)`**
-- **`LoadAndSendSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>>&)`**
-- **`ReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>>&)`**
+- **`StartReceiveFluxCorrections(std::shared_ptr<MeshData<Real>>&)`**
+- **`LoadAndSendFluxCorrections(std::shared_ptr<MeshData<Real>>&)`**
+- **`ReceiveFluxCorrections(std::shared_ptr<MeshData<Real>>&)`**
 - **`SetFluxCorrections(std::shared_ptr<MeshData<Real>>&)`**

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -87,9 +87,7 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
     const auto any = parthenon::BoundaryType::any;
 
     tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
-    tl.AddTask(none,
-               parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
-               mc0);
+    tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveFluxCorrections, mc0);
   }
 
   // Number of task lists that can be executed independently and thus *may*
@@ -126,11 +124,10 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
     auto &mc1 = pmesh->mesh_data.GetOrAdd(stage_name[stage], i);
     auto &mdudt = pmesh->mesh_data.GetOrAdd("dUdt", i);
 
-    auto send_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections,
-        mc0);
-    auto recv_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
+    auto send_flx =
+        tl.AddTask(none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections, mc0);
+    auto recv_flx =
+        tl.AddTask(none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
     auto set_flx =
         tl.AddTask(recv_flx, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -88,7 +88,7 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
 
     tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
     tl.AddTask(none,
-               parthenon::cell_centered_bvars::StartReceiveSparseFluxCorrectionBuffers,
+               parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
                mc0);
   }
 
@@ -127,10 +127,10 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
     auto &mdudt = pmesh->mesh_data.GetOrAdd("dUdt", i);
 
     auto send_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::LoadAndSendSparseFluxCorrectionBuffers,
+        none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections,
         mc0);
     auto recv_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::ReceiveSparseFluxCorrectionBuffers, mc0);
+        none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
     auto set_flx =
         tl.AddTask(recv_flx, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -450,14 +450,14 @@ TaskCollection ParticleDriver::MakeTaskCollection(BlockList_t &blocks, int stage
 
     tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
     tl.AddTask(none,
-               parthenon::cell_centered_bvars::StartReceiveSparseFluxCorrectionBuffers,
+               parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
                mc0);
 
     auto send_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::LoadAndSendSparseFluxCorrectionBuffers,
+        none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections,
         mc0);
     auto recv_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::ReceiveSparseFluxCorrectionBuffers, mc0);
+        none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
     auto set_flx =
         tl.AddTask(recv_flx, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -449,15 +449,12 @@ TaskCollection ParticleDriver::MakeTaskCollection(BlockList_t &blocks, int stage
     const auto any = parthenon::BoundaryType::any;
 
     tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
-    tl.AddTask(none,
-               parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
-               mc0);
+    tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveFluxCorrections, mc0);
 
-    auto send_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections,
-        mc0);
-    auto recv_flx = tl.AddTask(
-        none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
+    auto send_flx =
+        tl.AddTask(none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections, mc0);
+    auto recv_flx =
+        tl.AddTask(none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
     auto set_flx =
         tl.AddTask(recv_flx, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/example/sparse_advection/sparse_advection_driver.cpp
+++ b/example/sparse_advection/sparse_advection_driver.cpp
@@ -104,17 +104,14 @@ TaskCollection SparseAdvectionDriver::MakeTaskCollection(BlockList_t &blocks,
 
     const auto any = parthenon::BoundaryType::any;
     auto start_flxcor = tl.AddTask(
-        none, parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
-        mc0);
+        none, parthenon::cell_centered_bvars::StartReceiveFluxCorrections, mc0);
     auto start_bound =
         tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
 
     auto send_flxcor = tl.AddTask(
-        start_flxcor,
-        parthenon::cell_centered_bvars::LoadAndSendFluxCorrections, mc0);
+        start_flxcor, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections, mc0);
     auto recv_flxcor = tl.AddTask(
-        start_flxcor, parthenon::cell_centered_bvars::ReceiveFluxCorrections,
-        mc0);
+        start_flxcor, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
     auto set_flxcor =
         tl.AddTask(recv_flxcor, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/example/sparse_advection/sparse_advection_driver.cpp
+++ b/example/sparse_advection/sparse_advection_driver.cpp
@@ -104,16 +104,16 @@ TaskCollection SparseAdvectionDriver::MakeTaskCollection(BlockList_t &blocks,
 
     const auto any = parthenon::BoundaryType::any;
     auto start_flxcor = tl.AddTask(
-        none, parthenon::cell_centered_bvars::StartReceiveSparseFluxCorrectionBuffers,
+        none, parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
         mc0);
     auto start_bound =
         tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
 
     auto send_flxcor = tl.AddTask(
         start_flxcor,
-        parthenon::cell_centered_bvars::LoadAndSendSparseFluxCorrectionBuffers, mc0);
+        parthenon::cell_centered_bvars::LoadAndSendFluxCorrections, mc0);
     auto recv_flxcor = tl.AddTask(
-        start_flxcor, parthenon::cell_centered_bvars::ReceiveSparseFluxCorrectionBuffers,
+        start_flxcor, parthenon::cell_centered_bvars::ReceiveFluxCorrections,
         mc0);
     auto set_flxcor =
         tl.AddTask(recv_flxcor, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);

--- a/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
+++ b/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
@@ -135,15 +135,12 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
       const auto any = parthenon::BoundaryType::any;
 
       tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
-      tl.AddTask(none,
-                 parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
-                 mc0);
+      tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveFluxCorrections, mc0);
 
       auto send_flx = tl.AddTask(
-          none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections,
-          mc0);
-      auto recv_flx = tl.AddTask(
-          none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
+          none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections, mc0);
+      auto recv_flx =
+          tl.AddTask(none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
       auto set_flx =
           tl.AddTask(recv_flx, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
+++ b/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
@@ -136,14 +136,14 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
 
       tl.AddTask(none, parthenon::cell_centered_bvars::StartReceiveBoundBufs<any>, mc1);
       tl.AddTask(none,
-                 parthenon::cell_centered_bvars::StartReceiveSparseFluxCorrectionBuffers,
+                 parthenon::cell_centered_bvars::StartReceiveFluxCorrections,
                  mc0);
 
       auto send_flx = tl.AddTask(
-          none, parthenon::cell_centered_bvars::LoadAndSendSparseFluxCorrectionBuffers,
+          none, parthenon::cell_centered_bvars::LoadAndSendFluxCorrections,
           mc0);
       auto recv_flx = tl.AddTask(
-          none, parthenon::cell_centered_bvars::ReceiveSparseFluxCorrectionBuffers, mc0);
+          none, parthenon::cell_centered_bvars::ReceiveFluxCorrections, mc0);
       auto set_flx =
           tl.AddTask(recv_flx, parthenon::cell_centered_bvars::SetFluxCorrections, mc0);
 

--- a/src/bvals/cc/bvals_cc_in_one.hpp
+++ b/src/bvals/cc/bvals_cc_in_one.hpp
@@ -74,9 +74,9 @@ inline TaskStatus SetBoundaries(std::shared_ptr<MeshData<Real>> &md) {
   return SetBounds<BoundaryType::any>(md);
 }
 
-TaskStatus StartReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &md);
-TaskStatus LoadAndSendSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &md);
-TaskStatus ReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &md);
+TaskStatus StartReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
+TaskStatus LoadAndSendFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
+TaskStatus ReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
 TaskStatus SetFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
 
 struct BndInfo {

--- a/src/bvals/cc/sparse_flux_correction_cc_in_one.cpp
+++ b/src/bvals/cc/sparse_flux_correction_cc_in_one.cpp
@@ -39,8 +39,8 @@ namespace cell_centered_bvars {
 
 using namespace impl;
 
-TaskStatus LoadAndSendSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &md) {
-  Kokkos::Profiling::pushRegion("Task_LoadAndSendFluxCorrectionBuffers");
+TaskStatus LoadAndSendFluxCorrections(std::shared_ptr<MeshData<Real>> &md) {
+  Kokkos::Profiling::pushRegion("Task_LoadAndSendFluxCorrections");
 
   Mesh *pmesh = md->GetMeshPointer();
 
@@ -174,12 +174,12 @@ TaskStatus LoadAndSendSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>
     return LoopControl::cont;
   });
 
-  Kokkos::Profiling::popRegion(); // Task_LoadAndSendFluxCorrectionBuffers
+  Kokkos::Profiling::popRegion(); // Task_LoadAndSendFluxCorrections
   return TaskStatus::complete;
 }
 
-TaskStatus StartReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &md) {
-  Kokkos::Profiling::pushRegion("Task_ReceiveFluxCorrectionBuffers");
+TaskStatus StartReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md) {
+  Kokkos::Profiling::pushRegion("Task_ReceiveFluxCorrections");
   Mesh *pmesh = md->GetMeshPointer();
   ForEachBoundary<BoundaryType::flxcor_recv>(
       md, [&](sp_mb_t pmb, sp_mbd_t rc, nb_t &nb, const sp_cv_t v) {
@@ -189,12 +189,12 @@ TaskStatus StartReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real
         auto &buf = pmesh->boundary_comm_flxcor_map[ReceiveKey(pmb, nb, v)];
         buf.TryStartReceive();
       });
-  Kokkos::Profiling::popRegion(); // Task_ReceiveFluxCorrectionBuffers
+  Kokkos::Profiling::popRegion(); // Task_ReceiveFluxCorrections
   return TaskStatus::complete;
 }
 
-TaskStatus ReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &md) {
-  Kokkos::Profiling::pushRegion("Task_ReceiveFluxCorrectionBuffers");
+TaskStatus ReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md) {
+  Kokkos::Profiling::pushRegion("Task_ReceiveFluxCorrections");
   bool all_received = true;
   Mesh *pmesh = md->GetMeshPointer();
   ForEachBoundary<BoundaryType::flxcor_recv>(
@@ -206,7 +206,7 @@ TaskStatus ReceiveSparseFluxCorrectionBuffers(std::shared_ptr<MeshData<Real>> &m
         all_received = buf.TryReceive() && all_received;
       });
 
-  Kokkos::Profiling::popRegion(); // Task_ReceiveFluxCorrectionBuffers
+  Kokkos::Profiling::popRegion(); // Task_ReceiveFluxCorrections
 
   if (all_received) return TaskStatus::complete;
   return TaskStatus::incomplete;


### PR DESCRIPTION
## PR Summary
@brryan pointed out the flux correction routines still include `Sparse` in their name even though they are for all variables while he was updating Phoebus. This PR removes `Sparse` from the flux correction routine names and also removes the word `Buffers` from the names (where present) to make them less verbose. It should be straightforward to update downstream codes by first search and replacing `SparseFluxCorrection`->`FluxCorrection` and then `FluxCorrectionBuffers` -> `FluxCorrections`. 

@pgrete: I think you will need to update AthenaPK as well.  

## PR Checklist

- [x] Code passes cpplint
- [x] New names are documented.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
