### PR TITLE
fix profiling regions in bvals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR725]](https://github.com/lanl/parthenon/pull/725) Fix improperly exited kokkos profiling region
 - [[PR 719]](https://github.com/lanl/parthenon/pull/719) Fix type mismatch in swarm boundaries when host pinned memory enabled
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 

--- a/src/bvals/cc/sparse_bvals_cc_in_one.cpp
+++ b/src/bvals/cc/sparse_bvals_cc_in_one.cpp
@@ -232,9 +232,14 @@ TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
 
         ++nbound;
       });
-  if (nbound == 0) return TaskStatus::complete;
-  if (other_communication_unfinished) return TaskStatus::incomplete;
-
+  if (nbound == 0) {
+    Kokkos::Profiling::popRegion(); // Task_LoadAndSendBoundBufs
+    return TaskStatus::complete;
+  }
+  if (other_communication_unfinished) {
+    Kokkos::Profiling::popRegion(); // Task_LoadAndSendBoundBufs
+    return TaskStatus::incomplete;
+  }
   if (rebuild) {
     cache.send_bnd_info = BufferCache_t("send_boundary_info", nbound);
     cache.send_bnd_info_h = Kokkos::create_mirror_view(cache.send_bnd_info);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

The kokkos tools profiling region was not properly "popped" when returning from one of the functions in `bvals_cc_in_one`. When running with Kokkos tools enabled, the profiling tooling crashed because profiling region was only added to, never removed. This PR resolves this issue.

I don't add a test, but perhaps we should think about running some of our tests with kokkos tooling instrumentation to avoid this kind of issue in the future (and to give us some time-history of profiling.)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
