### PR TITLE
Fix an output bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 777]](https://github.com/parthenon-hpc-lab/parthenon/pull/784) Fix double-output of last file in rare cases 
 - [[PR 740]](https://github.com/lanl/parthenon/pull/740) Faster PHDF file load times in phdf.py
 - [[PR 751]](https://github.com/lanl/parthenon/pull/751) Delete useless file in advection example
 - [[PR 765]](https://github.com/lanl/parthenon/pull/765) Fix incorrect BC labeling in swarm

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -108,7 +108,7 @@ DriverStatus EvolutionDriver::Execute() {
     }
 
     // skip the final (last) output at the end of the simulation time as it happens later
-    if (!tm.KeepGoing()) {
+    if (tm.KeepGoing()) {
       pouts->MakeOutputs(pmesh, pinput, &tm, signal);
     }
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -108,7 +108,7 @@ DriverStatus EvolutionDriver::Execute() {
     }
 
     // skip the final (last) output at the end of the simulation time as it happens later
-    if (tm.time < tm.tlim) {
+    if (!tm.KeepGoing()) {
       pouts->MakeOutputs(pmesh, pinput, &tm, signal);
     }
 


### PR DESCRIPTION
While looking at making output naming/production a little more flexible, I noticed an output bug: if the code would stop because the current step number is >=nlim (part of the KeepGoing() check), then an output may be produced twice on the last step.

This was likely only ever triggered when outputs were produced every single step during debugging, so I doubt anyone hit it in a way that mattered, and in any case the "workaround" to produce normal behavior would just be to delete the last numbered file before "final."

Anyway, I fixed it.  A wider reimagining of outputs will will take a while longer, so if it misses the next release we should at least not carry around a known bug with a one-line fix.

Ulterior motive: how small a PR is too small?  I can add the usual stuff to this PR, but I'd be happy if another pending output-related PR picked it up too -- at some point, writing too much about one line is a waste of time.  Maybe some protocol around "miscellaneous fixes" PRs to try to bundle things like this?
