### PR TITLE
Update parthenon_hdf5.cpp for TimeVaryingMetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 759]](https://github.com/lanl/parthenon/pull/759) Add metadata so Visit treats outputs as time series
 - [[PR 743]](https://github.com/lanl/parthenon/pull/743) Add missing HDF5 type on MacOS 
 - [[PR 739]](https://github.com/lanl/parthenon/pull/739) Fix phdf.py for flattened vectors 
 - [[PR 724]](https://github.com/lanl/parthenon/pull/724) Fix failing CI on Darwin due to differing `OutputFormatVersion` attribute in hdf5 gold files.

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -341,6 +341,8 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
   xdmf << R"(<?xml version="1.0" ?>)" << std::endl;
   xdmf << R"(<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">)" << std::endl;
   xdmf << R"(<Xdmf Version="3.0">)" << std::endl;
+  xdmf << R"(<Information Name="TimeVaryingMetaData" Value="True"/>)"
+       << std::endl;
   xdmf << "  <Domain>" << std::endl;
   xdmf << R"(  <Grid Name="Mesh" GridType="Collection">)" << std::endl;
   if (tm != nullptr) {

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -341,8 +341,7 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
   xdmf << R"(<?xml version="1.0" ?>)" << std::endl;
   xdmf << R"(<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">)" << std::endl;
   xdmf << R"(<Xdmf Version="3.0">)" << std::endl;
-  xdmf << R"(<Information Name="TimeVaryingMetaData" Value="True"/>)"
-       << std::endl;
+  xdmf << R"(<Information Name="TimeVaryingMetaData" Value="True"/>)" << std::endl;
   xdmf << "  <Domain>" << std::endl;
   xdmf << R"(  <Grid Name="Mesh" GridType="Collection">)" << std::endl;
   if (tm != nullptr) {


### PR DESCRIPTION
<!--Update outputs/parthenon_hdf5.cpp to write a boolean with name TimeVaryingMetaData and value True to the Xdmf/Information node.-->

## PR Summary

<!--This enables one to use VisIt to load, plot and play an animation of the simulation results and tells VisIt that it should expect that the mesh metadata changes in each output file.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
