### PR TITLE
Add some guard rails to prevent accidental registration of empty prolongation/restriction ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 843]](https://github.com/parthenon-hpc-lab/parthenon/pull/843) Add guard rails to prolongation/restriction infrastructure
 - [[PR 832]](https://github.com/parthenon-hpc-lab/parthenon/pull/833) Fix movie2d script after it broke due to change in HDF5 format
 - [[PR 820]](https://github.com/parthenon-hpc-lab/parthenon/pull/820) Fix XDMF spec to conform to standard and handle scalar and vector variables
 - [[PR 795]](https://github.com/parthenon-hpc-lab/parthenon/pull/795) Fix length-1 vectors in output format version >= 3

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -402,7 +402,7 @@ class Metadata {
 
   // Individual flag setters, using these could result in an invalid set of flags, use
   // IsValid to check if the flags are valid
-  // TODO(JMM):
+  // TODO(JMM): This is dangerous. See Issue #844.
   void Set(MetadataFlag f) { DoBit(f, true); }    ///< Set specific bit
   void Unset(MetadataFlag f) { DoBit(f, false); } ///< Unset specific bit
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -331,11 +331,6 @@ class Metadata {
     if (CountSet({Independent, Derived}) == 0) {
       DoBit(Derived, true);
     }
-    // If variable is refined, set a default prolongation/restriction op
-    if (IsRefined()) {
-      refinement_funcs_ = refinement::RefinementFunctions_t::RegisterOps<
-          refinement_ops::ProlongateCellMinMod, refinement_ops::RestrictCellAverage>();
-    }
 
     // check if all flag constraints are satisfied, throw if not
     IsValid(true);
@@ -406,6 +401,7 @@ class Metadata {
 
   // Individual flag setters, using these could result in an invalid set of flags, use
   // IsValid to check if the flags are valid
+  // TODO(JMM): 
   void Set(MetadataFlag f) { DoBit(f, true); }    ///< Set specific bit
   void Unset(MetadataFlag f) { DoBit(f, false); } ///< Unset specific bit
 
@@ -625,7 +621,9 @@ class Metadata {
 
  private:
   /// the attribute flags that are set for the class
-  refinement::RefinementFunctions_t refinement_funcs_;
+  refinement::RefinementFunctions_t refinement_funcs_ =
+      refinement::RefinementFunctions_t::RegisterOps<
+          refinement_ops::ProlongateCellMinMod, refinement_ops::RestrictCellAverage>();
   std::vector<bool> bits_;
   std::vector<int> shape_ = {1};
   std::vector<std::string> component_labels_ = {};

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -355,6 +355,7 @@ class Metadata {
     }
 
     // Set the allocation and deallocation thresholds
+    // TODO(JMM): This is dangerous. See Issue #844.
     if (IsSet(Sparse)) {
       allocation_threshold_ = Globals::sparse_config.allocation_threshold;
       deallocation_threshold_ = Globals::sparse_config.deallocation_threshold;
@@ -401,7 +402,7 @@ class Metadata {
 
   // Individual flag setters, using these could result in an invalid set of flags, use
   // IsValid to check if the flags are valid
-  // TODO(JMM): 
+  // TODO(JMM):
   void Set(MetadataFlag f) { DoBit(f, true); }    ///< Set specific bit
   void Unset(MetadataFlag f) { DoBit(f, false); } ///< Unset specific bit
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -331,6 +331,12 @@ class Metadata {
     if (CountSet({Independent, Derived}) == 0) {
       DoBit(Derived, true);
     }
+    // If variable is refined, set a default prolongation/restriction op
+    // TODO(JMM): This is dangerous. See Issue #844.
+    if (IsRefined()) {
+      refinement_funcs_ = refinement::RefinementFunctions_t::RegisterOps<
+          refinement_ops::ProlongateCellMinMod, refinement_ops::RestrictCellAverage>();
+    }
 
     // check if all flag constraints are satisfied, throw if not
     IsValid(true);
@@ -622,9 +628,7 @@ class Metadata {
 
  private:
   /// the attribute flags that are set for the class
-  refinement::RefinementFunctions_t refinement_funcs_ =
-      refinement::RefinementFunctions_t::RegisterOps<
-          refinement_ops::ProlongateCellMinMod, refinement_ops::RestrictCellAverage>();
+  refinement::RefinementFunctions_t refinement_funcs_;
   std::vector<bool> bits_;
   std::vector<int> shape_ = {1};
   std::vector<std::string> component_labels_ = {};

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -457,6 +457,17 @@ class Metadata {
       }
     }
 
+    // Prolongation/restriction
+    if (IsRefined()) {
+      if (refinement_funcs_.label().size() == 0) {
+        valid = false;
+        if (throw_on_fail) {
+          PARTHENON_THROW(
+              "Registered for refinment but no prolongation/restriction ops found");
+        }
+      }
+    }
+
     return valid;
   }
 

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -271,7 +271,7 @@ bool StateDescriptor::AddFieldImpl(const VarID &vid, const Metadata &m_in,
     return false; // this field has already been added
   } else {
     metadataMap_.insert({vid, m});
-    refinementFuncMaps_.Register(m);
+    refinementFuncMaps_.Register(m, vid.label());
     allocControllerReverseMap_.insert({vid, control_vid});
   }
 
@@ -289,7 +289,7 @@ bool StateDescriptor::AddSparsePoolImpl(const SparsePool &pool) {
   }
 
   sparsePoolMap_.insert({pool.base_name(), pool});
-  refinementFuncMaps_.Register(pool.shared_metadata());
+  refinementFuncMaps_.Register(pool.shared_metadata(), pool.base_name());
 
   std::string controller_base = pool.controller_base_name();
   if (controller_base == "") controller_base = pool.base_name();

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -17,6 +17,7 @@
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -81,9 +82,19 @@ struct VarIDHasher {
 /// RefinementFunctions_t? That would mean we could avoid
 /// StateDescriptor entirely.
 struct RefinementFunctionMaps {
-  void Register(const Metadata &m) {
+  void Register(const Metadata &m, std::string varname) {
     if (m.IsRefined()) {
       const auto &funcs = m.GetRefinementFunctions();
+      // Guard against uninitialized refinement functions by checking
+      // if the label is the empty string.
+      if (funcs.label().size() == 0) {
+	std::stringstream ss;
+	ss << "Variable " << varname << " registed for refinement, "
+	   << "but no prolongation/restriction options found!"
+	   << "Please register them with Metadata::RegisterRefinementOps."
+	   << std::endl;
+	PARTHENON_THROW(ss);
+      }
       bool in_map = (funcs_to_ids.count(funcs) > 0);
       if (!in_map) {
         funcs_to_ids[funcs] = next_refinement_id_++;

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -90,12 +90,11 @@ struct RefinementFunctionMaps {
       // Guard against uninitialized refinement functions by checking
       // if the label is the empty string.
       if (funcs.label().size() == 0) {
-	std::stringstream ss;
-	ss << "Variable " << varname << " registed for refinement, "
-	   << "but no prolongation/restriction options found!"
-	   << "Please register them with Metadata::RegisterRefinementOps."
-	   << std::endl;
-	PARTHENON_THROW(ss);
+        std::stringstream ss;
+        ss << "Variable " << varname << " registed for refinement, "
+           << "but no prolongation/restriction options found!"
+           << "Please register them with Metadata::RegisterRefinementOps." << std::endl;
+        PARTHENON_THROW(ss);
       }
       bool in_map = (funcs_to_ids.count(funcs) > 0);
       if (!in_map) {

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -81,6 +81,8 @@ struct VarIDHasher {
 /// TODO(JMM): Should this cache be a static member field of
 /// RefinementFunctions_t? That would mean we could avoid
 /// StateDescriptor entirely.
+/// TODO(JMM): The IDs here are not the same as the variable unique
+/// IDs but they maybe could be? We should consider unifying that.
 struct RefinementFunctionMaps {
   void Register(const Metadata &m, std::string varname) {
     if (m.IsRefined()) {

--- a/src/prolong_restrict/prolong_restrict.cpp
+++ b/src/prolong_restrict/prolong_restrict.cpp
@@ -27,6 +27,7 @@
 #include "kokkos_abstraction.hpp"
 #include "prolong_restrict/pr_ops.hpp"
 #include "prolong_restrict/prolong_restrict.hpp"
+#include "utils/error_checking.hpp"
 
 namespace parthenon {
 namespace refinement {
@@ -39,6 +40,7 @@ void Restrict(const StateDescriptor *resolved_packages,
   const auto &ref_func_map = resolved_packages->RefinementFncsToIDs();
   for (const auto &[func, idx] : ref_func_map) {
     auto restrictor = func.restrictor;
+    PARTHENON_DEBUG_REQUIRE_THROWS(restrictor != nullptr, "Valid restriction op");
     loops::Idx_t subset = Kokkos::subview(cache.buffer_subsets, idx, Kokkos::ALL());
     loops::IdxHost_t subset_h =
         Kokkos::subview(cache.buffer_subsets_h, idx, Kokkos::ALL());

--- a/src/prolong_restrict/prolong_restrict.cpp
+++ b/src/prolong_restrict/prolong_restrict.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020-2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -225,5 +225,12 @@ TEST_CASE("Refinement Information in Metadata", "[Metadata]") {
         REQUIRE_THROWS_AS(m.GetRefinementFunctions(), std::runtime_error);
       }
     }
+    WHEN("We set the refinement flag after the fact") {
+      m.Set(Metadata::FillGhost);
+      THEN("The refinement funcs should be present with a valid label") {
+        const auto &my_funcs = m.GetRefinementFunctions();
+        REQUIRE(my_funcs.label().size() > 0);
+      }
+    }
   }
 }

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -226,4 +226,14 @@ TEST_CASE("Refinement Information in Metadata", "[Metadata]") {
       }
     }
   }
+  GIVEN("A simple metadata object") {
+    using FlagVec = std::vector<parthenon::MetadataFlag>;
+    Metadata m(FlagVec{Metadata::Derived, Metadata::OneCopy});
+    THEN("It's valid") { REQUIRE(m.IsValid()); }
+    // TODO(JMM): This test should go away when issue #844 is resolved
+    WHEN("We improperly set prolongation/restriction") {
+      m.Set(Metadata::FillGhost);
+      THEN("The metadata is no longer valid") { REQUIRE(!m.IsValid()); }
+    }
+  }
 }

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -225,12 +225,5 @@ TEST_CASE("Refinement Information in Metadata", "[Metadata]") {
         REQUIRE_THROWS_AS(m.GetRefinementFunctions(), std::runtime_error);
       }
     }
-    WHEN("We set the refinement flag after the fact") {
-      m.Set(Metadata::FillGhost);
-      THEN("The refinement funcs should be present with a valid label") {
-        const auto &my_funcs = m.GetRefinementFunctions();
-        REQUIRE(my_funcs.label().size() > 0);
-      }
-    }
   }
 }

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -374,6 +374,14 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
           }
         }
       }
+      WHEN("We register a var that needs prolongation/restriction without ops") {
+        Metadata m_dangerous(
+            FlagVec{Metadata::Sparse, Metadata::Derived, Metadata::OneCopy});
+        m_dangerous.Set(Metadata::FillGhost);
+        THEN("Dependency resolution captures an ill-formed variable") {
+          REQUIRE_THROWS(pkg2->AddSparsePool("sparse", m_dangerous, sparse_ids));
+        }
+      }
     }
   }
 }

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -374,6 +374,7 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
           }
         }
       }
+      // TODO(JMM): This test should go away when issue #844 is resolved
       WHEN("We register a var that needs prolongation/restriction without ops") {
         Metadata m_dangerous(
             FlagVec{Metadata::Sparse, Metadata::Derived, Metadata::OneCopy});


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Recently @brryan and I tracked down a bug in Phoebus that was caused by the following pattern in a package initialization:

```C++
Metadata m({some set of flags});
if (condition) {
  m.Set(Metadata::FillGhost);
}
```

This was a problem because no prolongation/restriction ops were being set for the variable with this metadata. Default prolongation/restriction ops are provided, but are only automatically registered in the constructor if `IsRefined()` returns true at construct time, not later. So the metadata object was being created with empty prolongation/restriction ops and then set to prolongate and restrict at boundary communication time.

This wasn't a bug in parthenon per se, but I think it was an unexpected and unintuitive requirement on how the downstream code has to interact with the infrastructure.

This PR includes a number of guard rails for this:
1. A check in the `StateDescriptor` when the map from refinement function maps are created.
2. A check in `Restrict` that looks for nullpointers and provides a more useful error message.
3. Automatically set defaults for the prolongation and restriction ops in the state descriptor. Since these are only accessed if the variable `IsRefined`, this should be safer.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
