### PR TITLE
Trigger short CI only for PRs and remove old SpaceInstances test

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -25,7 +25,7 @@ jobs:
       matrix:
         device: ['cuda', 'host']
         parallel: ['serial', 'mpi']
-    runs-on: self-hosted
+    runs-on: [self-hosted, A100]
     container:
       image: registry.gitlab.com/pgrete/parthenon/cuda11.6-mpi-hdf5
       # map to local user id on CI  machine to allow writing to build cache

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -1,6 +1,6 @@
 name: CI short
 
-on: [push, pull_request]
+on: [pull_request]
 
 # Cancel "duplicated" workflows triggered by pushes to internal
 # branches with associated PRs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
-- [[PR 743]](https://github.com/lanl/parthenon/pull/740) Faster PHDF file load times in phdf.py
+- [[PR 740]](https://github.com/lanl/parthenon/pull/740) Faster PHDF file load times in phdf.py
 - [[PR 751]](https://github.com/lanl/parthenon/pull/751) Delete useless file in advection example
 - [[PR 765]](https://github.com/lanl/parthenon/pull/765) Fix incorrect BC labeling in swarm
 - [[PR 759]](https://github.com/lanl/parthenon/pull/759) Add metadata so Visit treats outputs as time series
@@ -28,6 +28,7 @@
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 772]](https://github.com/lanl/parthenon/pull/772) Trigger short CI only for PRs and remove old SpaceInstances test
 - [[PR 757]](https://github.com/lanl/parthenon/pull/757) Move to flux correction in-one and unify with bvals 
 - [[PR 768]](https://github.com/lanl/parthenon/pull/768) Update CI image and move to new CI machine (short and extended tests)
 - [[PR 766]](https://github.com/lanl/parthenon/pull/766) Remove IAS performance regression test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ include(CTest)
 # Compile Options
 option(PARTHENON_SINGLE_PRECISION "Run in single precision" OFF)
 option(PARTHENON_DISABLE_MPI "MPI is enabled by default if found, set this to True to disable MPI" OFF)
-option(PARTHENON_ENABLE_HOST_COMM_BUFFERS "Allocate communication buffers on host" OFF)
+option(PARTHENON_ENABLE_HOST_COMM_BUFFERS "CUDA/HIP Only: Allocate communication buffers on host (may be slower)" OFF)
 option(PARTHENON_DISABLE_OPENMP "OpenMP is enabled by default if found, set this to True to disable OpenMP" OFF)
 option(PARTHENON_DISABLE_HDF5 "HDF5 is enabled by default if found, set this to True to disable HDF5" OFF)
 option(PARTHENON_DISABLE_HDF5_COMPRESSION "HDF5 compression is enabled by default, set this to True to disable compression in HDF5 output/restart files" OFF)
@@ -277,6 +277,12 @@ if (Kokkos_ENABLE_SYCL)
     "It may or may not work. Use at your own risk. "
     "Please get in contact for support."
   )
+endif()
+
+if (PARTHENON_ENABLE_HOST_COMM_BUFFERS)
+  if (NOT Kokkos_ENABLE_CUDA AND NOT Kokkos_ENABLE_HIP)
+    message(FATAL_ERROR "Host pinned buffers for MPI communication are supported only for CUDA and HIP backends.")
+  endif()
 endif()
 
 # Build Tests and download Catch2

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -48,8 +48,14 @@ using HostExecSpace = Kokkos::DefaultHostExecutionSpace;
 using LayoutWrapper = Kokkos::LayoutRight;
 using MemUnmanaged = Kokkos::MemoryTraits<Kokkos::Unmanaged>;
 
-#if defined(KOKKOS_ENABLE_CUDA) && defined(PARTHENON_ENABLE_HOST_COMM_BUFFERS)
+#if defined(PARTHENON_ENABLE_HOST_COMM_BUFFERS)
+#if defined(KOKKOS_ENABLE_CUDA)
 using BufMemSpace = Kokkos::CudaHostPinnedSpace::memory_space;
+#elif defined(KOKKOS_ENABLE_HIP)
+using BufMemSpace = Kokkos::Experimental::HipHostPinnedSpace::memory_space;
+#else
+#error "Unknow comm buffer space for chose execution space."
+#endif
 #else
 using BufMemSpace = Kokkos::DefaultExecutionSpace::memory_space;
 #endif

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -24,7 +24,6 @@
 #include <catch2/catch.hpp>
 
 #include "kokkos_abstraction.hpp"
-#include "Kokkos_Macros.hpp"
 
 using parthenon::DevExecSpace;
 using parthenon::ParArray1D;

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -23,6 +23,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "Kokkos_Macros.hpp"
 #include "kokkos_abstraction.hpp"
 
 using parthenon::DevExecSpace;
@@ -230,13 +231,11 @@ TEST_CASE("par_for loops", "[wrapper]") {
     REQUIRE(test_wrapper_3d(parthenon::loop_pattern_tpttr_tag, default_exec_space) ==
             true);
 
-#if !(defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
-    REQUIRE(test_wrapper_3d(parthenon::loop_pattern_tptvr_tag, default_exec_space) ==
-            true);
+    KOKKOS_IF_ON_HOST(REQUIRE(test_wrapper_3d(parthenon::loop_pattern_tptvr_tag,
+                                              default_exec_space) == true);
 
-    REQUIRE(test_wrapper_3d(parthenon::loop_pattern_simdfor_tag, default_exec_space) ==
-            true);
-#endif
+                      REQUIRE(test_wrapper_3d(parthenon::loop_pattern_simdfor_tag,
+                                              default_exec_space) == true);)
   }
 
   SECTION("4D loops") {
@@ -252,13 +251,11 @@ TEST_CASE("par_for loops", "[wrapper]") {
     REQUIRE(test_wrapper_4d(parthenon::loop_pattern_tpttr_tag, default_exec_space) ==
             true);
 
-#if !(defined(KOKKOS_ENABLE_CUDA) || defined(KOKKOS_ENABLE_HIP))
-    REQUIRE(test_wrapper_4d(parthenon::loop_pattern_tptvr_tag, default_exec_space) ==
-            true);
+    KOKKOS_IF_ON_HOST(REQUIRE(test_wrapper_4d(parthenon::loop_pattern_tptvr_tag,
+                                              default_exec_space) == true);
 
-    REQUIRE(test_wrapper_4d(parthenon::loop_pattern_simdfor_tag, default_exec_space) ==
-            true);
-#endif
+                      REQUIRE(test_wrapper_4d(parthenon::loop_pattern_simdfor_tag,
+                                              default_exec_space) == true);)
   }
 }
 
@@ -409,11 +406,10 @@ TEST_CASE("nested par_for loops", "[wrapper]") {
                                    parthenon::inner_loop_pattern_tvr_tag,
                                    default_exec_space) == true);
 
-#ifndef KOKKOS_ENABLE_CUDA
-    REQUIRE(test_wrapper_nested_3d(parthenon::outer_loop_pattern_teams_tag,
-                                   parthenon::inner_loop_pattern_simdfor_tag,
-                                   default_exec_space) == true);
-#endif
+    KOKKOS_IF_ON_HOST(
+        REQUIRE(test_wrapper_nested_3d(parthenon::outer_loop_pattern_teams_tag,
+                                       parthenon::inner_loop_pattern_simdfor_tag,
+                                       default_exec_space) == true);)
   }
 
   SECTION("4D nested loops") {
@@ -421,11 +417,10 @@ TEST_CASE("nested par_for loops", "[wrapper]") {
                                    parthenon::inner_loop_pattern_tvr_tag,
                                    default_exec_space) == true);
 
-#ifndef KOKKOS_ENABLE_CUDA
-    REQUIRE(test_wrapper_nested_4d(parthenon::outer_loop_pattern_teams_tag,
-                                   parthenon::inner_loop_pattern_simdfor_tag,
-                                   default_exec_space) == true);
-#endif
+    KOKKOS_IF_ON_HOST(
+        REQUIRE(test_wrapper_nested_4d(parthenon::outer_loop_pattern_teams_tag,
+                                       parthenon::inner_loop_pattern_simdfor_tag,
+                                       default_exec_space) == true);)
   }
 }
 
@@ -472,275 +467,6 @@ TEST_CASE("Parallel scan", "[par_scan]") {
   SECTION("1D loops") {
     REQUIRE(test_wrapper_scan_1d(parthenon::loop_pattern_flatrange_tag,
                                  default_exec_space) == true);
-  }
-}
-
-struct LargeNShortTBufferPack {
-  int nghost;
-  int ncells; // number of cells in the linear dimension - very simplistic
-              // approach
-  ParArray4D<Real> arr_in;
-  // buffer in six direction, i plus, i minus, ...
-  ParArray1D<Real> buf_ip, buf_im, buf_jp, buf_jm, buf_kp, buf_km;
-  LargeNShortTBufferPack(const int nghost_, const int ncells_,
-                         const ParArray4D<Real> arr_in_, ParArray1D<Real> buf_ip_,
-                         ParArray1D<Real> buf_im_, ParArray1D<Real> buf_jp_,
-                         ParArray1D<Real> buf_jm_, ParArray1D<Real> buf_kp_,
-                         ParArray1D<Real> buf_km_)
-      : nghost(nghost_), ncells(ncells_), arr_in(arr_in_), buf_ip(buf_ip_),
-        buf_im(buf_im_), buf_jp(buf_jp_), buf_jm(buf_jm_), buf_kp(buf_kp_),
-        buf_km(buf_km_) {}
-  KOKKOS_INLINE_FUNCTION
-
-  void operator()(const int dir, const int n, const int it) const {
-    const int offset = n * (nghost * (ncells - 2 * nghost) * (ncells - 2 * nghost));
-
-    if (dir == 0) {
-      // it loops over [k,j,i]=[ [nghost,ncells-nghost),
-      //                         [nghost,ncells-nghost),
-      //                         [nghost,2*nghost) ]
-      // const int it_nk = ncells-nghost*2;
-      const int it_nj = ncells - nghost * 2;
-      const int it_ni = nghost;
-      const int it_k = it / (it_ni * it_nj);
-      const int it_j = (it - it_k * it_ni * it_nj) / it_ni;
-      const int it_i = it - it_k * it_ni * it_nj - it_j * it_ni;
-      const int k = it_k + nghost;
-      const int j = it_j + nghost;
-      const int i = it_i + nghost;
-      const int idx = it_i + it_ni * (it_j + it_nj * it_k);
-      buf_im(offset + idx) = arr_in(n, k, j, i);
-    } else if (dir == 1) {
-      // it loops over [k,j,i]=[ [nghost,ncells-nghost),
-      //                         [nghost,ncells-nghost),
-      //                         [ncells-2*nghost,ncells-nghost) ]
-      // const int it_nk = ncells-nghost*2;
-      const int it_nj = ncells - nghost * 2;
-      const int it_ni = nghost;
-      const int it_k = it / (it_ni * it_nj);
-      const int it_j = (it - it_k * it_ni * it_nj) / it_ni;
-      const int it_i = it - it_k * it_ni * it_nj - it_j * it_ni;
-      const int k = it_k + nghost;
-      const int j = it_j + nghost;
-      const int i = it_i + ncells - 2 * nghost;
-      const int idx = it_i + it_ni * (it_j + it_nj * it_k);
-      buf_ip(offset + idx) = arr_in(n, k, j, i);
-    } else if (dir == 2) {
-      // it loops over [k,j,i]=[ [nghost,ncells-nghost),
-      //                         [nghost,2*nghost),
-      //                         [nghost,ncells-nghost) ]
-      // const int it_nk = ncells-nghost*2;
-      const int it_nj = nghost;
-      const int it_ni = ncells - nghost * 2;
-      const int it_k = it / (it_ni * it_nj);
-      const int it_j = (it - it_k * it_ni * it_nj) / it_ni;
-      const int it_i = it - it_k * it_ni * it_nj - it_j * it_ni;
-      const int k = it_k + nghost;
-      const int j = it_j + nghost;
-      const int i = it_i + nghost;
-      const int idx = it_i + it_ni * (it_j + it_nj * it_k);
-      buf_jm(offset + idx) = arr_in(n, k, j, i);
-    } else if (dir == 3) {
-      // it loops over [k,j,i]=[ [nghost,ncells-nghost),
-      //                        [ncells-2*nghost,ncells),
-      //                        [nghost,ncells-nghost) ]
-      // const int it_nk = ncells-nghost*2;
-      const int it_nj = nghost;
-      const int it_ni = ncells - nghost * 2;
-      const int it_k = it / (it_ni * it_nj);
-      const int it_j = (it - it_k * it_ni * it_nj) / it_ni;
-      const int it_i = it - it_k * it_ni * it_nj - it_j * it_ni;
-      const int k = it_k + nghost;
-      const int j = it_j + ncells - 2 * nghost;
-      const int i = it_i + nghost;
-      const int idx = it_i + it_ni * (it_j + it_nj * it_k);
-      buf_jp(offset + idx) = arr_in(n, k, j, i);
-    } else if (dir == 4) {
-      // it loops over [k,j,i]=[ [nghost,2*nghost),
-      //                         [nghost,ncells-nghost),
-      //                         [nghost,ncells-nghost) ]
-      // const int it_nk = nghost;
-      const int it_nj = ncells - nghost * 2;
-      const int it_ni = ncells - nghost * 2;
-      const int it_k = it / (it_ni * it_nj);
-      const int it_j = (it - it_k * it_ni * it_nj) / it_ni;
-      const int it_i = it - it_k * it_ni * it_nj - it_j * it_ni;
-      const int k = it_k + nghost;
-      const int j = it_j + nghost;
-      const int i = it_i + nghost;
-      const int idx = it_i + it_ni * (it_j + it_nj * it_k);
-      buf_km(offset + idx) = arr_in(n, k, j, i);
-    } else if (dir == 5) {
-      // it loops over [k,j,i]=[ [ncells-2*nghost,ncells),
-      //                         [nghost,ncells-nghost),
-      //                         [nghost,ncells-nghost) ]
-      // const int it_nk = nghost;
-      const int it_nj = ncells - nghost * 2;
-      const int it_ni = ncells - nghost * 2;
-      const int it_k = it / (it_ni * it_nj);
-      const int it_j = (it - it_k * it_ni * it_nj) / it_ni;
-      const int it_i = it - it_k * it_ni * it_nj - it_j * it_ni;
-      const int k = it_k + ncells - 2 * nghost;
-      const int j = it_j + nghost;
-      const int i = it_i + nghost;
-      const int idx = it_i + it_ni * (it_j + it_nj * it_k);
-      buf_kp(offset + idx) = arr_in(n, k, j, i);
-    }
-  }
-
-  void run(DevExecSpace exec_space) {
-    const int nbuffers = 6; // number of buffers, here up, down, left, right, back, front
-    auto M = arr_in.extent(0);
-    auto slab_size = buf_im.extent(0) / M;
-    parthenon::par_for(parthenon::loop_pattern_mdrange_tag, "LargeNShortTBufferPack",
-                       exec_space, 0, nbuffers - 1, 0, M - 1, 0, slab_size - 1, *this);
-  }
-
-  template <typename TimeType>
-  static void test_time(const TimeType time_default, const TimeType time_spaces) {
-    // Test that streams are not introducing a performance penalty (within 10%
-    // uncertainty). The efficiency here depends on the available HW.
-    REQUIRE(time_spaces < 1.10 * time_default);
-  }
-};
-
-struct SmallNLongTBufferPack {
-  int nghost;
-  int ncells; // number of cells in the linear dimension - very simplistic
-              // approach
-  ParArray4D<Real> arr_in;
-  // buffer in six direction, i plus, i minus, ...
-  ParArray1D<Real> buf_ip, buf_im, buf_jp, buf_jm, buf_kp, buf_km;
-  SmallNLongTBufferPack(const int nghost_, const int ncells_,
-                        const ParArray4D<Real> arr_in_, ParArray1D<Real> buf_ip_,
-                        ParArray1D<Real> buf_im_, ParArray1D<Real> buf_jp_,
-                        ParArray1D<Real> buf_jm_, ParArray1D<Real> buf_kp_,
-                        ParArray1D<Real> buf_km_)
-      : nghost(nghost_), ncells(ncells_), arr_in(arr_in_), buf_ip(buf_ip_),
-        buf_im(buf_im_), buf_jp(buf_jp_), buf_jm(buf_jm_), buf_kp(buf_kp_),
-        buf_km(buf_km_) {}
-  KOKKOS_INLINE_FUNCTION
-  void operator()(const int n, const int dir) const {
-    int idx = 0;
-    const int offset = n * (nghost * (ncells - 2 * nghost) * (ncells - 2 * nghost));
-
-    if (dir == 0) {
-      for (auto k = nghost; k < ncells - nghost; k++)
-        for (auto j = nghost; j < ncells - nghost; j++)
-          for (auto i = nghost; i < 2 * nghost; i++)
-            buf_im(offset + idx++) = arr_in(n, k, j, i);
-    } else if (dir == 1) {
-      for (auto k = nghost; k < ncells - nghost; k++)
-        for (auto j = nghost; j < ncells - nghost; j++)
-          for (auto i = ncells - nghost; i < ncells; i++)
-            buf_ip(offset + idx++) = arr_in(n, k, j, i);
-    } else if (dir == 2) {
-      for (auto k = nghost; k < ncells - nghost; k++)
-        for (auto j = nghost; j < 2 * nghost; j++)
-          for (auto i = nghost; i < ncells - nghost; i++)
-            buf_jm(offset + idx++) = arr_in(n, k, j, i);
-    } else if (dir == 3) {
-      for (auto k = nghost; k < ncells - nghost; k++)
-        for (auto j = ncells - nghost; j < ncells; j++)
-          for (auto i = nghost; i < ncells - nghost; i++)
-            buf_jp(offset + idx++) = arr_in(n, k, j, i);
-    } else if (dir == 4) {
-      for (auto k = nghost; k < 2 * nghost; k++)
-        for (auto j = nghost; j < ncells - nghost; j++)
-          for (auto i = nghost; i < ncells - nghost; i++)
-            buf_km(offset + idx++) = arr_in(n, k, j, i);
-    } else if (dir == 5) {
-      for (auto k = ncells - nghost; k < ncells; k++)
-        for (auto j = nghost; j < ncells - nghost; j++)
-          for (auto i = nghost; i < ncells - nghost; i++)
-            buf_kp(offset + idx++) = arr_in(n, k, j, i);
-    }
-  }
-
-  void run(DevExecSpace exec_space) {
-    auto M = arr_in.extent(0);
-    const int nbuffers = 6; // number of buffers, here up, down, left, right, back, front
-    parthenon::par_for(parthenon::loop_pattern_mdrange_tag, "SmallNLongTBufferPack",
-                       exec_space, 0, M - 1, 0, nbuffers - 1, *this);
-  }
-
-  template <typename TimeType>
-  static void test_time(const TimeType time_default, const TimeType time_spaces) {
-    // Test that streams are not introducing a performance penalty (within 10%
-    // uncertainty). The efficiency here depends on the available HW.
-    REQUIRE(time_spaces < 1.10 * time_default);
-  }
-};
-
-template <class BufferPack>
-void test_wrapper_buffer_pack_overlapping_space_instances(const std::string &test_name) {
-  auto default_exec_space = DevExecSpace();
-
-  const int N = 24;      // ~meshblock size
-  const int M = 5;       // ~nhydro
-  const int nspaces = 2; // number of streams
-  const int nghost = 2;  // number of ghost zones
-  const int buf_size = M * nghost * (N - 2 * nghost) * (N - 2 * nghost);
-
-  std::vector<BufferPack> functs;
-  std::vector<DevExecSpace> exec_spaces;
-
-  for (auto n = 0; n < nspaces; n++) {
-    functs.push_back(BufferPack(
-        nghost, N, ParArray4D<Real>("SpaceInstance in", M, N, N, N),
-        ParArray1D<Real>("buf_ip", buf_size), ParArray1D<Real>("buf_im", buf_size),
-        ParArray1D<Real>("buf_jp", buf_size), ParArray1D<Real>("buf_jm", buf_size),
-        ParArray1D<Real>("buf_kp", buf_size), ParArray1D<Real>("buf_kp", buf_size)));
-    exec_spaces.push_back(parthenon::SpaceInstance<DevExecSpace>::create());
-  }
-
-  // warmup
-  for (auto it = 0; it < 10; it++) {
-    for (auto n = 0; n < nspaces; n++) {
-      functs[n].run(exec_spaces[n]);
-    }
-  }
-  Kokkos::fence();
-
-  Kokkos::Timer timer;
-
-  // meausre time using two execution space simultaneously
-  // race condition in access to arr_dev doesn't matter for this test
-  for (auto n = 0; n < nspaces; n++) {
-    functs[n].run(exec_spaces[n]);
-  }
-
-  Kokkos::fence();
-  auto time_spaces = timer.seconds();
-
-  timer.reset();
-
-  // measure runtime using the default execution space
-  for (auto n = 0; n < nspaces; n++) {
-    functs[n].run(default_exec_space);
-  }
-
-  default_exec_space.fence(); // making sure the kernel is done
-  auto time_default = timer.seconds();
-
-  std::cout << test_name << std::endl;
-  std::cout << "time default: " << time_default << std::endl;
-  std::cout << "time spaces: " << time_spaces << std::endl;
-
-  // make sure this test is reasonable IIF streams actually overlap, which is
-  // not the case for the OpenMP backend at this point
-  if (parthenon::SpaceInstance<DevExecSpace>::overlap()) {
-    BufferPack::test_time(time_default, time_spaces);
-  }
-}
-TEST_CASE("Overlapping SpaceInstances", "[wrapper][performance]") {
-  SECTION("Many Threads Short Kernel") {
-    test_wrapper_buffer_pack_overlapping_space_instances<LargeNShortTBufferPack>(
-        "Many Threads Short Kernel");
-  }
-  SECTION("Few Threads Long Kernel") {
-    test_wrapper_buffer_pack_overlapping_space_instances<SmallNLongTBufferPack>(
-        "Few Threads Long Kernel");
   }
 }
 

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -23,7 +23,6 @@
 
 #include <catch2/catch.hpp>
 
-#include "Kokkos_Core_fwd.hpp"
 #include "kokkos_abstraction.hpp"
 
 using parthenon::DevExecSpace;

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -23,6 +23,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "Kokkos_Core_fwd.hpp"
 #include "kokkos_abstraction.hpp"
 
 using parthenon::DevExecSpace;
@@ -230,11 +231,14 @@ TEST_CASE("par_for loops", "[wrapper]") {
     REQUIRE(test_wrapper_3d(parthenon::loop_pattern_tpttr_tag, default_exec_space) ==
             true);
 
-    KOKKOS_IF_ON_HOST(REQUIRE(test_wrapper_3d(parthenon::loop_pattern_tptvr_tag,
-                                              default_exec_space) == true);
+    if constexpr (std::is_same<Kokkos::DefaultExecutionSpace,
+                               Kokkos::DefaultHostExecutionSpace>::value) {
+      REQUIRE(test_wrapper_3d(parthenon::loop_pattern_tptvr_tag, default_exec_space) ==
+              true);
 
-                      REQUIRE(test_wrapper_3d(parthenon::loop_pattern_simdfor_tag,
-                                              default_exec_space) == true);)
+      REQUIRE(test_wrapper_3d(parthenon::loop_pattern_simdfor_tag, default_exec_space) ==
+              true);
+    }
   }
 
   SECTION("4D loops") {
@@ -250,11 +254,14 @@ TEST_CASE("par_for loops", "[wrapper]") {
     REQUIRE(test_wrapper_4d(parthenon::loop_pattern_tpttr_tag, default_exec_space) ==
             true);
 
-    KOKKOS_IF_ON_HOST(REQUIRE(test_wrapper_4d(parthenon::loop_pattern_tptvr_tag,
-                                              default_exec_space) == true);
+    if constexpr (std::is_same<Kokkos::DefaultExecutionSpace,
+                               Kokkos::DefaultHostExecutionSpace>::value) {
+      REQUIRE(test_wrapper_4d(parthenon::loop_pattern_tptvr_tag, default_exec_space) ==
+              true);
 
-                      REQUIRE(test_wrapper_4d(parthenon::loop_pattern_simdfor_tag,
-                                              default_exec_space) == true);)
+      REQUIRE(test_wrapper_4d(parthenon::loop_pattern_simdfor_tag, default_exec_space) ==
+              true);
+    }
   }
 }
 
@@ -405,10 +412,12 @@ TEST_CASE("nested par_for loops", "[wrapper]") {
                                    parthenon::inner_loop_pattern_tvr_tag,
                                    default_exec_space) == true);
 
-    KOKKOS_IF_ON_HOST(
-        REQUIRE(test_wrapper_nested_3d(parthenon::outer_loop_pattern_teams_tag,
-                                       parthenon::inner_loop_pattern_simdfor_tag,
-                                       default_exec_space) == true);)
+    if constexpr (std::is_same<Kokkos::DefaultExecutionSpace,
+                               Kokkos::DefaultHostExecutionSpace>::value) {
+      REQUIRE(test_wrapper_nested_3d(parthenon::outer_loop_pattern_teams_tag,
+                                     parthenon::inner_loop_pattern_simdfor_tag,
+                                     default_exec_space) == true);
+    }
   }
 
   SECTION("4D nested loops") {
@@ -416,10 +425,12 @@ TEST_CASE("nested par_for loops", "[wrapper]") {
                                    parthenon::inner_loop_pattern_tvr_tag,
                                    default_exec_space) == true);
 
-    KOKKOS_IF_ON_HOST(
-        REQUIRE(test_wrapper_nested_4d(parthenon::outer_loop_pattern_teams_tag,
-                                       parthenon::inner_loop_pattern_simdfor_tag,
-                                       default_exec_space) == true);)
+    if constexpr (std::is_same<Kokkos::DefaultExecutionSpace,
+                               Kokkos::DefaultHostExecutionSpace>::value) {
+      REQUIRE(test_wrapper_nested_4d(parthenon::outer_loop_pattern_teams_tag,
+                                     parthenon::inner_loop_pattern_simdfor_tag,
+                                     default_exec_space) == true);
+    }
   }
 }
 

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -23,8 +23,8 @@
 
 #include <catch2/catch.hpp>
 
-#include "Kokkos_Macros.hpp"
 #include "kokkos_abstraction.hpp"
+#include "Kokkos_Macros.hpp"
 
 using parthenon::DevExecSpace;
 using parthenon::ParArray1D;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Implemented changes as discussed during the call yesterday.
Fixes #770 


Also 
- fixed a hostcomm buffer logic on HIP that resulted in that feature silently falling back to device memory.
- started to use more abstract `KOKKOS_IF_ON_HOST` macros rather than separate checks for Cuda, Hip, ...


## PR Checklist

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
