### PR TITLE
Output variables with same shape as in parthenon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [[PR 712]](https://github.com/lanl/parthenon/pull/712) Allow to add params from cmdline
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 781]](https://github.com/lanl/parthenon/pull/781) Output variables with same shape as in parthenon
 - [[PR 758]](https://github.com/lanl/parthenon/pull/758) Bump required C++ standard to C++17
 - [[PR 710]](https://github.com/lanl/parthenon/pull/710) Remove data transpose in hdf5 and restart outputs
 - [[PR 713]](https://github.com/lanl/parthenon/pull/713) Remove Coordinates stub in favor of Coordinates_t
@@ -30,7 +31,7 @@
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[PR 772]](https://github.com/lanl/parthenon/pull/772) Trigger short CI only for PRs and remove old SpaceInstances test
-- [[PR 757]](https://github.com/lanl/parthenon/pull/757) Move to flux correction in-one and unify with bvals 
+- [[PR 757]](https://github.com/lanl/parthenon/pull/757) Move to flux correction in-one and unify with bvals
 - [[PR 768]](https://github.com/lanl/parthenon/pull/768) Update CI image and move to new CI machine (short and extended tests)
 - [[PR 766]](https://github.com/lanl/parthenon/pull/766) Remove IAS performance regression test
 - [[PR 735]](https://github.com/lanl/parthenon/pull/735) Clean up HDF5 output

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -499,21 +499,24 @@ class phdf:
 
             elif self.OutputFormatVersion == 2:
                 if np.prod(vShape) > self.TotalCells:
-                      ret = np.empty(
-                          (vShape[1], self.TotalCells), dtype=self.varData[variable].dtype
-                      )
-                      ret[:] = np.nan
-                      for i in range(vShape[1]):
-                          ret[i] = self.varData[variable][:, i, :, :, :].ravel()
-                      assert (ret != np.nan).all()
-                      return ret
+                    ret = np.empty(
+                        (vShape[1], self.TotalCells), dtype=self.varData[variable].dtype
+                    )
+                    ret[:] = np.nan
+                    for i in range(vShape[1]):
+                        ret[i] = self.varData[variable][:, i, :, :, :].ravel()
+                    assert (ret != np.nan).all()
+                    return ret
                 else:
                     return self.varData[variable][:].reshape(self.TotalCells)
 
             elif self.OutputFormatVersion == 3:
                 # Check for cell-centered data
-                if (vShape[-1] == self.MeshBlockSize[0] and vShape[-2] == self.MeshBlockSize[1] and
-                   vShape[-3] == self.MeshBlockSize[2]):
+                if (
+                    vShape[-1] == self.MeshBlockSize[0]
+                    and vShape[-2] == self.MeshBlockSize[1]
+                    and vShape[-3] == self.MeshBlockSize[2]
+                ):
                     fieldShape = vShape[1:-3]
                     totalFieldEntries = np.prod(fieldShape)
                     ndim = len(fieldShape)
@@ -522,36 +525,48 @@ class phdf:
                     else:
                         if ndim == 1:
                             ret = np.empty(
-                              (vShape[1], self.TotalCells), dtype=self.varData[variable].dtype)
+                                (vShape[1], self.TotalCells),
+                                dtype=self.varData[variable].dtype,
+                            )
                             ret[:] = np.nan
                             for i in range(vShape[1]):
-                                ret[i] = self.varData[variable][:,i,:,:,:].ravel()
+                                ret[i] = self.varData[variable][:, i, :, :, :].ravel()
                             assert (ret != np.nan).all()
                             return ret
                         elif ndim == 2:
                             ret = np.empty(
-                              (vShape[1]*vShape[2], self.TotalCells), dtype=self.varData[variable].dtype)
+                                (vShape[1] * vShape[2], self.TotalCells),
+                                dtype=self.varData[variable].dtype,
+                            )
                             ret[:] = np.nan
                             for i in range(vShape[1]):
                                 for j in range(vShape[2]):
-                                    ret[i + vShape[1]*j] = self.varData[variable][:,i,j,:,:,:].ravel()
+                                    ret[i + vShape[1] * j] = self.varData[variable][
+                                        :, i, j, :, :, :
+                                    ].ravel()
                             assert (ret != np.nan).all()
                             return ret
                         else:
                             ret = np.empty(
-                              (vShape[1]*vShape[2]*vShape[3], self.TotalCells), dtype=self.varData[variable].dtype)
+                                (vShape[1] * vShape[2] * vShape[3], self.TotalCells),
+                                dtype=self.varData[variable].dtype,
+                            )
                             ret[:] = np.nan
                             for i in range(vShape[1]):
                                 for j in range(vShape[2]):
                                     for k in range(vShape[3]):
-                                        ret[i + vShape[1]*(j + vShape[2]*k)] = self.varData[variable][:,i,j,k,:,:,:].ravel()
+                                        ret[
+                                            i + vShape[1] * (j + vShape[2] * k)
+                                        ] = self.varData[variable][
+                                            :, i, j, k, :, :, :
+                                        ].ravel()
                             assert (ret != np.nan).all()
                             return ret
                 else:
-                  # Not cell-based variable
-                  raise Exception(
-                      f"Flattening only supported for cell-based variables but requested for {variable}"
-                  )
+                    # Not cell-based variable
+                    raise Exception(
+                        f"Flattening only supported for cell-based variables but requested for {variable}"
+                    )
 
         if self.IncludesGhost and interior:
             nghost = self.NGhost

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -488,10 +488,6 @@ class phdf:
 
         vShape = self.varData[variable].shape
         if flatten:
-            # if variable is not a scalar flatten cells component-wise
-            print('sdifj')
-            print(vShape)
-            print(self.TotalCells)
             # TODO(tbd) remove legacy mode in next major rel.
             if self.OutputFormatVersion == -1:
                 if np.prod(vShape) > self.TotalCells:
@@ -515,9 +511,9 @@ class phdf:
                     return self.varData[variable][:].reshape(self.TotalCells)
 
             elif self.OutputFormatVersion == 3:
-                # TODO(BRR) This isn't quite right -- may need to output additional metadata
                 # Check for cell-centered data
-                if vShape[-1] * vShape[-2] * vShape[-3] == self.TotalCells:
+                if (vShape[-1] == self.MeshBlockSize[0] and vShape[-2] == self.MeshBlockSize[1] and
+                   vShape[-3] == self.MeshBlockSize[2]):
                     fieldShape = vShape[1:-3]
                     totalFieldEntries = np.prod(fieldShape)
                     ndim = len(fieldShape)

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -142,12 +142,16 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
     for (int i = N; i < 3; i++)
       arrDims[i + 3] = 1;
   } else if (IsSet(Particle)) {
-    assert(N >= 1 && N <= 5);
+    assert(N >= 0 && N <= 5);
     arrDims[0] = 1; // To be updated by swarm based on pool size before allocation
     for (int i = 0; i < N; i++)
       arrDims[i + 1] = shape[i];
     for (int i = N; i < 5; i++)
       arrDims[i + 1] = 1;
+  } else if (IsSet(Swarm)) {
+    // No dimensions
+    // TODO(BRR) This will be replaced in the swarm packing PR, but is currently required
+    // since swarms carry metadata but do not have an array size.
   } else {
     // This variable is not necessarily tied to any specific
     // mesh element, so dims will be used as the actual array

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -128,7 +128,7 @@ std::array<int, 6> Metadata::GetArrayDims(std::weak_ptr<MeshBlock> wpmb,
     // classes add the +1's where needed.  They all expect
     // these dimensions to be the number of cells in each
     // direction, NOT the size of the arrays
-    assert(N >= 1 && N <= 3);
+    assert(N >= 0 && N <= 3);
     PARTHENON_REQUIRE_THROWS(!wpmb.expired(),
                              "Cannot determine array dimensions for mesh-tied entity "
                              "without a valid meshblock");

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -272,14 +272,6 @@ class Metadata {
   bool IsValid(bool throw_on_fail = false) const {
     bool valid = true;
 
-    // No empty shapes for variables not tied to mesh
-    if (shape_.size() == 0 && CountSet({None}) == 1) {
-      valid = false;
-      if (throw_on_fail) {
-        PARTHENON_THROW("Must specify non-empty Shape if variable is not tied to mesh");
-      }
-    }
-
     // Topology
     if (CountSet({None, Node, Edge, Face, Cell}) != 1) {
       valid = false;

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -194,6 +194,8 @@ class Metadata {
   // There are 3 optional arguments: shape, component_labels, and associated, so we'll
   // need 8 constructors to provide all possible variants
 
+  // By default shape is empty; this corresponds to scalar data on the mesh
+
   // 4 constructors, this is the general constructor called by all other constructors, so
   // we do some sanity checks here
   Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
@@ -270,6 +272,14 @@ class Metadata {
   // is true, throw a descriptive exception when invalid
   bool IsValid(bool throw_on_fail = false) const {
     bool valid = true;
+
+    // No empty shapes for variables not tied to mesh
+    if (shape.size() == 0 && CountSet({None}) == 1) {
+      valid = false;
+      if (throw_on_fail) {
+        PARTHENON_THROW("Must specify non-empty Shape if variable is not tied to mesh");
+      }
+    }
 
     // Topology
     if (CountSet({None, Node, Edge, Face, Cell}) != 1) {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -225,7 +225,7 @@ class Metadata {
     // check shape is valid
     // TODO(JL) Should we be extra pedantic and check that shape matches Vector/Tensor
     // flags?
-    PARTHENON_REQUIRE_THROWS(shape_.size() > 0, "Shape must have at least rank 1");
+    PARTHENON_REQUIRE_THROWS(shape_.size() >= 0, "Shape must have at least rank 0");
     if (IsMeshTied()) {
       PARTHENON_REQUIRE_THROWS(
           shape_.size() <= 3,

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -227,7 +227,6 @@ class Metadata {
     // check shape is valid
     // TODO(JL) Should we be extra pedantic and check that shape matches Vector/Tensor
     // flags?
-    PARTHENON_REQUIRE_THROWS(shape_.size() >= 0, "Shape must have at least rank 0");
     if (IsMeshTied()) {
       PARTHENON_REQUIRE_THROWS(
           shape_.size() <= 3,

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -196,7 +196,7 @@ class Metadata {
 
   // 4 constructors, this is the general constructor called by all other constructors, so
   // we do some sanity checks here
-  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {1},
+  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
            const std::vector<std::string> &component_labels = {},
            const std::string &associated = "")
       : shape_(shape), component_labels_(component_labels), associated_(associated) {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -51,6 +51,8 @@
   PARTHENON_INTERNAL_FOR_FLAG(Node)                                                      \
   /** particle variable */                                                               \
   PARTHENON_INTERNAL_FOR_FLAG(Particle)                                                  \
+  /** swarm */                                                                           \
+  PARTHENON_INTERNAL_FOR_FLAG(Swarm)                                                     \
   /************************************************/                                     \
   /** ROLE: Exactly one must be specified (default is Provides) */                       \
   /** Private to a package */                                                            \

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -274,7 +274,7 @@ class Metadata {
     bool valid = true;
 
     // No empty shapes for variables not tied to mesh
-    if (shape.size() == 0 && CountSet({None}) == 1) {
+    if (shape_.size() == 0 && CountSet({None}) == 1) {
       valid = false;
       if (throw_on_fail) {
         PARTHENON_THROW("Must specify non-empty Shape if variable is not tied to mesh");

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -212,7 +212,9 @@ class SwarmProvider : public VariableProvider {
  private:
   void AddSwarm_(StateDescriptor *package, const std::string &swarm,
                  const std::string &swarm_name, const Metadata &metadata) {
-    state_->AddSwarm(swarm_name, metadata);
+    Metadata newm(metadata);
+    newm.Set(Metadata::Swarm);
+    state_->AddSwarm(swarm_name, newm);
     for (auto &p : package->AllSwarmValues(swarm)) {
       auto &val_name = p.first;
       auto &val_meta = p.second;

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -172,10 +172,13 @@ void Swarm::Add(const std::string &label, const Metadata &metadata) {
                                 " already enrolled during Add()!");
   }
 
-  if (metadata.Type() == Metadata::Integer) {
-    Add_<int>(label, metadata);
-  } else if (metadata.Type() == Metadata::Real) {
-    Add_<Real>(label, metadata);
+  Metadata newm(metadata);
+  newm.Set(Metadata::Particle);
+
+  if (newm.Type() == Metadata::Integer) {
+    Add_<int>(label, newm);
+  } else if (newm.Type() == Metadata::Real) {
+    Add_<Real>(label, newm);
   } else {
     throw std::invalid_argument("swarm variable " + label +
                                 " does not have a valid type during Add()");

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -842,16 +842,31 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
 
     int ndim = -1;
     if (vinfo.where == MetadataFlag(Metadata::Cell)) {
-      ndim = 3 + vinfo.ndim;
+      printf("CELL VARIABLE!\n");
+      ndim = 3 + vinfo.ndim + 1;
       for (int i = 0; i < vinfo.ndim; i++) {
-        local_count[1 + i] = alldims[3 - ndim + i];
+        local_count[1 + i] = global_count[1 + i] = alldims[3 - vinfo.ndim + i];
+        printf("extradim: alldims[%i] = %i\n", 3-vinfo.ndim + 1, alldims[3-vinfo.ndim+i]);
       }
-      local_count[ndim + 1] = nx3;
-      local_count[ndim + 2] = nx2;
-      local_count[ndim + 3] = nx1;
+      local_count[vinfo.ndim + 1] = global_count[vinfo.ndim + 1] = nx3;
+      local_count[vinfo.ndim + 2] = global_count[vinfo.ndim + 2] = nx2;
+      local_count[vinfo.ndim + 3] = global_count[vinfo.ndim + 3] = nx1;
     } else {
-      ndim = vinfo.ndim;
+      printf("NONE VARIABLE!\n");
+      ndim = vinfo.ndim + 1;
+      for (int i = 0; i < vinfo.ndim; i++) {
+        local_count[1 + i] = global_count[1 + i] = alldims[6 - vinfo.ndim + i];
+      }
     }
+
+    printf("label: %s\n", vinfo.label.c_str());
+    printf("  aldims: %i %i %i %i %i %i\n", alldims[0], alldims[1], alldims[2], alldims[3], alldims[4], alldims[5]);
+    printf("ndim: %i\n", ndim);
+    for (int i = 0; i < ndim; i++) {
+      printf("local_count[%i] = %i  glob: %i\n", i, local_count[i], global_count[i]);
+    }
+
+
 
     // load up data
     hsize_t index = 0;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -843,9 +843,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       if (output_params.hdf5_compression_level > 0) {
         // we need chunks to enable compression
         std::array<hsize_t, H5_NDIM> chunk_size({1, 1, 1, 1, 1, 1, 1});
-        for (int i = 0; i < ndim - 3; i++) {
-          chunk_size[i] = 1;
-        }
         for (int i = ndim - 3; i < ndim; i++) {
           chunk_size[i] = local_count[i];
         }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -919,6 +919,13 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
         }
       }
 
+      if (b_idx == 0) {
+      printf("var_name: %s sparse? %i\n", var_name.c_str(), vinfo.is_sparse);
+      for (int i = 0; i < 7; i++) {
+        printf("[%i] count local: %i global: %i\n", i, local_count[i], global_count[i]);
+      }
+      }
+
       if (vinfo.is_sparse) {
         size_t sparse_idx = sparse_field_idx.at(vinfo.label);
         sparse_allocated[b_idx * num_sparse + sparse_idx] = is_allocated;
@@ -927,7 +934,10 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       if (!is_allocated) {
         if (vinfo.is_sparse) {
           const hsize_t varSize =
-              vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
+              //vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
+              vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * (out_kb.e - out_kb.s + 1) * (out_jb.e - out_jb.s + 1) * (out_ib.e - out_ib.s + 1);
+//              printf("vlen: %i varSize = %i -> N = %i  new varSize = %i\n",
+//                vinfo.vlen, vinfo.nx3*info.nx2*vinfo.nx1
           memset(tmpData.data() + index, 0, varSize * sizeof(OutT));
           index += varSize;
         } else {

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -838,12 +838,14 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     local_count[2] = global_count[2] = nx5;
     local_count[3] = global_count[3] = nx4;
 
-    std::vector<hsize_t> alldims({nx6, nx5, nx4, nx3, nx2, nx1});
+    std::vector<hsize_t> alldims({nx6, nx5, nx4, static_cast<hsize_t>(nx3), static_cast<hsize_t>(nx2), static_cast<hsize_t>(nx1)});
 
     int ndim = -1;
     if (vinfo.where == MetadataFlag(Metadata::Cell)) {
       ndim = 3 + vinfo.ndim;
-      for (int i = 0;
+      for (int i = 0; i < vinfo.ndim; i++) {
+        local_count[1 + i] = alldims[3 - ndim + i];
+      }
       local_count[ndim + 1] = nx3;
       local_count[ndim + 2] = nx2;
       local_count[ndim + 3] = nx1;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -817,7 +817,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     memset(tmpData.data(), 0, tmpData.size() * sizeof(OutT));
 
     const std::string var_name = vinfo.label;
-    const hsize_t vlen = vinfo.vlen;
     const hsize_t nx6 = vinfo.nx6;
     const hsize_t nx5 = vinfo.nx5;
     const hsize_t nx4 = vinfo.nx4;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -851,12 +851,14 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       local_count[vinfo.ndim + 1] = global_count[vinfo.ndim + 1] = nx3;
       local_count[vinfo.ndim + 2] = global_count[vinfo.ndim + 2] = nx2;
       local_count[vinfo.ndim + 3] = global_count[vinfo.ndim + 3] = nx1;
-    } else {
+    } else if (vinfo.where == MetadataFlag(Metadata::None)) {
       printf("NONE VARIABLE!\n");
       ndim = vinfo.ndim + 1;
       for (int i = 0; i < vinfo.ndim; i++) {
         local_count[1 + i] = global_count[1 + i] = alldims[6 - vinfo.ndim + i];
       }
+    } else {
+      PARTHENON_THROW("Only Cell and None locations supported!");
     }
 
     printf("label: %s\n", vinfo.label.c_str());

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -919,13 +919,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
         }
       }
 
-      if (b_idx == 0) {
-      printf("var_name: %s sparse? %i\n", var_name.c_str(), vinfo.is_sparse);
-      for (int i = 0; i < 7; i++) {
-        printf("[%i] count local: %i global: %i\n", i, local_count[i], global_count[i]);
-      }
-      }
-
       if (vinfo.is_sparse) {
         size_t sparse_idx = sparse_field_idx.at(vinfo.label);
         sparse_allocated[b_idx * num_sparse + sparse_idx] = is_allocated;
@@ -933,11 +926,14 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
 
       if (!is_allocated) {
         if (vinfo.is_sparse) {
-          const hsize_t varSize =
-              //vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
-              vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * (out_kb.e - out_kb.s + 1) * (out_jb.e - out_jb.s + 1) * (out_ib.e - out_ib.s + 1);
-//              printf("vlen: %i varSize = %i -> N = %i  new varSize = %i\n",
-//                vinfo.vlen, vinfo.nx3*info.nx2*vinfo.nx1
+          hsize_t varSize{};
+          if (vinfo.where == MetadataFlag(Metadata::Cell)) {
+            varSize = vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * (out_kb.e - out_kb.s + 1) *
+                      (out_jb.e - out_jb.s + 1) * (out_ib.e - out_ib.s + 1);
+          } else {
+            varSize =
+                vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
+          }
           memset(tmpData.data() + index, 0, varSize * sizeof(OutT));
           index += varSize;
         } else {
@@ -949,7 +945,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     }
 
     // write data to file
-    // HDF5WriteND(file, var_name, tmpData.data(), H5_NDIM, p_loc_offset, p_loc_cnt,
     HDF5WriteND(file, var_name, tmpData.data(), ndim, p_loc_offset, p_loc_cnt, p_glob_cnt,
                 pl_xfer, pl_dcreate);
   }

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -38,10 +38,10 @@
 namespace parthenon {
 namespace HDF5 {
 
-// Number of dimension of HDF5 field data sets (block x num vars x nz x ny x nx)
-static constexpr size_t H5_NDIM = 5;
+// Number of dimension of HDF5 field data sets (block x nv x nu x nt x nz x ny x nx)
+static constexpr size_t H5_NDIM = 7;
 
-static constexpr int OUTPUT_VERSION_FORMAT = 2;
+static constexpr int OUTPUT_VERSION_FORMAT = 3;
 
 /**
  * @brief RAII handles for HDF5. Use the typedefs directly (e.g. `H5A`, `H5D`, etc.)

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -89,9 +89,6 @@ RestartReader::SparseInfo RestartReader::GetSparseInfo() const {
     // member
     info.allocated.reset(new hbool_t[hdl.count]);
     info.num_blocks = static_cast<int>(hdl.dims[0]);
-    printf("num_blocks = %i\n", info.num_blocks);
-    printf("num_sparse: %i\n", info.num_sparse);
-    printf("count: %i\n", hdl.count);
 
     const H5S memspace =
         H5S::FromHIDCheck(H5Screate_simple(hdl.rank, hdl.dims.data(), NULL));

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -89,6 +89,9 @@ RestartReader::SparseInfo RestartReader::GetSparseInfo() const {
     // member
     info.allocated.reset(new hbool_t[hdl.count]);
     info.num_blocks = static_cast<int>(hdl.dims[0]);
+    printf("num_blocks = %i\n", info.num_blocks);
+    printf("num_sparse: %i\n", info.num_sparse);
+    printf("count: %i\n", hdl.count);
 
     const H5S memspace =
         H5S::FromHIDCheck(H5Screate_simple(hdl.rank, hdl.dims.data(), NULL));

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -205,10 +205,8 @@ class RestartReader {
     }
 
     hsize_t total_count = 1;
-    printf("name: %s\n", name.c_str());
     for (int i = 0; i < total_dim; ++i) {
       total_count *= count[i];
-      printf("[%i] count = %i\n", i, count[i]);
     }
 
     PARTHENON_REQUIRE_THROWS(dataVec.size() >= total_count,

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -28,8 +28,8 @@
 #ifdef ENABLE_HDF5
 #include <hdf5.h>
 
-#include "outputs/parthenon_hdf5.hpp"
 #include "interface/metadata.hpp"
+#include "outputs/parthenon_hdf5.hpp"
 
 using namespace parthenon::HDF5;
 // TODO(someone) the following "else" is very ugly but fixes missing types when not
@@ -144,8 +144,7 @@ class RestartReader {
   template <typename T>
   void ReadBlocks(const std::string &name, IndexRange range, std::vector<T> &dataVec,
                   const std::vector<size_t> &bsize, int file_output_format_version,
-                  MetadataFlag where,
-                  const std::vector<int> &shape = {}) const {
+                  MetadataFlag where, const std::vector<int> &shape = {}) const {
 #ifndef ENABLE_HDF5
     PARTHENON_FAIL("Restart functionality is not available because HDF5 is disabled");
 #else  // HDF5 enabled
@@ -192,12 +191,9 @@ class RestartReader {
     }
 
     hsize_t total_count = 1;
-    printf("name: %s\n", name.c_str());
     for (int i = 0; i < total_dim; ++i) {
       total_count *= count[i];
-      printf("  count[%i] = %i\n", i, count[i]);
     }
-    printf("total_count: %i\n", total_count);
 
     PARTHENON_REQUIRE_THROWS(dataVec.size() >= total_count,
                              "Buffer (size " + std::to_string(dataVec.size()) +

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -168,6 +168,13 @@ class RestartReader {
       count[4] = vlen;
       total_dim = 5;
     } else if (file_output_format_version == 2) {
+      PARTHENON_REQUIRE(
+          shape.size() <= 1,
+          "Higher than vector datatypes are unstable in output versions < 3");
+      size_t vlen = 1;
+      for (int i = 0; i < shape.size(); i++) {
+        vlen *= shape[i];
+      }
       count[0] = static_cast<hsize_t>(range.e - range.s + 1);
       count[1] = vlen;
       count[2] = bsize[2];

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -205,8 +205,10 @@ class RestartReader {
     }
 
     hsize_t total_count = 1;
+    printf("name: %s\n", name.c_str());
     for (int i = 0; i < total_dim; ++i) {
       total_count *= count[i];
+      printf("[%i] count = %i\n", i, count[i]);
     }
 
     PARTHENON_REQUIRE_THROWS(dataVec.size() >= total_count,

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -29,6 +29,7 @@
 #include <hdf5.h>
 
 #include "outputs/parthenon_hdf5.hpp"
+#include "interface/metadata.hpp"
 
 using namespace parthenon::HDF5;
 // TODO(someone) the following "else" is very ugly but fixes missing types when not
@@ -143,40 +144,60 @@ class RestartReader {
   template <typename T>
   void ReadBlocks(const std::string &name, IndexRange range, std::vector<T> &dataVec,
                   const std::vector<size_t> &bsize, int file_output_format_version,
-                  size_t vlen = 1) const {
+                  MetadataFlag where,
+                  const std::vector<int> &shape = {}) const {
 #ifndef ENABLE_HDF5
     PARTHENON_FAIL("Restart functionality is not available because HDF5 is disabled");
 #else  // HDF5 enabled
     auto hdl = OpenDataset<T>(name);
 
-    PARTHENON_REQUIRE_THROWS(hdl.rank == 5, "Expected data set of rank 5, but dataset " +
-                                                name + " has rank " +
-                                                std::to_string(hdl.rank));
+    constexpr int CHUNK_MAX_DIM = 7;
 
     /** Select hyperslab in dataset **/
-    hsize_t offset[5] = {static_cast<hsize_t>(range.s), 0, 0, 0, 0};
-    hsize_t count[5];
+    hsize_t offset[CHUNK_MAX_DIM] = {static_cast<hsize_t>(range.s), 0, 0, 0, 0, 0, 0};
+    hsize_t count[CHUNK_MAX_DIM];
+    int total_dim = 0;
     if (file_output_format_version == -1) {
+      size_t vlen = 1;
+      for (int i = 0; i < shape.size(); i++) {
+        vlen *= shape[i];
+      }
       count[0] = static_cast<hsize_t>(range.e - range.s + 1);
       count[1] = bsize[2];
       count[2] = bsize[1];
       count[3] = bsize[0];
       count[4] = vlen;
-
+      total_dim = 5;
     } else if (file_output_format_version == HDF5::OUTPUT_VERSION_FORMAT) {
       count[0] = static_cast<hsize_t>(range.e - range.s + 1);
-      count[1] = vlen;
-      count[2] = bsize[2];
-      count[3] = bsize[1];
-      count[4] = bsize[0];
+      const int ndim = shape.size();
+      if (where == MetadataFlag(Metadata::Cell)) {
+        for (int i = 0; i < ndim; i++) {
+          count[1 + i] = shape[ndim - i - 1];
+        }
+        count[ndim + 1] = bsize[2];
+        count[ndim + 2] = bsize[1];
+        count[ndim + 3] = bsize[0];
+        total_dim = 3 + ndim + 1;
+      } else if (where == MetadataFlag(Metadata::None)) {
+        for (int i = 0; i < ndim; i++) {
+          count[1 + i] = shape[ndim - i - 1];
+        }
+        total_dim = ndim + 1;
+      } else {
+        PARTHENON_THROW("Only Cell and None locations supported!");
+      }
     } else {
       PARTHENON_THROW("Unknown output format version in restart file.")
     }
 
     hsize_t total_count = 1;
-    for (int i = 0; i < 5; ++i) {
+    printf("name: %s\n", name.c_str());
+    for (int i = 0; i < total_dim; ++i) {
       total_count *= count[i];
+      printf("  count[%i] = %i\n", i, count[i]);
     }
+    printf("total_count: %i\n", total_count);
 
     PARTHENON_REQUIRE_THROWS(dataVec.size() >= total_count,
                              "Buffer (size " + std::to_string(dataVec.size()) +
@@ -185,7 +206,7 @@ class RestartReader {
     PARTHENON_HDF5_CHECK(
         H5Sselect_hyperslab(hdl.dataspace, H5S_SELECT_SET, offset, NULL, count, NULL));
 
-    const H5S memspace = H5S::FromHIDCheck(H5Screate_simple(5, count, NULL));
+    const H5S memspace = H5S::FromHIDCheck(H5Screate_simple(total_dim, count, NULL));
     PARTHENON_HDF5_CHECK(
         H5Sselect_hyperslab(hdl.dataspace, H5S_SELECT_SET, offset, NULL, count, NULL));
 

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -167,6 +167,13 @@ class RestartReader {
       count[3] = bsize[0];
       count[4] = vlen;
       total_dim = 5;
+    } else if (file_output_format_version == 2) {
+      count[0] = static_cast<hsize_t>(range.e - range.s + 1);
+      count[1] = vlen;
+      count[2] = bsize[2];
+      count[3] = bsize[1];
+      count[4] = bsize[0];
+      total_dim = 5;
     } else if (file_output_format_version == HDF5::OUTPUT_VERSION_FORMAT) {
       count[0] = static_cast<hsize_t>(range.e - range.s + 1);
       const int ndim = shape.size();

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -344,7 +344,8 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
             }
           }
         }
-      } else if (file_output_format_ver == HDF5::OUTPUT_VERSION_FORMAT) {
+      } else if (file_output_format_ver == 2 ||
+                 file_output_format_ver == HDF5::OUTPUT_VERSION_FORMAT) {
         for (int t = 0; t < Nt; ++t) {
           for (int u = 0; u < Nu; ++u) {
             for (int v = 0; v < Nv; ++v) {

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -235,7 +235,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     // Being extra stringent here so that we don't forget to update the machinery when
     // another change happens.
     PARTHENON_REQUIRE_THROWS(
-        HDF5::OUTPUT_VERSION_FORMAT == 2,
+        HDF5::OUTPUT_VERSION_FORMAT == 3,
         "Auto conversion from old to current format not implemented yet.")
     if (Globals::my_rank == 0) {
       PARTHENON_WARN("Restarting from a old output file format. New outputs written with "
@@ -306,7 +306,8 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     if (Globals::my_rank == 0) std::cout << "Var:" << label << ":" << vlen << std::endl;
     // Read relevant data from the hdf file, this works for dense and sparse variables
     try {
-      resfile.ReadBlocks(label, myBlocks, tmp, bsize, file_output_format_ver, vlen);
+      resfile.ReadBlocks(label, myBlocks, tmp, bsize, file_output_format_ver, v_info->metadata().Where(),
+        v_info->metadata().Shape());
     } catch (std::exception &ex) {
       std::cout << "[" << Globals::my_rank << "] WARNING: Failed to read variable "
                 << label << " from restart file:" << std::endl

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -332,6 +332,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
 
       // Double note that this also needs to be update in case
       // we update the HDF5 infrastructure!
+      printf("format: %i\n", file_output_format_ver);
       if (file_output_format_ver == -1) {
         for (int k = out_kb.s; k <= out_kb.e; ++k) {
           for (int j = out_jb.s; j <= out_jb.e; ++j) {

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -306,8 +306,8 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     if (Globals::my_rank == 0) std::cout << "Var:" << label << ":" << vlen << std::endl;
     // Read relevant data from the hdf file, this works for dense and sparse variables
     try {
-      resfile.ReadBlocks(label, myBlocks, tmp, bsize, file_output_format_ver, v_info->metadata().Where(),
-        v_info->metadata().Shape());
+      resfile.ReadBlocks(label, myBlocks, tmp, bsize, file_output_format_ver,
+                         v_info->metadata().Where(), v_info->metadata().Shape());
     } catch (std::exception &ex) {
       std::cout << "[" << Globals::my_rank << "] WARNING: Failed to read variable "
                 << label << " from restart file:" << std::endl

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -333,7 +333,6 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
 
       // Double note that this also needs to be update in case
       // we update the HDF5 infrastructure!
-      printf("format: %i\n", file_output_format_ver);
       if (file_output_format_ver == -1) {
         for (int k = out_kb.s; k <= out_kb.e; ++k) {
           for (int j = out_jb.s; j <= out_jb.e; ++j) {

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -235,8 +235,9 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     // Being extra stringent here so that we don't forget to update the machinery when
     // another change happens.
     PARTHENON_REQUIRE_THROWS(
-        HDF5::OUTPUT_VERSION_FORMAT == 3,
-        "Auto conversion from old to current format not implemented yet.")
+        HDF5::OUTPUT_VERSION_FORMAT == 2 || HDF5::OUTPUT_VERSION_FORMAT == 3,
+        "Auto conversion from original to format 2 or 3 not implemented yet.")
+
     if (Globals::my_rank == 0) {
       PARTHENON_WARN("Restarting from a old output file format. New outputs written with "
                      "this binary will use new format.")

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -271,6 +271,9 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
       }
 
       THEN("We can safely resolve conflicts") {
+        Metadata m_provides_swarm(m_provides);
+        // This is set automatically when adding a Swarm if not already set
+        m_provides_swarm.Set(Metadata::Swarm);
         auto pkg4 = ResolvePackages(packages);
         AND_THEN("The provides variables take precedence.") {
           REQUIRE(pkg4->FieldPresent("dense"));

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -279,7 +279,7 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
           REQUIRE(pkg4->FieldPresent("dense"));
           REQUIRE(pkg4->FieldMetadata("dense") == m_provides);
           REQUIRE(pkg4->SwarmPresent("swarm"));
-          REQUIRE(pkg4->SwarmMetadata("swarm") == m_provides);
+          REQUIRE(pkg4->SwarmMetadata("swarm") == m_provides_swarm);
           REQUIRE(pkg4->SwarmValuePresent("provides", "swarm"));
           REQUIRE(!(pkg4->SwarmValuePresent("overridable", "swarm")));
           REQUIRE(pkg4->SparseBaseNamePresent("sparse"));


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Currently all parthenon variables are output in HDF5 as `[nblock, nvar, nk, nj, ni]`. This PR changes this for dumps ~~(not restarts)~~ so that variables are output in the same shape as they exist in parthenon variables. For example, in the HDF5 file a cell-centered tensor will have shape `[nblock, nu, nv, nk, nj, ni]`, a cell-centered scalar will have shape `[nblock, nk, nj, ni]`, and a non-mesh-tied variable with metadata `shape = {a, b, c}` will have shape `[nblock, c, b, a]`. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
- [x] Get sign-off from a quorum of the various downstream code representatives
- [x] Fix `phdf.py` for the case `flatten = True`
- [x] Ensure that v2 restarts with scalar fields work with v3 parthenon