### PR TITLE
KOKKOS_DISABLE_WARNINGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 791]](https://github.com/parthenon-hpc-lab/parthenon/pull/791) Set KOKKOS_DISABLE_WARNINGS=TRUE
 - [[PR 777]](https://github.com/parthenon-hpc-lab/parthenon/pull/777) New action: check PR dependencies & warn until requirements merged
 - [[PR 772]](https://github.com/lanl/parthenon/pull/772) Trigger short CI only for PRs and remove old SpaceInstances test
 - [[PR 757]](https://github.com/lanl/parthenon/pull/757) Move to flux correction in-one and unify with bvals

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -30,7 +30,7 @@ int main(int argc, char *argv[]) {
   // parsed.
   for (auto i = 1; i < argc; i++) {
     if (std::string(argv[i]) == "--list-test-names-only") {
-      setenv("KOKKOS_DISABLE_WARNINGS", "ON", 1);
+      setenv("KOKKOS_DISABLE_WARNINGS", "TRUE", 1);
     }
   }
 


### PR DESCRIPTION
Kokkos@3.7.0 requires either (true, false) (1, 0) or (yes, no) for booleans.

This fixes the env. var. KOKKOS_DISABLE_WARNINGS=TRUE

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented. (N/A)
- [x] Adds a test for any bugs fixed. Adds tests for new features. (N/A)
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
