### PR TITLE
Add Crusher/Frontier machine file and bump Kokkos to 3.7.01

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 805]](https://github.com/parthenon-hpc-lab/parthenon/pull/805) Add Crusher/Frontier machine file and bump Kokkos to 3.7.01
 - [[PR 797]](https://github.com/parthenon-hpc-lab/parthenon/pull/797) Fix boundary flux correction boundary logic 
 - [[PR 800]](https://github.com/parthenon-hpc-lab/parthenon/pull/800) Fix rare and intermitted race condition to set allocation status
 - [[PR 777]](https://github.com/parthenon-hpc-lab/parthenon/pull/784) Fix double-output of last file in rare cases 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,8 @@ if (ENABLE_COMPILER_WARNINGS)
   add_compile_options(-Wall)
 endif()
 
+set(Kokkos_ENABLE_DEPRECATED_CODE_3 OFF CACHE BOOL "No need for old/unused code.")
+
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 17)
 

--- a/cmake/machinecfg/FrontierAndCrusher.cmake
+++ b/cmake/machinecfg/FrontierAndCrusher.cmake
@@ -1,0 +1,73 @@
+#========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2022 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+#========================================================================================
+# (C) (or copyright) 2022. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
+message(STATUS "Loading machine configuration for OLCF's Frontier and Crusher.\n"
+  "Supported MACHINE_VARIANT includes 'hip' or 'cray', and 'hip-mpi' (default) or 'hip-mpi, respectively.'\n"
+  "This configuration has been tested (on 2022-12-23) using the following modules: \n"
+  "  $ module load PrgEnv-amd craype-accel-amd-gfx90a cmake hdf5 cray-python amd/5.4.0 cray-mpich/8.1.21\n"
+  "and environment variables:\n"
+  "  $ export MPICH_GPU_SUPPORT_ENABLED=1\n\n"
+  "NOTE: In order to run the test suite, the build directory should be on GPFS work\n"
+  "filesystem and not in your NFS user or project home (because they are read-only\n"
+  "on compute nodes.\n\n")
+
+# common options
+set(Kokkos_ARCH_ZEN2 ON CACHE BOOL "CPU architecture")
+set(PARTHENON_DISABLE_OPENMP ON CACHE BOOL "OpenMP support not yet tested in Parthenon.")
+set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Default release build")
+set(MACHINE_VARIANT "hip-mpi" CACHE STRING "Default build for CUDA and MPI")
+
+# variants
+set(MACHINE_CXX_FLAGS "")
+if (${MACHINE_VARIANT} MATCHES "hip")
+  set(Kokkos_ARCH_VEGA90A ON CACHE BOOL "GPU architecture")
+  set(Kokkos_ENABLE_HIP ON CACHE BOOL "Enable HIP")
+  set(CMAKE_CXX_COMPILER hipcc CACHE STRING "Use hip wrapper")
+elseif (${MACHINE_VARIANT} MATCHES "cray")
+  set(Kokkos_ARCH_VEGA90A ON CACHE BOOL "GPU architecture")
+  set(Kokkos_ENABLE_HIP ON CACHE BOOL "Enable HIP")
+  set(CMAKE_CXX_COMPILER CC CACHE STRING "Use Cray wrapper")
+else()
+  set(CMAKE_CXX_COMPILER $ENV{ROCM_PATH}/llvm/bin/clang++ CACHE STRING "Use g++")
+  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -fopenmp-simd -fprefetch-loop-arrays")
+endif()
+
+# Setting launcher options independent of parallel or serial test as the launcher always
+# needs to be called from the batch node (so that the tests are actually run on the
+# compute nodes.
+set(TEST_MPIEXEC "srun" CACHE STRING "Command to launch MPI applications")
+set(TEST_NUMPROC_FLAG "-n" CACHE STRING "Flag to set number of processes")
+set(NUM_GPU_DEVICES_PER_NODE "1" CACHE STRING "4x MI250x per node with 2 GCDs each but one visible per rank")
+set(PARTHENON_ENABLE_GPU_MPI_CHECKS OFF CACHE BOOL "Disable check by default")
+
+if (${MACHINE_VARIANT} MATCHES "mpi")
+if (${MACHINE_VARIANT} MATCHES "hip")
+  # need to set include flags here as the target is not know yet when this file is parsed
+  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -I$ENV{MPICH_DIR}/include")
+  set(CMAKE_EXE_LINKER_FLAGS "-L$ENV{MPICH_DIR}/lib -lmpi -L$ENV{CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa" CACHE STRING "Default flags for this config")
+elseif (${MACHINE_VARIANT} MATCHES "cray")
+  set(MACHINE_CXX_FLAGS "${MACHINE_CXX_FLAGS} -I$ENV{ROCM_PATH_DIR}/include")
+  set(CMAKE_EXE_LINKER_FLAGS "-L$ENV{ROCM_PATH}/lib -lamdhip64" CACHE STRING "Default flags for this config")
+endif()
+
+  # ensure that GPU are properly bound to ranks
+  list(APPEND TEST_MPIOPTS "-c1" "--gpus-per-node=8" "--gpu-bind=closest")
+else()
+  set(PARTHENON_DISABLE_MPI ON CACHE BOOL "Disable MPI")
+endif()
+
+set(CMAKE_CXX_FLAGS "${MACHINE_CXX_FLAGS}" CACHE STRING "Default flags for this config")


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

All tests on Crusher now pass (both serial [requires serial HDF5 lib] and with MPI).
With older versions of Kokkos (e.g., the our current 3.6) some test still fail, which is why I bumped the Kokkos version.
I also tried to check the Kokkos version but didn't succeed (without adding more cmake boilerplate) as we add the Kokkos source directly (and thus don't get access the "Kokkos package version").
From my point of view, this is not an issue (or warrants additional code only to add this check) as our primary use case is the submodule anyway.
Also in prep for the bump to the Kokkos 4.0 release (which is scheduled for this month and removes HIP from "experimental" stage), I also deactivated the Kokkos 3 deprecated code (which we never used anyway).

I also requested more reviewers than necessary to trigger/encourage downstream testing.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files


