### PR TITLE
Fix restarting from files with ghost zones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [[PR 663]](https://github.com/lanl/parthenon/pull/663) Change bvals_in_one to use sparse boundary buffers and add flux_correction in one.
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 876]](https://github.com/parthenon-hpc-lab/parthenon/pull/876) Fix restarting from files which record ghost zones
 - [[PR 873]](https://github.com/parthenon-hpc-lab/parthenon/pull/873) Prevent HDF5 from throwing a fit when a swarm has no particles
 - [[PR 866]](https://github.com/parthenon-hpc-lab/parthenon/pull/866) Add missing guard for HDF5 on restart
 - [[PR 861]](https://github.com/parthenon-hpc-lab/parthenon/pull/861) Fix filesystem include for experimental namespace

--- a/cmake/FindFilesystem.cmake
+++ b/cmake/FindFilesystem.cmake
@@ -1,3 +1,17 @@
+
+#=========================================================================================
+# (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#=========================================================================================
+
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -620,9 +620,11 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   loclist = std::vector<LogicalLocation>(nbtotal);
 
   const auto blockSize = rr.GetAttrVec<int>("Info", "MeshBlockSize");
-  block_size.nx1 = blockSize[0];
-  block_size.nx2 = blockSize[1];
-  block_size.nx3 = blockSize[2];
+  const auto includesGhost = rr.GetAttr<int>("Info", "IncludesGhost");
+  const auto nGhost = rr.GetAttr<int>("Info", "NGhost");
+  block_size.nx1 = blockSize[0] - (blockSize[0] > 1)*includesGhost*nGhost;
+  block_size.nx2 = blockSize[1] - (blockSize[1] > 1)*includesGhost*nGhost;
+  block_size.nx3 = blockSize[2] - (blockSize[2] > 1)*includesGhost*nGhost;
 
   // calculate the number of the blocks
   nrbx1 = mesh_size.nx1 / block_size.nx1;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -622,9 +622,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   const auto blockSize = rr.GetAttrVec<int>("Info", "MeshBlockSize");
   const auto includesGhost = rr.GetAttr<int>("Info", "IncludesGhost");
   const auto nGhost = rr.GetAttr<int>("Info", "NGhost");
-  block_size.nx1 = blockSize[0] - (blockSize[0] > 1)*includesGhost*nGhost;
-  block_size.nx2 = blockSize[1] - (blockSize[1] > 1)*includesGhost*nGhost;
-  block_size.nx3 = blockSize[2] - (blockSize[2] > 1)*includesGhost*nGhost;
+  block_size.nx1 = blockSize[0] - (blockSize[0] > 1)*includesGhost*2*nGhost;
+  block_size.nx2 = blockSize[1] - (blockSize[1] > 1)*includesGhost*2*nGhost;
+  block_size.nx3 = blockSize[2] - (blockSize[2] > 1)*includesGhost*2*nGhost;
 
   // calculate the number of the blocks
   nrbx1 = mesh_size.nx1 / block_size.nx1;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -622,9 +622,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   const auto blockSize = rr.GetAttrVec<int>("Info", "MeshBlockSize");
   const auto includesGhost = rr.GetAttr<int>("Info", "IncludesGhost");
   const auto nGhost = rr.GetAttr<int>("Info", "NGhost");
-  block_size.nx1 = blockSize[0] - (blockSize[0] > 1)*includesGhost*2*nGhost;
-  block_size.nx2 = blockSize[1] - (blockSize[1] > 1)*includesGhost*2*nGhost;
-  block_size.nx3 = blockSize[2] - (blockSize[2] > 1)*includesGhost*2*nGhost;
+  block_size.nx1 = blockSize[0] - (blockSize[0] > 1) * includesGhost * 2 * nGhost;
+  block_size.nx2 = blockSize[1] - (blockSize[1] > 1) * includesGhost * 2 * nGhost;
+  block_size.nx3 = blockSize[2] - (blockSize[2] > 1) * includesGhost * 2 * nGhost;
 
   // calculate the number of the blocks
   nrbx1 = mesh_size.nx1 / block_size.nx1;


### PR DESCRIPTION
## PR Summary

Fix an old issue when restarting from files written including ghost zones (i.e., setting ghost_zones=true in the restart file block).

This is clearly not a common usage, but it's nice for Dirichlet boundary conditions -- as well as some old versions of KHARMA, which included ghosts in restart files for esoteric reasons related to recovering primitive variables.

We could regression-test this by enabling ghost_zones=true in one or another restarting test -- I'm not sure where or I'd go ahead.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
