### PR TITLE
fix no particle output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 873]](https://github.com/parthenon-hpc-lab/parthenon/pull/873) Prevent HDF5 from throwing a fit when a swarm has no particles
 - [[PR 866]](https://github.com/parthenon-hpc-lab/parthenon/pull/866) Add missing guard for HDF5 on restart
 - [[PR 861]](https://github.com/parthenon-hpc-lab/parthenon/pull/861) Fix filesystem include for experimental namespace
 - [[PR 859]](https://github.com/parthenon-hpc-lab/parthenon/pull/859) fix off-by-one indexing error in Ascent ghost mask

--- a/example/particle_leapfrog/parthinput.particle_leapfrog
+++ b/example/particle_leapfrog/parthinput.particle_leapfrog
@@ -51,6 +51,7 @@ integrator = rk1
 
 <Particles>
 cfl = 0.3
+disable = false
 
 <parthenon/output0>
 file_type = hdf5

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -62,10 +62,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   Real cfl = pin->GetOrAddReal("Particles", "cfl", 0.3);
   pkg->AddParam<>("cfl", cfl);
 
-  auto write_particle_log_nth_cycle =
-      pin->GetOrAddInteger("Particles", "write_particle_log_nth_cycle", 0);
-  pkg->AddParam<>("write_particle_log_nth_cycle", write_particle_log_nth_cycle);
-
   std::string swarm_name = "my_particles";
   Metadata swarm_metadata({Metadata::Provides, Metadata::None, Metadata::Independent});
   pkg->AddSwarm(swarm_name, swarm_metadata);
@@ -153,6 +149,9 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real &z_max = pmb->coords.Xf<3>(kb.e + 1);
 
   const auto &ic = particles_ic;
+
+  const bool no_particles = pin->GetOrAddBoolean("Particles", "disable", false);
+  if (no_particles) return;
 
   // determine which particles belong to this block
   size_t num_particles_this_block = 0;

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -204,9 +204,10 @@ struct AllSwarmInfo {
 
 // TODO(JMM): Potentially unsafe if MPI_UNSIGNED_LONG_LONG isn't a size_t
 // however I think it's probably safe to assume we'll be on systems
-// where tis is the case?
+// where this is the case?
 // TODO(JMM): If we ever need non-int need to generalize
 std::size_t MPIPrefixSum(std::size_t local, std::size_t &tot_count);
+std::size_t MPISum(std::size_t local);
 
 } // namespace OutputUtils
 } // namespace parthenon

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -576,6 +576,9 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
 
   AllSwarmInfo swarm_info(pm->block_list, output_params.swarms, restart_);
   for (auto &[swname, swinfo] : swarm_info.all_info) {
+    if (swinfo.global_count == 0) {
+      continue;
+    }
     const H5G g_swm = MakeGroup(file, swname);
     // offsets/counts are NOT the same here vs the grid data
     hsize_t local_offset[6] = {static_cast<hsize_t>(my_offset), 0, 0, 0, 0, 0};

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -576,9 +576,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
 
   AllSwarmInfo swarm_info(pm->block_list, output_params.swarms, restart_);
   for (auto &[swname, swinfo] : swarm_info.all_info) {
-    if (swinfo.global_count == 0) {
-      continue;
-    }
     const H5G g_swm = MakeGroup(file, swname);
     // offsets/counts are NOT the same here vs the grid data
     hsize_t local_offset[6] = {static_cast<hsize_t>(my_offset), 0, 0, 0, 0, 0};
@@ -592,6 +589,9 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                 global_count, pl_xfer);
 
     const H5G g_var = MakeGroup(g_swm, "SwarmVars");
+    if (swinfo.global_count == 0) {
+      continue;
+    }
     auto SetCounts = [&](const SwarmInfo &swinfo, const SwarmVarInfo &vinfo) {
       const int rank = vinfo.tensor_rank;
       for (int i = 0; i < 6; ++i) {

--- a/tst/style/cpplint.py
+++ b/tst/style/cpplint.py
@@ -5626,8 +5626,11 @@ def CheckLanguage(
         pass
 
     # Check if people are using the verboten C basic types.  The only exception
-    # we regularly allow is "unsigned short port" for port.
-    if Search(r"\bshort port\b", line):
+    # we regularly allow is "unsigned short port" for port
+    # or if it's used in a static assert
+    if Search(r"\bstatic_assert\b", line):
+        pass
+    elif Search(r"\bshort port\b", line):
         if not Search(r"\bunsigned short port\b", line):
             error(
                 filename,


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

My PR on particle-IO #830 was untested in the case where a swarm has zero particles. In that case, HDF5 complains, as it appears to dislike outputting arrays with zero length. This trivial PR fixes that edge case by outputting the hdf5 scaffolding but skipping output for swarm vars if the count is zero. Similarly, if the total count is zero, the restart reader does not read a given swarm.

I wasn't sure how to test this, as it needs regression testing but the correctness check is "it runs." I think it's a small enough change a test probably isn't necessary.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
