### PR TITLE
Fix failing Darwin CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 723]](https://github.com/lanl/parthenon/pull/719) Fix failing CI on Darwin due to differing `OutputFormatVersion` attribute in hdf5 gold files.
 - [[PR 719]](https://github.com/lanl/parthenon/pull/719) Fix type mismatch in swarm boundaries when host pinned memory enabled
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Parthenon
 
 [![testing](https://gitlab.com/theias/hpc/jmstone/athena-parthenon/parthenon-ci-mirror/badges/develop/pipeline.svg)](https://gitlab.com/theias/hpc/jmstone/athena-parthenon/parthenon-ci-mirror/-/commits/develop)
+[![Extended CI](https://github.com/lanl/parthenon/actions/workflows/ci-extended.yml/badge.svg?branch=develop)](https://github.com/lanl/parthenon/actions/workflows/ci-extended.yml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Matrix chat](https://img.shields.io/matrix/parthenon-general:matrix.org)](https://app.element.io/#/room/#parthenon-general:matrix.org)
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -215,12 +215,18 @@ def compare_metadata(f0, f1, quiet=False, one=False, check_input=False, tol=1.0e
     f0_Info = {
         key: value
         for key, value in f0.Info.items()
-        if key != "Time" and key != "BlocksPerPE" and key != "WallTime" and key != "OutputFormatVersion"
+        if key != "Time"
+        and key != "BlocksPerPE"
+        and key != "WallTime"
+        and key != "OutputFormatVersion"
     }
     f1_Info = {
         key: value
         for key, value in f1.Info.items()
-        if key != "Time" and key != "BlocksPerPE" and key != "WallTime" and key != "OutputFormatVersion"
+        if key != "Time"
+        and key != "BlocksPerPE"
+        and key != "WallTime"
+        and key != "OutputFormatVersion"
     }
     if sorted(f0_Info.keys()) != sorted(f1_Info.keys()):
         print("Names of attributes in '/Info' of differ")

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -215,12 +215,12 @@ def compare_metadata(f0, f1, quiet=False, one=False, check_input=False, tol=1.0e
     f0_Info = {
         key: value
         for key, value in f0.Info.items()
-        if key != "Time" and key != "BlocksPerPE" and key != "WallTime"
+        if key != "Time" and key != "BlocksPerPE" and key != "WallTime" and key != "OutputFormatVersion"
     }
     f1_Info = {
         key: value
         for key, value in f1.Info.items()
-        if key != "Time" and key != "BlocksPerPE" and key != "WallTime"
+        if key != "Time" and key != "BlocksPerPE" and key != "WallTime" and key != "OutputFormatVersion"
     }
     if sorted(f0_Info.keys()) != sorted(f1_Info.keys()):
         print("Names of attributes in '/Info' of differ")

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -104,7 +104,6 @@ class TestCase(utils.test_case.TestCaseAbs):
                 + "/tst/regression/gold_standard/advection_2d.out0.final.phdf",
             ],
             one=True,
-            check_metadata=False,  # Fixes outputformatversion mismatch. Removed prior to merge after gold update.
         )
         ret_3d = phdf_diff.compare(
             [
@@ -113,7 +112,6 @@ class TestCase(utils.test_case.TestCaseAbs):
                 + "/tst/regression/gold_standard/advection_3d.out0.final.phdf",
             ],
             one=True,
-            check_metadata=False,  # Fixes outputformatversion mismatch. Removed prior to merge after gold update.
         )
 
         if ret_2d != 0 or ret_3d != 0:


### PR DESCRIPTION
## PR Summary
Fixes issue #723 by removing the attribute `OutputFormatVersion` from the attributes that are checked in `compare_metadata(...)` in `phdf_diff.py`. With this change, the CI passes on Darwin.

## PR Checklist

- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
