### PR TITLE
Optional modifications to output format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 729]](https://github.com/lanl/parthenon/pull/729) Optional modifications to output format
 - [[PR 717]](https://github.com/lanl/parthenon/pull/717) Add ghost zone plotting capability to phdf.py and movie2d.py
 - [[PR 712]](https://github.com/lanl/parthenon/pull/712) Allow to add params from cmdline
 

--- a/docs/outputs.md
+++ b/docs/outputs.md
@@ -37,10 +37,13 @@ variables = density, velocity, & # comments are still ok
             energy               # notice the & continuation character
                                  # for multiline lists
 dt = 1.0
+file_number_width = 6 # default: 5
+use_final_label = true # default: true
 ```
-This will produce an hdf5 (`.phdf`) output file every 1 units of
-simulation time containing the density, velocity, and energy of each
-cell.
+This will produce an hdf5 (`.phdf`) output file every 1 units of simulation time containing the
+density, velocity, and energy of each cell. The files will be identified by a 6-digit ID, and the
+output file generated upon completion of the simulation will be labeled `*.final.*` rather than
+with the integer ID.
 
 HDF5 and restart files write variable field data with inline compression by default. This is
 especially helpful when there are sparse variables allocated only in a few blocks, because all other

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -150,6 +150,10 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       // set file number, basename, id, and format
       op.file_number = pin->GetOrAddInteger(op.block_name, "file_number", 0);
       op.file_basename = pin->GetOrAddString("parthenon/job", "problem_id", "parthenon");
+      op.file_number_width =
+          pin->GetOrAddInteger("parthenon/job", "file_number_width", 5);
+      op.file_label_final =
+          pin->GetOrAddBoolean("parthenon/job", "use_final_label", true);
       char define_id[10];
       std::snprintf(define_id, sizeof(define_id), "out%d",
                     op.block_number); // default id="outN"

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -150,10 +150,8 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       // set file number, basename, id, and format
       op.file_number = pin->GetOrAddInteger(op.block_name, "file_number", 0);
       op.file_basename = pin->GetOrAddString("parthenon/job", "problem_id", "parthenon");
-      op.file_number_width =
-          pin->GetOrAddInteger("parthenon/job", "file_number_width", 5);
-      op.file_label_final =
-          pin->GetOrAddBoolean("parthenon/job", "use_final_label", true);
+      op.file_number_width = pin->GetOrAddInteger(op.block_name, "file_number_width", 5);
+      op.file_label_final = pin->GetOrAddBoolean(op.block_name, "use_final_label", true);
       char define_id[10];
       std::snprintf(define_id, sizeof(define_id), "out%d",
                     op.block_number); // default id="outN"

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -43,6 +43,8 @@ struct OutputParameters {
   int block_number;
   std::string block_name;
   std::string file_basename;
+  int file_number_width;
+  bool file_label_final;
   std::string file_id;
   std::string variable;
   std::vector<std::string> variables;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -350,7 +350,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   if (signal == SignalHandler::OutputSignal::now) {
     filename.append("now");
   } else if (signal == SignalHandler::OutputSignal::final &&
-             (output_params.file_label_final || restart_)) {
+             output_params.file_label_final) {
     filename.append("final");
     // default time based data dump
   } else {

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -349,12 +349,14 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   filename.append(".");
   if (signal == SignalHandler::OutputSignal::now) {
     filename.append("now");
-  } else if (signal == SignalHandler::OutputSignal::final) {
+  } else if (signal == SignalHandler::OutputSignal::final &&
+             (output_params.file_label_final || restart_)) {
     filename.append("final");
     // default time based data dump
   } else {
     std::stringstream file_number;
-    file_number << std::setw(5) << std::setfill('0') << output_params.file_number;
+    file_number << std::setw(output_params.file_number_width) << std::setfill('0')
+                << output_params.file_number;
     filename.append(file_number.str());
   }
   filename.append(restart_ ? ".rhdf" : ".phdf");


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Currently parthenon hard-codes a 5-digit integer ID for output file names. This can be restrictive for very long-running applications. Also, the output file produced at simulation completion is always named `*.final.*`, which can confuse some visualization software packages. This PR adds optional runtime input parameters to choose the number of digits in the output file ID and to opt out of the `*.final.*` naming convention *only* for output, not restart, files. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
