### PR TITLE
Fix test expecting a last numbered dump

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -6,6 +6,9 @@ on:
     - cron: '0 6 * * *'
   # when triggered manually
   workflow_dispatch:
+  # when auto merge is enabled (hack to make sure it's run before merging)
+  pull_request:
+    types: [auto_merge_enabled]
 
 # Cancel "duplicated" workflows triggered by pushes to internal
 # branches with associated PRs.

--- a/tst/regression/test_suites/bvals/bvals.py
+++ b/tst/regression/test_suites/bvals/bvals.py
@@ -84,7 +84,7 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         # Reflection: First comparing initial condition to final state
         res = compare(
-            ["advection.reflecting.00000.phdf", "advection.reflecting.00004.phdf"],
+            ["advection.reflecting.00000.phdf", "advection.reflecting.final.phdf"],
             check_metadata=False,
             quiet=True,
         )
@@ -104,7 +104,7 @@ class TestCase(utils.test_case.TestCaseAbs):
 
         # Periodic: First comparing initial condition to final state
         res = compare(
-            ["advection.periodic.00000.phdf", "advection.periodic.00004.phdf"],
+            ["advection.periodic.00000.phdf", "advection.periodic.final.phdf"],
             check_metadata=False,
             quiet=True,
         )
@@ -130,7 +130,7 @@ class TestCase(utils.test_case.TestCaseAbs):
             all_pass = False
 
         # ... and nothing at the end
-        outflow_data_final = phdf.phdf("advection.outflow.00004.phdf")
+        outflow_data_final = phdf.phdf("advection.outflow.final.phdf")
         advected_final = outflow_data_final.Get("advected")
         if np.sum(advected_final) != 0.0:
             print("Some 'advected' did not leave the box in outflow test.")


### PR DESCRIPTION
## PR Summary

I "fixed" behavior where Parthenon would sometimes produce two identical dumps on the last step, one numbered and one 'final'.  It turns out at least one test expected that last numbered dump to exist.  Here, I fix that test.

Remaining question: should tests adopt reading 'final' dumps more broadly?  It seems more consistent than expecting a particular number, when what you're really testing is the contents...

This is effectively part of PR #784 and serves as my punishment for not triggering full CI on that PR. Lesson learned etc.

Fixes #785  

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
