### PR TITLE
fix movie2d. Resolves #832.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 832]](https://github.com/parthenon-hpc-lab/parthenon/pull/833) Fix movie2d script after it broke due to change in HDF5 format
 - [[PR 820]](https://github.com/parthenon-hpc-lab/parthenon/pull/820) Fix XDMF spec to conform to standard and handle scalar and vector variables
 - [[PR 795]](https://github.com/parthenon-hpc-lab/parthenon/pull/795) Fix length-1 vectors in output format version >= 3
 - [[PR 824]](https://github.com/parthenon-hpc-lab/parthenon/pull/824) Remove unsupported exception handling from device methods in UniformCartesian

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -22,7 +22,8 @@ import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 
 parser = ArgumentParser(
-    prog="movie2d", description="Plot snapshots of 2d parthenon output",
+    prog="movie2d",
+    description="Plot snapshots of 2d parthenon output",
 )
 parser.add_argument("field", type=str, help="field to plot")
 parser.add_argument(

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -1,5 +1,5 @@
 # =========================================================================================
-# (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     components = [0, 0]
     if (args.tc is not None) and (args.vc is not None):
         raise ValueError(
-            "Only one of --tensor-components and --vector-component should be set."
+            "Only one of --tensor-component and --vector-component should be set."
         )
     if args.tc is not None:
         components = args.tc

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -32,11 +32,11 @@ parser.add_argument(
     default=None,
     help=(
         "Vector component of field to plot. "
-        + "Mutually exclusive with --tensor-components."
+        + "Mutually exclusive with --tensor-component."
     ),
 )
 parser.add_argument(
-    "--tensor-components",
+    "--tensor-component",
     dest="tc",
     type=float,
     nargs=2,
@@ -84,6 +84,11 @@ def plot_dump(
         ye = yf
 
     # get tensor components
+    if len(q.shape) > 5:
+        raise ValueError(
+            "Tensor rank is higher than I can handle. "
+            + "Please revise the movie2d script"
+        )
     if len(q.shape) == 5:
         q = q[:, components[0], components[1], :, :]
     if len(q.shape) == 4:
@@ -151,9 +156,9 @@ if __name__ == "__main__":
             "Only one of --tensor-components and --vector-component should be set."
         )
     if args.tc is not None:
-        components = tc
+        components = args.tc
     if args.vc is not None:
-        components = [0, vc]
+        components = [0, args.vc]
     dump_id = 0
     debug_plot = False
     for f in files:

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -13,11 +13,40 @@
 
 from __future__ import print_function
 
+from argparse import ArgumentParser
+
 import os
 import sys
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
+
+parser = ArgumentParser(
+    prog="movie2d", description="Plot snapshots of 2d parthenon output",
+)
+parser.add_argument("field", type=str, help="field to plot")
+parser.add_argument(
+    "--vector-component",
+    dest="vc",
+    type=float,
+    default=None,
+    help=(
+        "Vector component of field to plot. "
+        + "Mutually exclusive with --tensor-components."
+    ),
+)
+parser.add_argument(
+    "--tensor-components",
+    dest="tc",
+    type=float,
+    nargs=2,
+    default=None,
+    help=(
+        "Tensor components of field to plot "
+        + "Mutally exclusive with --vector-component."
+    ),
+)
+parser.add_argument("files", type=str, nargs="+", help="files to plot")
 
 
 def addPath():
@@ -36,13 +65,29 @@ def read(filename, nGhost=0):
 
 
 def plot_dump(
-    xf, yf, q, name, with_mesh=False, block_ids=[], xi=None, yi=None, xe=None, ye=None
+    xf,
+    yf,
+    q,
+    name,
+    with_mesh=False,
+    block_ids=[],
+    xi=None,
+    yi=None,
+    xe=None,
+    ye=None,
+    components=[0, 0],
 ):
 
     if xe is None:
         xe = xf
     if ye is None:
         ye = yf
+
+    # get tensor components
+    if len(q.shape) == 5:
+        q = q[:, components[0], components[1], :, :]
+    if len(q.shape) == 4:
+        q = q[:, components[-1], :, :]
 
     fig = plt.figure()
     p = fig.add_subplot(111, aspect=1)
@@ -53,7 +98,7 @@ def plot_dump(
     for i in range(NumBlocks):
         # Plot the actual data, should work if parthenon/output*/ghost_zones = true or false
         # but obviously no ghost data will be shown if ghost_zones = false
-        p.pcolormesh(xf[i, :], yf[i, :], q[i, 0, :, :], vmin=qmin, vmax=qmax)
+        p.pcolormesh(xf[i, :], yf[i, :], q[i, :, :], vmin=qmin, vmax=qmax)
 
         # Print the block gid in the center of the block
         if len(block_ids) > 0:
@@ -97,8 +142,18 @@ def plot_dump(
 
 if __name__ == "__main__":
     addPath()
-    field = sys.argv[1]
-    files = sys.argv[2:]
+    args = parser.parse_args()
+    field = args.field
+    files = args.files
+    components = [0, 0]
+    if (args.tc is not None) and (args.vc is not None):
+        raise ValueError(
+            "Only one of --tensor-components and --vector-component should be set."
+        )
+    if args.tc is not None:
+        components = tc
+    if args.vc is not None:
+        components = [0, vc]
     dump_id = 0
     debug_plot = False
     for f in files:
@@ -118,6 +173,7 @@ if __name__ == "__main__":
                 data.yig,
                 data.xeg,
                 data.yeg,
+                components,
             )
         else:
             plot_dump(data.xng, data.yng, q, name, True)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As @pgrete noted in #832 , the movie script is currently broken. This was due to the change to outputting more than just vector- or scalar-valued variables. Here I fix this by allowing the user to optionally pass in tensor components, which default to 0 for a scalar.

I wanted to also add a test to make sure the movie script was working. And there's a way to do this---we can generate a png file as a gold file and compare to that---but I wasn't sure if we wanted to pull in the additional dependency of Pillow. See [here](https://fabiorosado.dev/blog/comparing-images-with-numpy/). If people are ok with including Pillow as an additional python dependency, then we can add that test later. I don't have the time to do so right now.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
