### PR TITLE
New action: check PR dependencies & warn until requirements merged

### DIFF
--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,0 +1,10 @@
+on: [pull_request]
+
+jobs:
+  check_dependencies:
+    runs-on: ubuntu-latest
+    name: Check Dependencies
+    steps:
+    - uses: gregsdennis/dependencies-action@main
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-dependencies.yml
+++ b/.github/workflows/pr-dependencies.yml
@@ -1,9 +1,9 @@
+name: Check PR Dependencies
 on: [pull_request]
-
 jobs:
   check_dependencies:
     runs-on: ubuntu-latest
-    name: Check Dependencies
+    name: Required PRs Merged
     steps:
     - uses: gregsdennis/dependencies-action@main
       env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 777]](https://github.com/parthenon-hpc-lab/parthenon/pull/777) New action: check PR dependencies & warn until requirements merged
 - [[PR 772]](https://github.com/lanl/parthenon/pull/772) Trigger short CI only for PRs and remove old SpaceInstances test
 - [[PR 757]](https://github.com/lanl/parthenon/pull/757) Move to flux correction in-one and unify with bvals 
 - [[PR 768]](https://github.com/lanl/parthenon/pull/768) Update CI image and move to new CI machine (short and extended tests)

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ how to use them.
 
 # Contributors
 
-| Name          | Handle                | Team              |
+| Name     | Handle       | Team       |
 |----------|--------------|------------|
 | Jonah Miller | @Yurlungur  | LANL Physics  |
 | Josh Dolence | @jdolence | LANL Physics |
@@ -137,4 +137,4 @@ how to use them.
 | Ben Ryan | @brryan | LANL Physics |
 | Clell J. (CJ) Solomon | @clellsolomon | LANL Physics |
 | Luke Roberts | @lroberts36 | LANL Physics |
-
+| Ben Prather | @bprather | LANL Physics |


### PR DESCRIPTION
Add a Github action which checks dependencies between PRs.  Should fail until all required PRs are merged.

Action repository is here: https://github.com/gregsdennis/dependencies-action

The required access token need cover only reading pull requests and issues, which are public anyway.  It keys on any dependencies mentioned in the opening comment, e.g.

Depends on #772