### PR TITLE
At least partially fix XDMF output

### DIFF
--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -957,11 +957,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     }
 
     // write data to file
-    printf("var: %s ndim: %i dims: ", var_name.c_str(), ndim);
-    for (int i = 0; i < ndim; i++) {
-      printf("%i ", local_count[i]);
-    }
-    printf("\n");
     HDF5WriteND(file, var_name, tmpData.data(), ndim, p_loc_offset, p_loc_cnt, p_glob_cnt,
                 pl_xfer, pl_dcreate);
   }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -316,7 +316,7 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
     fid << ">" << std::endl;
     fid << prefix << "  "
         << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
-    for (int i = 0; i < ndims; i++) {
+    for (int i = 1; i < ndims; i++) {
       fid << dims[i] << " ";
     }
     fid << R"(">)" << std::endl;
@@ -957,6 +957,11 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     }
 
     // write data to file
+    printf("var: %s ndim: %i dims: ", var_name.c_str(), ndim);
+    for (int i = 0; i < ndim; i++) {
+      printf("%i ", local_count[i]);
+    }
+    printf("\n");
     HDF5WriteND(file, var_name, tmpData.data(), ndim, p_loc_offset, p_loc_cnt, p_glob_cnt,
                 pl_xfer, pl_dcreate);
   }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -316,7 +316,8 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
     fid << ">" << std::endl;
     fid << prefix << "  "
         << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
-    for (int i = 1; i < ndims; i++) {
+    fid << "1 ";
+    for (int i = 2; i < ndims; i++) {
       fid << dims[i] << " ";
     }
     fid << R"(">)" << std::endl;
@@ -957,6 +958,10 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     }
 
     // write data to file
+    printf("var_name: %s ndim: %i vector? %i\n", var_name.c_str(), ndim, static_cast<int>(vinfo.is_vector));
+    for (int i = 0; i < ndim; i++) {
+      printf("  [%i]: %i\n", i, local_count[i]);
+    }
     HDF5WriteND(file, var_name, tmpData.data(), ndim, p_loc_offset, p_loc_cnt, p_glob_cnt,
                 pl_xfer, pl_dcreate);
   }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -433,7 +433,6 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
     // write graphics variables
     int ndim;
     for (const auto &vinfo : var_list) {
-      // TODO(BRR) just let vinfo provide this
       std::vector<hsize_t> alldims(
           {static_cast<hsize_t>(vinfo.nx6), static_cast<hsize_t>(vinfo.nx5),
            static_cast<hsize_t>(vinfo.nx4), static_cast<hsize_t>(vinfo.nx3),
@@ -452,7 +451,6 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
       }
 
       const int vlen = vinfo.vlen;
-      // dims[1] = vlen;
       writeXdmfSlabVariableRef(xdmf, vinfo.label, vinfo.component_labels, hdfFile, ib,
                                vlen, ndim, dims, dims321, vinfo.is_vector);
     }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -265,21 +265,8 @@ static std::string stringXdmfArrayRef(const std::string &prefix,
                                       const std::string &label, const hsize_t *dims,
                                       const int &ndims, const std::string &theType,
                                       const int &precision, bool isVector) {
-  printf("prefix: %s\n", label.c_str());
-  printf("ndims: %i\n", ndims);
-  for (int n = 0; n < ndims; n++) {
-    printf("  %i\n", dims[n]);
-  }
   std::string mystr =
-      prefix + R"(<DataItem Format="HDF" Dimensions=")";// + std::to_string(dims[0]);
-  //    printf("%s:%i isVector: %i\n", __FILE__, __LINE__, static_cast<int>(isVector));
-  //    if (isVector) {
-  //for (int i = 1; i < ndims; i++)
-  //  mystr += " " + std::to_string(dims[i]);
-  //    } else {
-  //for (int i = 2; i < ndims; i++)
-  //  mystr += " " + std::to_string(dims[i]);
-  //    }
+      prefix + R"(<DataItem Format="HDF" Dimensions=")"; // + std::to_string(dims[0]);
   for (int i = 0; i < ndims; i++) {
     mystr += " " + std::to_string(dims[i]);
   }
@@ -293,8 +280,10 @@ static std::string stringXdmfArrayRef(const std::string &prefix,
 static void writeXdmfArrayRef(std::ofstream &fid, const std::string &prefix,
                               const std::string &hdfPath, const std::string &label,
                               const hsize_t *dims, const int &ndims,
-                              const std::string &theType, const int &precision, bool isVector=false) {
-  fid << stringXdmfArrayRef(prefix, hdfPath, label, dims, ndims, theType, precision, isVector)
+                              const std::string &theType, const int &precision,
+                              bool isVector = false) {
+  fid << stringXdmfArrayRef(prefix, hdfPath, label, dims, ndims, theType, precision,
+                            isVector)
       << std::flush;
 }
 
@@ -325,50 +314,18 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
           << R"( Dimensions=")" << vector_size << " " << dims321 << R"(")";
     }
     fid << ">" << std::endl;
-    printf("%s:%i\n", __FILE__, __LINE__);
-    printf("  name: %s isVector: %i dims321: %s vector_size: %i\n",
-      name.c_str(), isVector, dims321.c_str(), vector_size);
-    printf("  ndims: %i\n", ndims);
-    for (int i = 0; i < ndims; i++) {
-      printf("  [%i] %i\n", i, dims[i]);
-    }
-    //if (isVector) {
-   //fid << prefix << "  "
-   //    << R"(<DataItem ItemType="HyperSlab" Dimensions=")" << dims321 << " "
-   //    << vector_size << R"(">)" << std::endl;
-    fid << prefix << "  " << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
+    fid << prefix << "  "
+        << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
     for (int i = 0; i < ndims; i++) {
       fid << dims[i] << " ";
     }
     fid << R"(">)" << std::endl;
-    //} else {
-    //fid << prefix << "  "
-    //    << R"(<DataItem ItemType="HyperSlab" Dimensions=")" << dims321 << " "
-    //    << R"(">)" << std::endl;
-   // }
-    // TODO(JL) 3 and 5 are literals here, careful if they change.
-    // "3" rows for START, STRIDE, and COUNT for each slab with "5" (H5_NDIM) entries.
-    // START: iblock variable(_component)  0   0   0
-    // STRIDE: 1               1           1   1   1
-    // COUNT:  1           vector_size    nx3 nx2 nx1
-    //if (isVector) {
-      fid << prefix << "    "
-          << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock
-          << " " << i << " 0 0 0 "
-          << " 1 1 1 1 1 1 " << vector_size << " " << dims321 << "</DataItem>"
-          << std::endl;
-      writeXdmfArrayRef(fid, prefix + "    ", hdfFile + ":/", name, dims, ndims, "Float",
-                      8, true);
-    /*} else {
-      fid << prefix << "    "
-          << R"(<DataItem Dimensions="3 4" NumberType="Int" Format="XML">)" << iblock
-          << " "
-          << " 0 0 0 "
-          << " 1 1 1 1 1 "
-          << " " << dims321 << "</DataItem>" << std::endl;
-    writeXdmfArrayRef(fid, prefix + "    ", hdfFile + ":/", name, dims, ndims, "Float",
-                      8, false);
-    }*/
+    fid << prefix << "    "
+        << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock << " "
+        << i << " 0 0 0 "
+        << " 1 1 1 1 1 1 " << vector_size << " " << dims321 << "</DataItem>" << std::endl;
+    writeXdmfArrayRef(fid, prefix + "    ", hdfFile + ":/", name, dims, ndims, "Float", 8,
+                      true);
     fid << prefix << "  "
         << "</DataItem>" << std::endl;
     fid << prefix << "</Attribute>" << std::endl;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -958,10 +958,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     }
 
     // write data to file
-    printf("var_name: %s ndim: %i vector? %i\n", var_name.c_str(), ndim, static_cast<int>(vinfo.is_vector));
-    for (int i = 0; i < ndim; i++) {
-      printf("  [%i]: %i\n", i, local_count[i]);
-    }
     HDF5WriteND(file, var_name, tmpData.data(), ndim, p_loc_offset, p_loc_cnt, p_glob_cnt,
                 pl_xfer, pl_dcreate);
   }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -320,15 +320,18 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
     // STRIDE: 1               1           1   1   1
     // COUNT:  1           vector_size    nx3 nx2 nx1
     if (isVector) {
-    fid << prefix << "    "
-        << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock << " "
-        << i << " 0 0 0 "
-        << " 1 1 1 1 1 1 " << vector_size << " " << dims321 << "</DataItem>" << std::endl;
+      fid << prefix << "    "
+          << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock
+          << " " << i << " 0 0 0 "
+          << " 1 1 1 1 1 1 " << vector_size << " " << dims321 << "</DataItem>"
+          << std::endl;
     } else {
-    fid << prefix << "    "
-        << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock << " "
-        << " 0 0 0 "
-        << " 1 1 1 1 1 " << " " << dims321 << "</DataItem>" << std::endl;
+      fid << prefix << "    "
+          << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock
+          << " "
+          << " 0 0 0 "
+          << " 1 1 1 1 1 "
+          << " " << dims321 << "</DataItem>" << std::endl;
     }
     writeXdmfArrayRef(fid, prefix + "    ", hdfFile + ":/", name, dims, ndims, "Float",
                       8);
@@ -411,17 +414,18 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
     xdmf << "      </Geometry>" << std::endl;
 
     // write graphics variables
-    //dims[1] = 1;
-    //dims[2] = nx3;
-    //dims[3] = nx2;
-    //dims[4] = nx1;
+    // dims[1] = 1;
+    // dims[2] = nx3;
+    // dims[3] = nx2;
+    // dims[4] = nx1;
 
     int ndim;
     for (const auto &vinfo : var_list) {
-    // TODO(BRR) just let vinfo provide this
-    std::vector<hsize_t> alldims({static_cast<hsize_t>(vinfo.nx6), static_cast<hsize_t>(vinfo.nx5), static_cast<hsize_t>(vinfo.nx4), static_cast<hsize_t>(vinfo.nx3),
-                                   static_cast<hsize_t>(vinfo.nx2),
-                                   static_cast<hsize_t>(vinfo.nx1)});
+      // TODO(BRR) just let vinfo provide this
+      std::vector<hsize_t> alldims(
+          {static_cast<hsize_t>(vinfo.nx6), static_cast<hsize_t>(vinfo.nx5),
+           static_cast<hsize_t>(vinfo.nx4), static_cast<hsize_t>(vinfo.nx3),
+           static_cast<hsize_t>(vinfo.nx2), static_cast<hsize_t>(vinfo.nx1)});
       // Only cell-based data currently supported for visualization
       if (vinfo.where == MetadataFlag(Metadata::Cell)) {
         ndim = 3 + vinfo.tensor_rank + 1;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -264,7 +264,7 @@ static std::string stringXdmfArrayRef(const std::string &prefix,
                                       const std::string &hdfPath,
                                       const std::string &label, const hsize_t *dims,
                                       const int &ndims, const std::string &theType,
-                                      const int &precision, bool isVector) {
+                                      const int &precision) {
   std::string mystr =
       prefix + R"(<DataItem Format="HDF" Dimensions=")"; // + std::to_string(dims[0]);
   for (int i = 0; i < ndims; i++) {
@@ -282,8 +282,7 @@ static void writeXdmfArrayRef(std::ofstream &fid, const std::string &prefix,
                               const hsize_t *dims, const int &ndims,
                               const std::string &theType, const int &precision,
                               bool isVector = false) {
-  fid << stringXdmfArrayRef(prefix, hdfPath, label, dims, ndims, theType, precision,
-                            isVector)
+  fid << stringXdmfArrayRef(prefix, hdfPath, label, dims, ndims, theType, precision)
       << std::flush;
 }
 
@@ -304,33 +303,59 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
       names.push_back(component_labels[i]);
     }
   }
-  const int vector_size = isVector ? vlen : 1;
+  const int tensor_dims = ndims - 1 - 3;
 
-  const std::string prefix = "      ";
-  for (int i = 0; i < nentries; i++) {
-    fid << prefix << R"(<Attribute Name=")" << names[i] << R"(" Center="Cell")";
-    if (isVector) {
-      fid << R"( AttributeType="Vector")"
-          << R"( Dimensions=")" << vector_size << " " << dims321 << R"(")";
-    }
+  if (tensor_dims == 0) {
+    const std::string prefix = "      ";
+    fid << prefix << R"(<Attribute Name=")" << names[0] << R"(" Center="Cell")";
     fid << ">" << std::endl;
     fid << prefix << "  "
         << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
-    fid << "1 ";
-    for (int i = 2; i < ndims; i++) {
-      fid << dims[i] << " ";
-    }
+    fid << dims321 << " ";
     fid << R"(">)" << std::endl;
+    // "3" rows for START, STRIDE, and COUNT for each slab with "4" (H5_NDIM) entries.
+    // START: iblock 0   0   0
+    // STRIDE: 1     1   1   1
+    // COUNT:  1     nx3 nx2 nx1
     fid << prefix << "    "
-        << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock << " "
-        << i << " 0 0 0 "
-        << " 1 1 1 1 1 1 " << vector_size << " " << dims321 << "</DataItem>" << std::endl;
+        << R"(<DataItem Dimensions="3 4" NumberType="Int" Format="XML">)" << iblock << " "
+        << " 0 0 0 "
+        << " 1 1 1 1 1 "
+        << " " << dims321 << "</DataItem>" << std::endl;
     writeXdmfArrayRef(fid, prefix + "    ", hdfFile + ":/", name, dims, ndims, "Float", 8,
                       true);
     fid << prefix << "  "
         << "</DataItem>" << std::endl;
     fid << prefix << "</Attribute>" << std::endl;
+  } else if (tensor_dims == 1) {
+    const std::string prefix = "      ";
+    for (int i = 0; i < nentries; i++) {
+      fid << prefix << R"(<Attribute Name=")" << names[i] << R"(" Center="Cell")";
+      if (isVector) {
+        fid << R"( AttributeType="Vector")"
+            << R"( Dimensions=")" << dims[1] << " " << dims321 << R"(")";
+      }
+      fid << ">" << std::endl;
+      fid << prefix << "  "
+          << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
+      fid << dims321 << " ";
+      fid << R"(">)" << std::endl;
+      // "3" rows for START, STRIDE, and COUNT for each slab with "5" (H5_NDIM) entries.
+      // START: iblock variable(_component)  0   0   0
+      // STRIDE: 1               1           1   1   1
+      // COUNT:  1               dims[1]     nx3 nx2 nx1
+      fid << prefix << "    "
+          << R"(<DataItem Dimensions="3 5" NumberType="Int" Format="XML">)" << iblock
+          << " " << i << " 0 0 0 "
+          << " 1 1 1 1 1 1 " << dims[1] << " " << dims321 << "</DataItem>" << std::endl;
+      writeXdmfArrayRef(fid, prefix + "    ", hdfFile + ":/", name, dims, ndims, "Float",
+                        8, true);
+      fid << prefix << "  "
+          << "</DataItem>" << std::endl;
+      fid << prefix << "</Attribute>" << std::endl;
+    }
   }
+  // TODO(BRR) Support tensor dims 2 and 3
 }
 
 void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int nx3,

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -414,11 +414,6 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
     xdmf << "      </Geometry>" << std::endl;
 
     // write graphics variables
-    // dims[1] = 1;
-    // dims[2] = nx3;
-    // dims[3] = nx2;
-    // dims[4] = nx1;
-
     int ndim;
     for (const auto &vinfo : var_list) {
       // TODO(BRR) just let vinfo provide this
@@ -440,11 +435,7 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, int nx1, int nx2, int n
       }
 
       const int vlen = vinfo.vlen;
-      dims[1] = vlen;
-      printf("label: %s\n", vinfo.label.c_str());
-      for (auto &label : vinfo.component_labels) {
-        printf("  component: %s\n", label.c_str());
-      }
+      // dims[1] = vlen;
       writeXdmfSlabVariableRef(xdmf, vinfo.label, vinfo.component_labels, hdfFile, ib,
                                vlen, ndim, dims, dims321, vinfo.is_vector);
     }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -271,15 +271,18 @@ static std::string stringXdmfArrayRef(const std::string &prefix,
     printf("  %i\n", dims[n]);
   }
   std::string mystr =
-      prefix + R"(<DataItem Format="HDF" Dimensions=")" + std::to_string(dims[0]);
-      printf("%s:%i isVector: %i\n", __FILE__, __LINE__, static_cast<int>(isVector));
-      if (isVector) {
-  for (int i = 1; i < ndims; i++)
+      prefix + R"(<DataItem Format="HDF" Dimensions=")";// + std::to_string(dims[0]);
+  //    printf("%s:%i isVector: %i\n", __FILE__, __LINE__, static_cast<int>(isVector));
+  //    if (isVector) {
+  //for (int i = 1; i < ndims; i++)
+  //  mystr += " " + std::to_string(dims[i]);
+  //    } else {
+  //for (int i = 2; i < ndims; i++)
+  //  mystr += " " + std::to_string(dims[i]);
+  //    }
+  for (int i = 0; i < ndims; i++) {
     mystr += " " + std::to_string(dims[i]);
-      } else {
-  for (int i = 2; i < ndims; i++)
-    mystr += " " + std::to_string(dims[i]);
-      }
+  }
   mystr += "\" Name=\"" + label + "\"";
   mystr += " NumberType=\"" + theType + "\"";
   mystr += R"( Precision=")" + std::to_string(precision) + R"(">)" + '\n';
@@ -322,15 +325,27 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
           << R"( Dimensions=")" << vector_size << " " << dims321 << R"(")";
     }
     fid << ">" << std::endl;
-    if (isVector) {
-    fid << prefix << "  "
-        << R"(<DataItem ItemType="HyperSlab" Dimensions=")" << dims321 << " "
-        << vector_size << R"(">)" << std::endl;
-    } else {
-    fid << prefix << "  "
-        << R"(<DataItem ItemType="HyperSlab" Dimensions=")" << dims321 << " "
-        << R"(">)" << std::endl;
+    printf("%s:%i\n", __FILE__, __LINE__);
+    printf("  name: %s isVector: %i dims321: %s vector_size: %i\n",
+      name.c_str(), isVector, dims321.c_str(), vector_size);
+    printf("  ndims: %i\n", ndims);
+    for (int i = 0; i < ndims; i++) {
+      printf("  [%i] %i\n", i, dims[i]);
     }
+    //if (isVector) {
+   //fid << prefix << "  "
+   //    << R"(<DataItem ItemType="HyperSlab" Dimensions=")" << dims321 << " "
+   //    << vector_size << R"(">)" << std::endl;
+    fid << prefix << "  " << R"(<DataItem ItemType="HyperSlab" Dimensions=")";
+    for (int i = 0; i < ndims; i++) {
+      fid << dims[i] << " ";
+    }
+    fid << R"(">)" << std::endl;
+    //} else {
+    //fid << prefix << "  "
+    //    << R"(<DataItem ItemType="HyperSlab" Dimensions=")" << dims321 << " "
+    //    << R"(">)" << std::endl;
+   // }
     // TODO(JL) 3 and 5 are literals here, careful if they change.
     // "3" rows for START, STRIDE, and COUNT for each slab with "5" (H5_NDIM) entries.
     // START: iblock variable(_component)  0   0   0


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@tagardiner noticed that #781 unfortunately broke XDMF output on e.g. the `advection` problem. It looks like this is due to the change in output format 2 -> 3 where scalars are no longer length-1 vectors in the HDF5 data, but rather have dimension `[nblock, nx3, nx2, nx1]`. This change in the HDF5 was not accompanied by any change in the XDMF.

Fixing the scalar case is straightforward I think, but it would be nice to also provide support for rank-2 and rank-3 parthenon output variables as well.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
