### PR TITLE
WIP: Signal Handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [[PR 712]](https://github.com/lanl/parthenon/pull/712) Allow to add params from cmdline
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 782]](https://github.com/parthenon-hpc-lab/parthenon/pull/782) Die on repeatedly receiving SIGINT
 - [[PR 758]](https://github.com/lanl/parthenon/pull/758) Bump required C++ standard to C++17
 - [[PR 710]](https://github.com/lanl/parthenon/pull/710) Remove data transpose in hdf5 and restart outputs
 - [[PR 713]](https://github.com/lanl/parthenon/pull/713) Remove Coordinates stub in favor of Coordinates_t

--- a/src/utils/signal_handler.cpp
+++ b/src/utils/signal_handler.cpp
@@ -23,8 +23,8 @@
 
 // first 2x macros and signal() are the only ISO C features; rest are POSIX C extensions
 #include <csignal>
-#include <iostream>
 #include <filesystem>
+#include <iostream>
 
 #include "parthenon_mpi.hpp"
 

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -50,7 +50,7 @@ constexpr int nsignal = 3;
 static volatile int signalflag[nsignal + 1];
 
 // Immediately throw upon receiving 3+ SIGINT without clearing them
-static int SIGINTS_BEFORE_THROW = 3;
+const int SIGINTS_BEFORE_THROW = 3;
 
 static sigset_t mask;
 void SignalHandlerInit();

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -40,11 +40,18 @@ void ShowConfig();
 //  \brief static data and functions that implement a simple signal handling system
 namespace SignalHandler {
 
+// Enum of desired signal results
 enum class OutputSignal { none, now, final };
-constexpr int nsignal = 3;
-// using the +1 for signaling based on "output_now" trigger
-static volatile int signalflag[nsignal + 1];
+// Signals handled: SIGTERM, SIGINT, SIGALRM
 const int ITERM = 0, IINT = 1, IALRM = 2;
+constexpr int nsignal = 3;
+// Flag/counter of signals received of each type
+// using the +1 for signaling based on a trigger file
+static volatile int signalflag[nsignal + 1];
+
+// Immediately throw upon receiving 3+ SIGINT without clearing them
+static int SIGINTS_BEFORE_THROW = 3;
+
 static sigset_t mask;
 void SignalHandlerInit();
 OutputSignal CheckSignalFlags();

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -43,14 +43,14 @@ namespace SignalHandler {
 // Enum of desired signal results
 enum class OutputSignal { none, now, final };
 // Signals handled: SIGTERM, SIGINT, SIGALRM
-const int ITERM = 0, IINT = 1, IALRM = 2;
+constexpr int ITERM = 0, IINT = 1, IALRM = 2;
 constexpr int nsignal = 3;
 // Flag/counter of signals received of each type
 // using the +1 for signaling based on a trigger file
 static volatile int signalflag[nsignal + 1];
 
 // Immediately throw upon receiving 3+ SIGINT without clearing them
-const int SIGINTS_BEFORE_THROW = 3;
+constexpr int SIGINTS_BEFORE_THROW = 3;
 
 static sigset_t mask;
 void SignalHandlerInit();


### PR DESCRIPTION
Currently, Parthenon has custom handlers for SIGINT, SIGTERM, and SIGALRM, which all set a flag, wait until the end of the next step, output any final files, and then terminate the program (a 'clean exit', as opposed to immediate termination). 

This PR as-is would exit immediately if more than three SIGINTs are received.  This was intended to restore an easy way of exiting the program without the extra stepping and file operations, which may not be necessary and could take a long time.

However, in researching and testing behavior under MPI, I've discovered that triggering a clean exit (that is, sending a single SIGINT or SIGTERM) is MPI implementation-dependent.  So much so that there is not a single key combination which will send a single SIGINT to Parthenon in all circumstances: some frontends (srun) eat the first SIGINT and do nothing, whereas others (OpenMPI) effectively do nothing on 2 or more SIGINTs as they exit immediately themselves upon receiving the second.  In fact, OpenMPI will never actually send a SIGINT specifically -- when it receives one, it upgrades it to a SIGTERM before sending it on (and then sets a timer before it sends a SIGKILL in addition).

As far as I know, there does not exist any signal which will be passed cleanly to a user process by all major MPI implementations, with the very possible exception of USR2, which seems like a documentation nightmare.  Certainly, signal forwarding is nowhere in the standard.

Thus I propose that Parthenon drop support for providing any special behavior upon receiving signals, and revert to using the default handlers/behavior (immediate exit on SIGINT and up).  Instead, we should cleanly exit upon seeing a file in the working directory (e.g., "die_now", or "exit_now" or something).  This is already what we use for triggering output ("output_now").

To be clear, this is a shame to me -- I'm very surprised the MPI standard isn't stricter about this, and that implementations have picked such a wide variety of useless extra behavior to tack to a simple ctrl-C.

## PR Summary

This would make the "signalflag" array in SignalHandler into a counter of signals received since the last reset.  It then adds intelligence to SetSignalFlag to throw an error if some number (currently 3) SIGINTs have been received since the flag was last cleared.

The number/behavior is not currently runtime-configurable, as at that point it's probably better to make SignalHandler a class, and I wasn't sure this was worth that effort yet.

Also, I updated the FS check to use std::filesystem::exists now that we're C++17, as @pgrete left in a comment a while ago.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
