### PR TITLE
Fix incorrect BC labeling in swarm 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 765]](https://github.com/lanl/parthenon/pull/765) Fix incorrect BC labeling in swarm
 - [[PR 759]](https://github.com/lanl/parthenon/pull/759) Add metadata so Visit treats outputs as time series
-- [[PR 743]](https://github.com/lanl/parthenon/pull/743) Add missing HDF5 type on MacOS 
-- [[PR 739]](https://github.com/lanl/parthenon/pull/739) Fix phdf.py for flattened vectors 
+- [[PR 743]](https://github.com/lanl/parthenon/pull/743) Add missing HDF5 type on MacOS
+- [[PR 739]](https://github.com/lanl/parthenon/pull/739) Fix phdf.py for flattened vectors
 - [[PR 724]](https://github.com/lanl/parthenon/pull/724) Fix failing CI on Darwin due to differing `OutputFormatVersion` attribute in hdf5 gold files.
 - [[PR 725]](https://github.com/lanl/parthenon/pull/725) Fix improperly exited kokkos profiling region
 - [[PR 719]](https://github.com/lanl/parthenon/pull/719) Fix type mismatch in swarm boundaries when host pinned memory enabled

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -102,13 +102,13 @@ void Swarm::AllocateBoundariesImpl_(MeshBlock *pmb) {
     if (pmb->pmy_mesh->SwarmBndryFnctn[iFace] != nullptr) {
       bounds_uptrs[iFace] = pmb->pmy_mesh->SwarmBndryFnctn[iFace]();
     } else {
-      msg << "ix" << iFace + 1
+      msg << (iFace % 2 == 0 ? "i" : "o") << "x" << iFace / 2 + 1
           << " user boundary requested but provided function is null!";
       PARTHENON_THROW(msg);
     }
   } else {
-    msg << "ix" << iFace + 1 << " boundary flag " << static_cast<int>(bcs[iFace])
-        << " not supported!";
+    msg << (iFace % 2 == 0 ? "i" : "o") << "x" << iFace / 2 + 1 << " boundary flag "
+        << static_cast<int>(bcs[iFace]) << " not supported!";
     PARTHENON_THROW(msg);
   }
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

There was a bug when reporting an unprovided/unsupported boundary condition inside the particles framework where the wrong boundary flag was being called out. Just got thrown by this so here is the fix.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
