### PR TITLE
Looser MPI hang detection: wait a few seconds to error

### DIFF
--- a/src/utils/communication_buffer.hpp
+++ b/src/utils/communication_buffer.hpp
@@ -320,8 +320,8 @@ bool CommBuffer<T>::TryReceive() noexcept {
       *comm_type_ == BuffCommType::sparse_receiver) {
 #ifdef MPI_PARALLEL
     (*nrecv_tries_)++;
-    PARTHENON_REQUIRE(*nrecv_tries_ < 1e6,
-                      "MPI probably hanging after 1e6 receive tries.");
+    PARTHENON_REQUIRE(*nrecv_tries_ < 1e8,
+                      "MPI probably hanging after 1e8 receive tries.");
 
     TryStartReceive();
 


### PR DESCRIPTION
Addresses crash described in #808 in the crudest possible way.

## PR Summary

Some downstreams were seeing a Parthenon error due to some hang detection code in communication_buffer.hpp.  This is likely due to fast MPI checks vs. the network latency: even in normal circumstances, without an MPI hang, a rank could conceivably check 1e6 times for a message before receiving one.

This raises the hard-coded check limit to 1e8 tries, which still should not take very long to hit (judging by the rate to reach 1e6 checks, maybe a minute at the very most).

One alternative mentioned in the issue would be to make the limit user-configurable -- however, it's not immediately obvious to me how to implement this without an extra parameter in the CommBuffer constructor, which would require widespread changes and a couple of documentation updates.  Would love any pointers on how to plumb through the option if there's a better way to do so.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] (@lanl.gov employees) Update copyright on changed files
