### PR TITLE
Coordinates class to Coordinates_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 713]] (https://github.com/lanl/parthenon/pull/713) Remove Coordinates stub in favor of Coordinates_t
 - [[PR 711]](https://github.com/lanl/parthenon/pull/711) Rename flux correction routines.
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -44,7 +44,6 @@ class Mesh;
 class MeshBlock;
 class MeshBlockTree;
 class ParameterInput;
-class Coordinates;
 struct RegionSize;
 
 // free functions to return boundary flag given input string, and vice versa

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -40,7 +40,6 @@ class MeshBlock;
 class MeshBlockTree;
 class Field;
 class ParameterInput;
-class Coordinates;
 class BoundaryValues;
 struct RegionSize;
 

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -46,7 +46,6 @@ namespace parthenon {
 
 // forward declarations needed for function pointer type aliases
 class MeshBlock;
-class Coordinates;
 class ParameterInput;
 
 //--------------------------------------------------------------------------------------

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -72,7 +72,6 @@ class Mesh {
   friend class MeshBlockTree;
   friend class BoundaryBase;
   friend class BoundaryValues;
-  friend class Coordinates;
   friend class MeshRefinement;
 
  public:

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -86,8 +86,8 @@
 #include <stdexcept>
 #include <string>
 
-#include "defs.hpp"
 #include "coordinates/coordinates.hpp"
+#include "defs.hpp"
 #include "mesh/mesh.hpp"
 #include "mesh/meshblock.hpp"
 #include "parameter_input.hpp"

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -87,6 +87,7 @@
 #include <string>
 
 #include "defs.hpp"
+#include "coordinates/coordinates.hpp"
 #include "mesh/mesh.hpp"
 #include "mesh/meshblock.hpp"
 #include "parameter_input.hpp"
@@ -708,6 +709,6 @@ void OutputType::SumOutputData(MeshBlock *pmb, int dim) {
 //  \brief Convert vectors in curvilinear coordinates into Cartesian
 
 void OutputType::CalculateCartesianVector(ParArrayND<Real> &src, ParArrayND<Real> &dst,
-                                          Coordinates *pco) {}
+                                          Coordinates_t *pco) {}
 
 } // namespace parthenon

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -115,7 +115,7 @@ class OutputType {
   bool SliceOutputData(MeshBlock *pmb, int dim);
   void SumOutputData(MeshBlock *pmb, int dim);
   void CalculateCartesianVector(ParArrayND<Real> &src, ParArrayND<Real> &dst,
-				Coordinates_t *pco);
+                                Coordinates_t *pco);
   // following pure virtual function must be implemented in all derived classes
   virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
                                const SignalHandler::OutputSignal signal) = 0;

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "basic_types.hpp"
+#include "coordinates/coordinates.hpp"
 #include "interface/mesh_data.hpp"
 #include "io_wrapper.hpp"
 #include "parthenon_arrays.hpp"
@@ -33,7 +34,6 @@ namespace parthenon {
 // forward declarations
 class Mesh;
 class ParameterInput;
-class Coordinates;
 
 //----------------------------------------------------------------------------------------
 //! \struct OutputParameters
@@ -115,7 +115,7 @@ class OutputType {
   bool SliceOutputData(MeshBlock *pmb, int dim);
   void SumOutputData(MeshBlock *pmb, int dim);
   void CalculateCartesianVector(ParArrayND<Real> &src, ParArrayND<Real> &dst,
-                                Coordinates *pco);
+				Coordinates_t *pco);
   // following pure virtual function must be implemented in all derived classes
   virtual void WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
                                const SignalHandler::OutputSignal signal) = 0;

--- a/src/parthenon/package.hpp
+++ b/src/parthenon/package.hpp
@@ -42,7 +42,6 @@ using namespace ::parthenon::prelude;
 using ::parthenon::AmrTag;
 using ::parthenon::ApplicationInput;
 using ::parthenon::BlockList_t;
-using ::parthenon::Coordinates;
 using ::parthenon::DevExecSpace;
 using ::parthenon::HostExecSpace;
 using ::parthenon::Mesh;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When building code downstream in `clang` I found that the `Coordinates` namespace was being shadowed by a non-existent `Coordinates` class inside `parthenon`. But now the `parthenon` way is to use `Coordinates_t`. This PR removes all the forward declarations for the nonexistent `Coordinates` class.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
