### PR TITLE
Update component label logic in output to include basename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [[PR 712]](https://github.com/lanl/parthenon/pull/712) Allow to add params from cmdline
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 870]](https://github.com/parthenon-hpc-lab/parthenon/pull/870) Update component label logic in output to include basename
 - [[PR 853]](https://github.com/parthenon-hpc-lab/parthenon/pull/853) Add multiple features and improve the performance of the movie2d.py tool
 - [[PR 775]](https://github.com/parthenon-hpc-lab/parthenon/pull/775) Reorganize some of the bvals and prolongation/restriction machinery
 - [[PR 753]](https://github.com/parthenon-hpc-lab/parthenon/pull/753) Cleanup uniform Cartesian variable names

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 15 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 16 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=33a2e58f9e8970652febcc3564bb8be02186e0eafbde58417bdf9ee89b0ee9a62ad4058acc6bb4ed9a755c092a0d16323884c8bd29336836c8a7040375fb37c6"
+  "SHA512=33f5df050dbca10a4e7ee1788007f3bd00fe549b8f9e0ae8e4175b76f1cdb28190d64c9eecd9daecdcd880aade8614e8b48d534a96a23b59d7356638ef6045f3"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 
@@ -306,7 +306,7 @@ if (PARTHENON_ENABLE_UNIT_TESTS OR PARTHENON_ENABLE_INTEGRATION_TESTS OR PARTHEN
     if (NOT (${REGRESSION_GOLD_STANDARD_ON_DISK} EQUAL ${REGRESSION_GOLD_STANDARD_VER}))
       message(STATUS "Attempting to download latest gold standard files for regression tests. To disable set REGRESSION_GOLD_STANDARD_SYNC=OFF.")
       file(
-        DOWNLOAD https://github.com/lanl/parthenon/releases/download/regression-gold-v${REGRESSION_GOLD_STANDARD_VER}/parthenon_regression_gold_v${REGRESSION_GOLD_STANDARD_VER}.tgz ${PROJECT_SOURCE_DIR}/tst/regression/gold_standard/parthenon_regression_gold_v${REGRESSION_GOLD_STANDARD_VER}.tgz
+        DOWNLOAD https://github.com/parthenon-hpc-lab/parthenon/releases/download/regression-gold-v${REGRESSION_GOLD_STANDARD_VER}/parthenon_regression_gold_v${REGRESSION_GOLD_STANDARD_VER}.tgz ${PROJECT_SOURCE_DIR}/tst/regression/gold_standard/parthenon_regression_gold_v${REGRESSION_GOLD_STANDARD_VER}.tgz
         EXPECTED_HASH ${REGRESSION_GOLD_STANDARD_HASH}
         )
       execute_process(

--- a/doc/sphinx/src/outputs.rst
+++ b/doc/sphinx/src/outputs.rst
@@ -166,16 +166,12 @@ Ascent actions in ``.yaml`` or ``.json`` format, see
 `Ascent documentation <https://ascent.readthedocs.io/en/latest/Actions/index.html>`__ for a complete list of options.
 
 Parthenon currently only publishes cell-centered variables to Ascent.
-Moreover, the published name of the field is
-
-* for scalars and vectors/tensors with only a single component, the variable name itself
-  (or the component label if provided)
-* for vectors/tensors with more than one component, the variable name followed by
-
-  * ``_#`` with ``#`` being the (flattened) component index, if no component labels
-    have been defined, or
-  * ``_component-label``, if components labels are given.
-
+Moreover, the published name of the field always starts with the base name (to avoid
+name clashes between multiple fields that may have the same [component] labels).
+If component label(s) are provided, they will be added as a suffix, e.g,.
+``basename_component-label`` for all variable types (even scalars).
+Otherwise, an integer index is added for vectors/tensors with more than one component, i.e.,
+vectors/tensors with a single component and without component labels will not contain a suffix.
 The definition of component labels for variables is typically done by downstream codes
 so that the downstream documention should be consulted for more specific information.
 

--- a/doc/sphinx/src/outputs.rst
+++ b/doc/sphinx/src/outputs.rst
@@ -165,6 +165,20 @@ The mandatory ``actions_file`` parameter points to a separate file that defines
 Ascent actions in ``.yaml`` or ``.json`` format, see
 `Ascent documentation <https://ascent.readthedocs.io/en/latest/Actions/index.html>`__ for a complete list of options.
 
+Parthenon currently only publishes cell-centered variables to Ascent.
+Moreover, the published name of the field is
+
+* for scalars and vectors/tensors with only a single component, the variable name itself
+  (or the component label if provided)
+* for vectors/tensors with more than one component, the variable name followed by
+
+  * ``_#`` with ``#`` being the (flattened) component index, if no component labels
+    have been defined, or
+  * ``_component-label``, if components labels are given.
+
+The definition of component labels for variables is typically done by downstream codes
+so that the downstream documention should be consulted for more specific information.
+
 A ``<parthenon/output*>`` block might look like::
 
   <parthenon/output9>

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -153,8 +153,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     std::vector<std::string> advected_labels;
     advected_labels.reserve(vec_size);
     for (int j = 0; j < vec_size; ++j) {
-      advected_labels.push_back("Advected_" + std::to_string(var) + "_" +
-                                std::to_string(j));
+      advected_labels.push_back(std::to_string(var) + "_" + std::to_string(j));
     }
     if (var == 0) { // first var is always called just "advected"
       field_name = field_name_base;

--- a/example/advection/custom_ascent_actions.yaml
+++ b/example/advection/custom_ascent_actions.yaml
@@ -5,7 +5,7 @@
       plots:
         plt1:
           type: "pseudocolor"
-          field: "Advected_0_0"
+          field: "advected_0_0"
           min_value: 0.0
           max_value: 1.0
         plt2:

--- a/src/outputs/ascent.cpp
+++ b/src/outputs/ascent.cpp
@@ -29,6 +29,7 @@
 #include "coordinates/coordinates.hpp"
 #include "defs.hpp"
 #include "globals.hpp"
+#include "interface/variable_state.hpp"
 #include "mesh/mesh.hpp"
 #include "outputs/output_utils.hpp"
 #include "outputs/outputs.hpp"
@@ -169,6 +170,11 @@ void AscentOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     auto &mbd = pmb->meshblock_data.Get();
 
     for (const auto &var : mbd->GetCellVariableVector()) {
+      // ensure that only cell vars are added (for now) as the topology above is only
+      // valid for cell centered vars
+      if (!var->IsSet(Metadata::Cell)) {
+        continue;
+      }
       const auto var_info = VarInfo(var);
 
       for (int icomp = 0; icomp < var_info.num_components; ++icomp) {

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -71,23 +71,20 @@ struct VarInfo {
       PARTHENON_FAIL(msg);
     }
 
-    // Note that this logic does not subscript components without component_labels if
-    // there is only one component. Component names will be e.g.
-    //   my_scalar
-    // or
-    //   my_non-vector_set_0
-    //   my_non-vector_set_1
-    // Note that this means the subscript will be dropped for multidim quantities if their
-    // Nx6, Nx5, Nx4 are set to 1 at runtime e.g.
-    //   my_non-vector_set
-    // Similarly, if component labels are given for all components, those will be used
-    // without the prefixed label.
+    // Full components labels will be composed according to the following rules:
+    // If there just one component (e.g., a scalar var or a vector/tensor with a single
+    // component) no suffix is used and the name is either the single component label (if
+    // available) or the basename. For variables with >1 components, the final component
+    // label will be composed of the basename and a suffix. This suffix is either a
+    // integer if no component labels are given, or the component label itself.
     component_labels = {};
-    if (num_components == 1 || is_vector) {
-      component_labels = component_labels_.size() > 0 ? component_labels_
-                                                      : std::vector<std::string>({label});
+    if (num_components == 1) {
+      component_labels = component_labels_.empty() ? std::vector<std::string>({label})
+                                                   : component_labels_;
     } else if (component_labels_.size() == num_components) {
-      component_labels = component_labels_;
+      for (int i = 0; i < num_components; i++) {
+        component_labels.push_back(label + "_" + component_labels_[i]);
+      }
     } else {
       for (int i = 0; i < num_components; i++) {
         component_labels.push_back(label + "_" + std::to_string(i));

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -81,7 +81,7 @@ struct VarInfo {
     component_labels = {};
     if (num_components == 1) {
       const auto suffix = component_labels_.empty() ? "" : "_" + component_labels_[0];
-      component_labels = std::vector<std::string>({label + suffix})
+      component_labels = std::vector<std::string>({label + suffix});
     } else if (component_labels_.size() == num_components) {
       for (int i = 0; i < num_components; i++) {
         component_labels.push_back(label + "_" + component_labels_[i]);

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -73,14 +73,15 @@ struct VarInfo {
 
     // Full components labels will be composed according to the following rules:
     // If there just one component (e.g., a scalar var or a vector/tensor with a single
-    // component) no suffix is used and the name is either the single component label (if
-    // available) or the basename. For variables with >1 components, the final component
-    // label will be composed of the basename and a suffix. This suffix is either a
-    // integer if no component labels are given, or the component label itself.
+    // component) only the basename and no suffix is used unless a component label is
+    // provided (which will then be added as suffix following an `_`). For variables with
+    // >1 components, the final component label will be composed of the basename and a
+    // suffix. This suffix is either a integer if no component labels are given, or the
+    // component label itself.
     component_labels = {};
     if (num_components == 1) {
-      component_labels = component_labels_.empty() ? std::vector<std::string>({label})
-                                                   : component_labels_;
+      const auto suffix = component_labels_.empty() ? "" : "_" + component_labels_[0];
+      component_labels = std::vector<std::string>({label + suffix})
     } else if (component_labels_.size() == num_components) {
       for (int i = 0; i < num_components; i++) {
         component_labels.push_back(label + "_" + component_labels_[i]);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This PR makes the component labels generated by `VarInfo` unique.
In the process I noticed that we cannot let component labels take precedence (and ignore the basename, e.g, for scalar or single component vectors/tensors) as this may result in a name clash between different fields.
Thus, the basename always needs to be included.

Fixes #864

I also fixed made sure that only cell variable are published.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
