### PR TITLE
fix off-by-one indexing error in Ascent ghost mask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 859]](https://github.com/parthenon-hpc-lab/parthenon/pull/859) fix off-by-one indexing error in Ascent ghost mask
 - [[PR 841]](https://github.com/parthenon-hpc-lab/parthenon/pull/841) De-allocate MPI communicators when freeing `Reduction` objects
 - [[PR 851]](https://github.com/parthenon-hpc-lab/parthenon/pull/851) Fix xdmf hyperslab definition for vectors
 - [[PR 843]](https://github.com/parthenon-hpc-lab/parthenon/pull/843) Add guard rails to prolongation/restriction infrastructure

--- a/src/outputs/ascent.cpp
+++ b/src/outputs/ascent.cpp
@@ -146,7 +146,7 @@ void AscentOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       const int njni = nj * ni;
       auto &ghost_mask = ghost_mask_; // redef to lambda capture class member
       pmb->par_for(
-          "Set ascent ghost mask", 0, ncells, KOKKOS_LAMBDA(const int &idx) {
+          "Set ascent ghost mask", 0, ncells - 1, KOKKOS_LAMBDA(const int &idx) {
             const int k = idx / (njni);
             const int j = (idx - k * njni) / ni;
             const int i = idx - k * njni - j * nj;


### PR DESCRIPTION
## PR Summary

The kernel to set the Ascent ghost mask was indexed incorrectly. @pgrete and I discovered this at the code-a-thon last week.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
