### PR TITLE
Improve the performance of movie2d.py script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 853]](https://github.com/parthenon-hpc-lab/parthenon/pull/853) Add multiple features and improve the performance of the movie2d.py tool
 - [[PR 848]](https://github.com/parthenon-hpc-lab/parthenon/pull/848) Implement recursive mkdir using [`std::filesystem`](https://en.cppreference.com/w/cpp/filesystem) in **src/utils/change_rundir.cpp**
 - [[PR 837]](https://github.com/parthenon-hpc-lab/parthenon/pull/837) Migrate docs to Sphinx
 - [[PR 791]](https://github.com/parthenon-hpc-lab/parthenon/pull/791) Set KOKKOS_DISABLE_WARNINGS=TRUE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [[PR 712]](https://github.com/lanl/parthenon/pull/712) Allow to add params from cmdline
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 853]](https://github.com/parthenon-hpc-lab/parthenon/pull/853) Add multiple features and improve the performance of the movie2d.py tool
 - [[PR 775]](https://github.com/parthenon-hpc-lab/parthenon/pull/775) Reorganize some of the bvals and prolongation/restriction machinery
 - [[PR 753]](https://github.com/parthenon-hpc-lab/parthenon/pull/753) Cleanup uniform Cartesian variable names
 - [[PR 769]](https://github.com/parthenon-hpc-lab/parthenon/pull/769) Thread custom prolongation-restriction functions through infrastructure and to userspace
@@ -51,7 +52,6 @@
 - [[PR 716]](https://github.com/lanl/parthenon/pull/716) Remove unneeded assert from ParArrayND
 
 ### Infrastructure (changes irrelevant to downstream codes)
-- [[PR 853]](https://github.com/parthenon-hpc-lab/parthenon/pull/853) Add multiple features and improve the performance of the movie2d.py tool
 - [[PR 848]](https://github.com/parthenon-hpc-lab/parthenon/pull/848) Implement recursive mkdir using [`std::filesystem`](https://en.cppreference.com/w/cpp/filesystem) in **src/utils/change_rundir.cpp**
 - [[PR 837]](https://github.com/parthenon-hpc-lab/parthenon/pull/837) Migrate docs to Sphinx
 - [[PR 791]](https://github.com/parthenon-hpc-lab/parthenon/pull/791) Set KOKKOS_DISABLE_WARNINGS=TRUE

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -272,7 +272,7 @@ if __name__ == "__main__":
                 )
 
     if not ERROR_FLAG:
-        logger.info("All files are sent to the processor")
+        logger.info("All frames produced.")
 
         if not args.no_render:
             logger.info(f"Generating {args.movie_format} movie")

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -110,8 +110,8 @@ parser.add_argument(
     default="output",
 )
 parser.add_argument(
-    "--no-render",
-    help="Prevent generating the movie from the parsed output files (default: false)",
+    "--render",
+    help="Generate the movie from the parsed output files (default: false)",
     default=False,
     action="store_true",
 )
@@ -274,7 +274,7 @@ if __name__ == "__main__":
     if not ERROR_FLAG:
         logger.info("All frames produced.")
 
-        if not args.no_render:
+        if args.render:
             logger.info(f"Generating {args.movie_format} movie")
             input_pattern = args.output_directory / "*.png"
             ffmpeg_cmd = f"ffmpeg -hide_banner -loglevel error -y -framerate {args.frame_rate} -pattern_type glob -i '{input_pattern}' "

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -246,9 +246,7 @@ if __name__ == "__main__":
                 break
 
             q = data.Get(args.field, False, not args.debug)
-            stem = f"{args.prefix}_{str(dump_id).rjust(4, '0')}".strip()
-            stem = re.sub(r"^_", "", stem)
-            name = stem + ".png"
+            name = "{}_{:04d}.png".format(args.prefix, dump_id).strip()
             output_file = args.output_directory / name
 
             # NOTE: After doing 5 test on different precision, keeping 2 looks more promising

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -80,8 +80,8 @@ parser.add_argument(
     metavar="PREFIX",
 )
 parser.add_argument(
-    "--debug",
-    help="Enable graph debug mode. (default: false)",
+    "--debug-plot",
+    help="Make plots with an exploded grid and including ghost zones. (default: false)",
     action="store_true",
     default=False,
 )
@@ -244,13 +244,13 @@ if __name__ == "__main__":
                 ERROR_FLAG = True
                 break
 
-            q = data.Get(args.field, False, not args.debug)
+            q = data.Get(args.field, False, not args.debug_plot)
             name = "{}_{:04d}.png".format(args.prefix, frame_id).strip()
             output_file = args.output_directory / name
 
             # NOTE: After doing 5 test on different precision, keeping 2 looks more promising
             current_time = format(round(data.Time, 2), ".2f")
-            if args.debug:
+            if args.debug_plot:
                 pool.submit(
                     plot_dump,
                     data.xg,

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -215,8 +215,7 @@ if __name__ == "__main__":
             data = phdf(file_name)
             if args.field not in data.Variables:
                 logging.error(
-                    f'No such field "{args.field}" in {file_name}. \
-This will lead to stop further processing'
+                    f'No such field "{args.field}" in {file_name}. This will lead to stop further processing'
                 )
                 break
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -15,8 +15,7 @@ from __future__ import print_function
 
 from argparse import ArgumentParser
 
-import os
-import sys
+# import os
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -50,11 +49,11 @@ parser.add_argument(
 parser.add_argument("files", type=str, nargs="+", help="files to plot")
 
 
-def addPath():
-    """add the vis/python directory to the pythonpath variable"""
-    myPath = os.path.realpath(os.path.dirname(__file__))
-    # sys.path.insert(0,myPath+'/../vis/python')
-    # sys.path.insert(0,myPath+'/vis/python')
+# def addPath():
+#     """add the vis/python directory to the pythonpath variable"""
+#     myPath = os.path.realpath(os.path.dirname(__file__))
+#     # sys.path.insert(0,myPath+'/../vis/python')
+#     # sys.path.insert(0,myPath+'/vis/python')
 
 
 def read(filename, nGhost=0):
@@ -147,7 +146,7 @@ def plot_dump(
 
 
 if __name__ == "__main__":
-    addPath()
+    # addPath()
     args = parser.parse_args()
     field = args.field
     files = args.files

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -123,7 +123,8 @@ def plot_dump(
 
     fig = plt.figure()
     p = fig.add_subplot(111, aspect=1)
-    p.set_title(f"t = {time_title} seconds")
+    if time_title is not None:
+        p.set_title(f"t = {time_title} seconds")
 
     qm = np.ma.masked_where(np.isnan(q), q)
     qmin = qm.min()
@@ -204,7 +205,7 @@ if __name__ == "__main__":
         components = [0, args.vc]
 
     _x = ProcessPoolExecutor if args.worker_type == "process" else ThreadPoolExecutor
-    current_time = 0.0
+    current_time = 0.0 if args.time_step else None
     with _x(max_workers=args.workers) as pool:
         for dump_id, file_name in enumerate(args.files):
             data = phdf(file_name)
@@ -236,8 +237,9 @@ This will lead to stop further processing'
                 )
             else:
                 pool.submit(plot_dump, data.xng, data.yng, q, current_time, name, True)
-            current_time += args.time_step
-            current_time = round(current_time, ndigits=2)
+            if args.time_step:
+                current_time += args.time_step
+                current_time = round(current_time, ndigits=2)
 
     logger.info("All files are sent to the processor")
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -235,7 +235,7 @@ if __name__ == "__main__":
 
     _x = ProcessPoolExecutor if args.worker_type == "process" else ThreadPoolExecutor
     with _x(max_workers=args.workers) as pool:
-        for dump_id, file_name in enumerate([]):
+        for dump_id, file_name in enumerate(args.files):
             data = phdf(file_name)
             if args.field not in data.Variables:
                 logger.error(

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -239,7 +239,7 @@ if __name__ == "__main__":
             data = phdf(file_name)
             if args.field not in data.Variables:
                 logger.error(
-                    f'No such field "{args.field}" in {file_name}. This will lead to stop further processing'
+                    f'No such field "{args.field}" in {file_name}. Further processing stopped.'
                 )
                 logger.info(f"Available fields: {data.Variables}")
                 ERROR_FLAG = True

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -268,7 +268,7 @@ if __name__ == "__main__":
                 )
             else:
                 pool.submit(
-                    plot_dump, data.xng, data.yng, q, current_time, output_file, True
+                    plot_dump, data.xng, data.yng, q, current_time, output_file, True, components=components
                 )
 
     if not ERROR_FLAG:

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -268,7 +268,14 @@ if __name__ == "__main__":
                 )
             else:
                 pool.submit(
-                    plot_dump, data.xng, data.yng, q, current_time, output_file, True, components=components
+                    plot_dump,
+                    data.xng,
+                    data.yng,
+                    q,
+                    current_time,
+                    output_file,
+                    True,
+                    components=components,
                 )
 
     if not ERROR_FLAG:

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -82,7 +82,7 @@ parser.add_argument(
 )
 parser.add_argument(
     "--debug",
-    help="Enable graph debug mode. This will run in the single thread. (default: false)",
+    help="Enable graph debug mode. (default: false)",
     action="store_true",
     default=False,
 )

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -234,7 +234,7 @@ if __name__ == "__main__":
 
     _x = ProcessPoolExecutor if args.worker_type == "process" else ThreadPoolExecutor
     with _x(max_workers=args.workers) as pool:
-        for dump_id, file_name in enumerate(args.files):
+        for frame_id, file_name in enumerate(args.files):
             data = phdf(file_name)
             if args.field not in data.Variables:
                 logger.error(
@@ -245,7 +245,7 @@ if __name__ == "__main__":
                 break
 
             q = data.Get(args.field, False, not args.debug)
-            name = "{}_{:04d}.png".format(args.prefix, dump_id).strip()
+            name = "{}_{:04d}.png".format(args.prefix, frame_id).strip()
             output_file = args.output_directory / name
 
             # NOTE: After doing 5 test on different precision, keeping 2 looks more promising

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -13,62 +13,49 @@
 
 from __future__ import print_function
 
-from argparse import ArgumentParser
-
-# import os
+import os
+import logging
 import numpy as np
+from phdf import phdf
+
+from argparse import ArgumentParser
+from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
+
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 
-parser = ArgumentParser(
-    prog="movie2d",
-    description="Plot snapshots of 2d parthenon output",
-)
+logging.basicConfig(level=logging.CRITICAL,
+                    format='%(asctime)s [%(levelname)s]\t%(message)s')
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.DEBUG)
+
+parser = ArgumentParser(prog="movie2d",description="Plot snapshots of 2d parthenon output")
+
+parser.add_argument("--vector-component", dest="vc", type=float, default=None,
+                    help="Vector component of field to plot. Mutually exclusive with --tensor-component.")
+parser.add_argument("--tensor-component", dest="tc", type=float, nargs=2, default=None, 
+                    help="Tensor components of field to plot. Mutally exclusive with --vector-component.")
+parser.add_argument("--workers", "-w", help="Number of parallel workers to use (default: 10)", 
+                    type=int, metavar="COUNT", default=10)
+parser.add_argument("--worker-type", help="Type of worker to use (default: process)", 
+                    choices=["process", "thread"], default="process", metavar="TYPE")
+parser.add_argument("--time-step", help="Value of dt parameter from parthenon/output* block", 
+                    metavar="DT", default=1.0, type=float)
+parser.add_argument("--output-directory", "-d", help=f"Output directory to save the images (default: {os.getcwd()})", 
+                    type=Path, default=os.getcwd(), metavar="DIR")
+parser.add_argument("--debug", help="Enable graph debug mode. This will run in the single thread. (default: false)", 
+                    action="store_true", default=False)
+
 parser.add_argument("field", type=str, help="field to plot")
-parser.add_argument(
-    "--vector-component",
-    dest="vc",
-    type=float,
-    default=None,
-    help=(
-        "Vector component of field to plot. "
-        + "Mutually exclusive with --tensor-component."
-    ),
-)
-parser.add_argument(
-    "--tensor-component",
-    dest="tc",
-    type=float,
-    nargs=2,
-    default=None,
-    help=(
-        "Tensor components of field to plot "
-        + "Mutally exclusive with --vector-component."
-    ),
-)
 parser.add_argument("files", type=str, nargs="+", help="files to plot")
-
-
-# def addPath():
-#     """add the vis/python directory to the pythonpath variable"""
-#     myPath = os.path.realpath(os.path.dirname(__file__))
-#     # sys.path.insert(0,myPath+'/../vis/python')
-#     # sys.path.insert(0,myPath+'/vis/python')
-
-
-def read(filename, nGhost=0):
-    """Read the parthenon hdf file"""
-    from phdf import phdf
-
-    f = phdf(filename)
-    return f
-
 
 def plot_dump(
     xf,
     yf,
     q,
-    name,
+    time_title,
+    output_file: Path,
     with_mesh=False,
     block_ids=[],
     xi=None,
@@ -96,12 +83,15 @@ def plot_dump(
 
     fig = plt.figure()
     p = fig.add_subplot(111, aspect=1)
+    p.set_title(f"t = {time_title} seconds")
+
     qm = np.ma.masked_where(np.isnan(q), q)
     qmin = qm.min()
     qmax = qm.max()
-    NumBlocks = q.shape[0]
-    for i in range(NumBlocks):
-        # Plot the actual data, should work if parthenon/output*/ghost_zones = true or false
+
+    n_blocks = q.shape[0]
+    for i in range(n_blocks):
+        # Plot the actual data, should work if parthenon/output*/ghost_zones = true/false
         # but obviously no ghost data will be shown if ghost_zones = false
         p.pcolormesh(xf[i, :], yf[i, :], q[i, :, :], vmin=qmin, vmax=qmax)
 
@@ -141,45 +131,59 @@ def plot_dump(
                 )
                 p.add_patch(rect)
 
-    plt.savefig(name, dpi=300)
-    plt.close()
+    fig.savefig(output_file, dpi=300)
+    plt.close(fig=fig)
+    logger.debug(f"Saved {time_title}s time-step to {output_file}")
+
 
 
 if __name__ == "__main__":
     # addPath()
     args = parser.parse_args()
-    field = args.field
-    files = args.files
-    components = [0, 0]
-    if (args.tc is not None) and (args.vc is not None):
+    logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
+
+    if args.tc and args.vc:
         raise ValueError(
             "Only one of --tensor-component and --vector-component should be set."
         )
+
+    if args.workers > 1:
+        logger.warning("Matplotlib is not multi-thread friendly. Read this for more details https://matplotlib.org/stable/users/faq/howto_faq.html#work-with-threads")
+        logger.warning("Try decreasing threads if you encounter any undefined behaviour")
+    # Create output director if does't exists
+    args.output_directory.mkdir(0o755, True, True)
+    logger.info(f"Total files to process: {len(args.files)}")
+
+    components = [0, 0]
     if args.tc is not None:
         components = args.tc
     if args.vc is not None:
         components = [0, args.vc]
-    dump_id = 0
-    debug_plot = False
-    for f in files:
-        data = read(f)
-        print(data)
-        q = data.Get(field, False, not debug_plot)
-        name = str(dump_id).rjust(4, "0") + ".png"
-        if debug_plot:
-            plot_dump(
-                data.xg,
-                data.yg,
-                q,
-                name,
-                True,
-                data.gid,
-                data.xig,
-                data.yig,
-                data.xeg,
-                data.yeg,
-                components,
-            )
-        else:
-            plot_dump(data.xng, data.yng, q, name, True)
-        dump_id += 1
+    
+    _x = ProcessPoolExecutor if args.worker_type == "process" else ThreadPoolExecutor
+    current_time = 0.0
+    with _x(max_workers=args.workers) as pool:
+        for dump_id, file_name in enumerate(args.files):
+            data = phdf(file_name)
+            if args.field not in data.Variables:
+                logging.error(f"No such field \"{args.field}\" in {file_name}. \
+This will lead to stop further processing")
+                break
+            
+            logger.debug(f"Submitting {file_name}")
+            q = data.Get(args.field, False, not args.debug)
+            name = args.output_directory / Path(str(dump_id).rjust(4, "0") + ".png")
+            if args.debug:
+                pool.submit(plot_dump, data.xg, data.yg, q, current_time, name, True,
+                            data.gid, data.xig, data.yig, data.xeg, data.yeg,
+                            components)
+            else:
+                pool.submit(plot_dump, data.xng, data.yng, 
+                            q, current_time, name, True)
+            current_time += args.time_step
+            current_time = round(current_time, ndigits=2)
+
+
+    logger.info("All files are sent to the processor")
+
+logger.info("All done")

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -245,7 +245,7 @@ if __name__ == "__main__":
                 break
 
             q = data.Get(args.field, False, not args.debug_plot)
-            name = "{}_{:04d}.png".format(args.prefix, frame_id).strip()
+            name = "{}{:04d}.png".format(args.prefix, frame_id).strip()
             output_file = args.output_directory / name
 
             # NOTE: After doing 5 test on different precision, keeping 2 looks more promising

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -206,7 +206,6 @@ def plot_dump(
 
 
 if __name__ == "__main__":
-    # addPath()
     ERROR_FLAG = False
     args = parser.parse_args()
     logger.setLevel(args.log_level)


### PR DESCRIPTION
## PR Summary

This PR solves a lot of things in the movie2d. Lets go one by one

1. Use a parallel processing using ProcessPoolExecutor. I tested with 10 workers, and it working fine. Although, I am printing the matplotlib threading warning. This improved the performance as shown below
    | Old Code | New Code |
    | :----:   | :----:   |
    | ![](https://user-images.githubusercontent.com/28386721/228910368-98ad31a0-a003-4482-81e4-41669d8e7629.png) | ![](https://user-images.githubusercontent.com/28386721/228910423-8dbb5cf5-9688-44a7-9386-577502a24d18.png) | 

   > **Note** Right click on the images and open them in new-tab to get more clear picture
2. Optionally add time-step to show as the axes title
 
    ![](https://user-images.githubusercontent.com/28386721/228911148-01d66f0a-65d8-4035-82a2-9ad9fd9d9e54.png)

3. Check if field exists in the data for each file and break the for-loop on error
4. Remove unused and unaffecting (_idk if that is even a work_) functions
5. Accept the `-d` / `--output-directory` parameter to save the files in the specified directory. It is using pathlib.Path so the functions are pretty simplified as well.
6. Provide switching of `--debug` option from the arguments
7. Generate gif or mp4 movie from the output file images

Motivation: My simulation code used to run faster than movie generation process.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
