### PR TITLE
Separate and expose `PackDescriptor` for `SparsePack`s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 885]](https://github.com/parthenon-hpc-lab/parthenon/pull/885) Expose PackDescriptor and use uids in SparsePacks
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 #=========================================================================================
-# (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,6 +147,7 @@ add_library(parthenon
   interface/state_descriptor.cpp
   interface/update.cpp
   interface/update.hpp
+  interface/var_id.hpp
   interface/variable_pack.hpp
   interface/variable_state.hpp
   interface/variable_state.cpp

--- a/src/amr_criteria/amr_criteria.hpp
+++ b/src/amr_criteria/amr_criteria.hpp
@@ -18,6 +18,7 @@
 
 #include "defs.hpp"
 #include "interface/meshblock_data.hpp"
+#include "mesh/domain.hpp"
 
 namespace parthenon {
 

--- a/src/amr_criteria/amr_criteria.hpp
+++ b/src/amr_criteria/amr_criteria.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -85,6 +85,7 @@ class MeshBlockData {
   }
   auto GetParentPointer() const { return GetBlockPointer(); }
   void SetAllowedDt(const Real dt) const { GetBlockPointer()->SetAllowedDt(dt); }
+  Mesh *GetMeshPointer() const { return GetBlockPointer()->pmy_mesh; }
 
   IndexRange GetBoundsI(const IndexDomain &domain) const {
     return GetBlockPointer()->cellbounds.GetBoundsI(domain);

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -151,7 +151,7 @@ class MeshBlockData {
     return varUidMap_.at(uid);
   }
 
-  auto &GetUidMap() { return varUidMap_; }
+  const auto &GetUidMap() const { return varUidMap_; }
 
   Variable<T> &Get(const std::string &base_name, int sparse_id = InvalidSparseID) const {
     return *GetVarPtr(MakeVarLabel(base_name, sparse_id));

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -151,6 +151,8 @@ class MeshBlockData {
     return varUidMap_.at(uid);
   }
 
+  auto &GetUidMap() { return varUidMap_; }
+
   Variable<T> &Get(const std::string &base_name, int sparse_id = InvalidSparseID) const {
     return *GetVarPtr(MakeVarLabel(base_name, sparse_id));
   }

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -347,8 +347,6 @@ class SparsePack : public SparsePackBase {
   }
 };
 
-enum class PDOpt { WithFluxes, Coarse, Flatten };
-
 inline auto MakePackDescriptor(StateDescriptor *psd, const std::vector<std::string> &vars,
                                const std::vector<bool> &use_regex,
                                const std::vector<MetadataFlag> &flags = {},
@@ -371,9 +369,7 @@ inline auto MakePackDescriptor(StateDescriptor *psd, const std::vector<std::stri
     return false;
   };
 
-  impl::PackDescriptor base_desc(psd, vars, selector, options.count(PDOpt::WithFluxes),
-                                 options.count(PDOpt::Coarse),
-                                 options.count(PDOpt::Flatten));
+  impl::PackDescriptor base_desc(psd, vars, selector, options);
   return typename SparsePack<>::Descriptor(base_desc);
 }
 

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -340,6 +340,11 @@ class SparsePack : public SparsePackBase {
     const int vidx = GetLowerBound(b, t) + t.idx;
     return pack_(dir, b, vidx)(k, j, i);
   }
+
+  template <class... VTs>
+  auto GetPtrs(const int b, const TE el, int k, int j, int i, VTs... vts) {
+    return std::make_tuple({&(*this)(b, el, vts, k, j, i)...});
+  }
 };
 
 enum class PDOpt { WithFluxes, Coarse, Flatten };

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -342,8 +342,9 @@ class SparsePack : public SparsePackBase {
   }
 
   template <class... VTs>
-  auto GetPtrs(const int b, const TE el, int k, int j, int i, VTs... vts) {
-    return std::make_tuple({&(*this)(b, el, vts, k, j, i)...});
+  KOKKOS_INLINE_FUNCTION auto GetPtrs(const int b, const TE el, int k, int j, int i,
+                                      VTs... vts) const {
+    return std::make_tuple(&(*this)(b, el, vts, k, j, i)...);
   }
 };
 

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -130,7 +130,7 @@ class SparsePack : public SparsePackBase {
     // accessed on device via instance of types in the type list Ts...
     // The pack will be created and accessible on the device
     template <class T>
-    SparsePack MakePack(T *pmd) const {
+    SparsePack GetPack(T *pmd) const {
       return SparsePack(SparsePackBase::GetPack(pmd, *this));
     }
 

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -409,16 +409,6 @@ inline auto MakePackDescriptor(
   return MakePackDescriptor(psd, vars, use_regex, flags, options);
 }
 
-// template <class VAR_VEC>
-// inline auto MakePackDescriptor(StateDescriptor *psd, const VAR_VEC &vars,
-//                                const std::vector<MetadataFlag> &flags = {},
-//                                const std::set<PDOpt> &options = {}) {
-//   impl::PackDescriptor base_desc(psd, vars, flags, options.count(PDOpt::WithFluxes),
-//                                  options.count(PDOpt::Coarse),
-//                                  options.count(PDOpt::Flatten));
-//   return typename SparsePack<>::Descriptor(base_desc);
-// }
-
 } // namespace parthenon
 
 #endif // INTERFACE_SPARSE_PACK_HPP_

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -102,8 +102,8 @@ SparsePackBase::alloc_t SparsePackBase::GetAllocStatus(T *pmd,
         if (uid_map.count(uid) > 0) {
           auto pv = uid_map[uid];
           astat.push_back(pv->GetAllocationStatus());
-        } else { 
-          astat.push_back(-1); 
+        } else {
+          astat.push_back(-1);
         }
       }
     }

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -109,11 +109,11 @@ SparsePackBase::alloc_t SparsePackBase::GetAllocStatus(T *pmd,
 
   std::vector<int> astat;
   ForEachBlock(pmd, [&](int b, mbd_t *pmbd) {
-    auto &uid_map = pmbd->GetUidMap();
+    const auto &uid_map = pmbd->GetUidMap();
     for (int i = 0; i < nvar; ++i) {
       for (const auto &[var_name, uid] : desc.var_groups[i]) {
         if (uid_map.count(uid) > 0) {
-          auto pv = uid_map[uid];
+          const auto pv = uid_map.at(uid);
           astat.push_back(pv->GetAllocationStatus());
         } else {
           astat.push_back(-1);
@@ -153,11 +153,11 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
       size = 0;
     }
     nblocks++;
-    auto &uid_map = pmbd->GetUidMap();
+    const auto &uid_map = pmbd->GetUidMap();
     for (int i = 0; i < nvar; ++i) {
       for (const auto &[var_name, uid] : desc.var_groups[i]) {
         if (uid_map.count(uid) > 0) {
-          auto pv = uid_map[uid];
+          const auto pv = uid_map.at(uid);
           if (pv->IsAllocated()) {
             if (pv->IsSet(Metadata::Face) || pv->IsSet(Metadata::Edge))
               contains_face_or_edge = true;
@@ -199,7 +199,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
   int idx = 0;
   ForEachBlock(pmd, [&](int block, mbd_t *pmbd) {
     int b = 0;
-    auto &uid_map = pmbd->GetUidMap();
+    const auto &uid_map = pmbd->GetUidMap();
     if (!desc.flat) {
       idx = 0;
       b = block;
@@ -213,7 +213,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
       pack.bounds_h_(0, block, i) = idx;
       for (const auto &[var_name, uid] : desc.var_groups[i]) {
         if (uid_map.count(uid) > 0) {
-          auto pv = uid_map[uid];
+          const auto pv = uid_map.at(uid);
           if (pv->IsAllocated()) {
             for (int t = 0; t < pv->GetDim(6); ++t) {
               for (int u = 0; u < pv->GetDim(5); ++u) {

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -102,6 +102,8 @@ SparsePackBase::alloc_t SparsePackBase::GetAllocStatus(T *pmd,
         if (uid_map.count(uid) > 0) {
           auto pv = uid_map[uid];
           astat.push_back(pv->GetAllocationStatus());
+        } else { 
+          astat.push_back(-1); 
         }
       }
     }

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -51,6 +51,14 @@ void PackDescriptor::BuildUids(const StateDescriptor *const psd,
       }
     }
   }
+  // Ensure ordering in terms of value of sparse indices
+  for (auto &vg : var_groups) {
+    std::sort(vg.begin(), vg.end(), [](const auto &a, const auto &b) {
+      if (a.first.base_name == b.first.base_name)
+        return a.first.sparse_id < b.first.sparse_id;
+      return a.first.base_name < b.first.base_name;
+    });
+  }
 }
 
 void PackDescriptor::Print() const {

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -52,6 +52,18 @@ void PackDescriptor::BuildUids(const StateDescriptor *const psd,
     }
   }
 }
+
+void PackDescriptor::Print() const {
+  printf("--------------------\n");
+  for (int i = 0; i < vars.size(); ++i) {
+    printf("group name: %s\n", vars[i].c_str());
+    printf("--------------------\n");
+    for (const auto &[var_name, uid] : var_groups[i]) {
+      printf("%s\n", var_name.label().c_str());
+    }
+  }
+  printf("--------------------\n");
+}
 } // namespace impl
 } // namespace parthenon
 

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -41,25 +41,27 @@ class StateDescriptor;
 
 namespace impl {
 struct PackDescriptor {
-  PackDescriptor(StateDescriptor *psd, const std::vector<std::string> &vars, const std::vector<bool> &use_regex,
+  PackDescriptor(StateDescriptor *psd, const std::vector<std::string> &vars,
+                 const std::vector<bool> &use_regex,
                  const std::vector<MetadataFlag> &flags, bool with_fluxes, bool coarse,
                  bool flat = false);
 
-  PackDescriptor(StateDescriptor *psd, const std::vector<std::pair<std::string, bool>> &vars_in,
+  PackDescriptor(StateDescriptor *psd,
+                 const std::vector<std::pair<std::string, bool>> &vars_in,
                  const std::vector<MetadataFlag> &flags, bool with_fluxes, bool coarse,
                  bool flat = false);
 
   PackDescriptor(StateDescriptor *psd, const std::vector<std::string> &vars_in,
                  const std::vector<MetadataFlag> &flags, bool with_fluxes, bool coarse,
                  bool flat = false);
-  
-  void BuildUids(const StateDescriptor * const psd);
+
+  void BuildUids(const StateDescriptor *const psd);
 
   // Method for determining if variable pv should be included in pack for this
   // PackDescriptor
   bool IncludeVariable(int vidx, const std::shared_ptr<Variable<Real>> &pv) const;
 
-  bool IncludeVariable(int vidx, const VarID& id, const Metadata& md) const;
+  bool IncludeVariable(int vidx, const VarID &id, const Metadata &md) const;
 
   std::vector<std::string> vars;
   std::vector<std::regex> regexes;

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -41,33 +41,17 @@ class StateDescriptor;
 
 namespace impl {
 struct PackDescriptor {
+  using SelectorFunction_t = std::function<bool(int, const VarID &, const Metadata &)>;
+
   PackDescriptor(StateDescriptor *psd, const std::vector<std::string> &vars,
-                 const std::vector<bool> &use_regex,
-                 const std::vector<MetadataFlag> &flags, bool with_fluxes, bool coarse,
-                 bool flat = false);
+                 const SelectorFunction_t &selector, bool with_fluxes, bool coarse,
+                 bool flat);
 
-  PackDescriptor(StateDescriptor *psd,
-                 const std::vector<std::pair<std::string, bool>> &vars_in,
-                 const std::vector<MetadataFlag> &flags, bool with_fluxes, bool coarse,
-                 bool flat = false);
+  void BuildUids(const StateDescriptor *const psd, const SelectorFunction_t &selector);
 
-  PackDescriptor(StateDescriptor *psd, const std::vector<std::string> &vars_in,
-                 const std::vector<MetadataFlag> &flags, bool with_fluxes, bool coarse,
-                 bool flat = false);
-
-  void BuildUids(const StateDescriptor *const psd);
-
-  // Method for determining if variable pv should be included in pack for this
-  // PackDescriptor
-  bool IncludeVariable(int vidx, const std::shared_ptr<Variable<Real>> &pv) const;
-
-  bool IncludeVariable(int vidx, const VarID &id, const Metadata &md) const;
-
+  using VariableGroup_t = std::vector<std::pair<VarID, Uid_t>>;
   std::vector<std::string> vars;
-  std::vector<std::regex> regexes;
-  std::vector<bool> use_regex;
-  std::vector<MetadataFlag> flags;
-  std::vector<std::vector<Uid_t>> uids;
+  std::vector<VariableGroup_t> var_groups;
   bool with_fluxes;
   bool coarse;
   bool flat;

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -49,6 +49,8 @@ struct PackDescriptor {
 
   void BuildUids(const StateDescriptor *const psd, const SelectorFunction_t &selector);
 
+  void Print() const;
+
   using VariableGroup_t = std::vector<std::pair<VarID, Uid_t>>;
   std::vector<std::string> vars;
   std::vector<VariableGroup_t> var_groups;
@@ -135,7 +137,6 @@ class SparsePackCache {
                               const std::string &ident);
 
   std::string GetIdentifier(const impl::PackDescriptor &desc) const;
-
   std::unordered_map<std::string, std::pair<SparsePackBase, SparsePackBase::alloc_t>>
       pack_map;
 

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -31,6 +31,7 @@
 #include "interface/params.hpp"
 #include "interface/sparse_pool.hpp"
 #include "interface/swarm.hpp"
+#include "interface/var_id.hpp"
 #include "interface/variable.hpp"
 #include "prolong_restrict/prolong_restrict.hpp"
 #include "utils/error_checking.hpp"
@@ -42,34 +43,6 @@ template <typename T>
 class MeshBlockData;
 template <typename T>
 class MeshData;
-
-/// We uniquely identify a variable by it's full label, i.e. base name plus sparse ID.
-/// However, sometimes we also need to be able to separate the base name from the sparse
-/// ID. Instead of relying on the fact that they are separated by a "_", we store them
-/// separately in VarID struct. This way we know that a dense variable "foo_3" does not
-/// have a sparse ID and a sparse field "foo_3" has base name "foo" and sparse ID 3,
-/// however, the two VarIDs representing them are still considered equal, so that we find
-/// such duplicates
-/// TODO(JMM): Using VarID machinery for prolongation/restriction
-/// implies that all vars in a sparse pool have the same custom
-/// prolongation/restriction operators.
-struct VarID {
-  std::string base_name;
-  int sparse_id;
-
-  explicit VarID(const std::string base_name, int sparse_id = InvalidSparseID)
-      : base_name(base_name), sparse_id(sparse_id) {}
-
-  std::string label() const { return MakeVarLabel(base_name, sparse_id); }
-
-  bool operator==(const VarID &other) const { return (label() == other.label()); }
-};
-
-struct VarIDHasher {
-  auto operator()(const VarID &vid) const {
-    return std::hash<std::string>{}(vid.label());
-  }
-};
 
 /// A little container class owning refinement function properties
 /// needed for the state descriptor.

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -147,11 +147,14 @@ TaskStatus SparseDealloc(MeshData<Real> *md) {
   const IndexRange ib = md->GetBoundsI(IndexDomain::entire);
   const IndexRange jb = md->GetBoundsJ(IndexDomain::entire);
   const IndexRange kb = md->GetBoundsK(IndexDomain::entire);
-
+  
   auto control_vars = md->GetMeshPointer()->resolved_packages->GetControlVariables();
-  const auto tup = SparsePack<>::Get(md, control_vars, {Metadata::Sparse});
-  auto pack = std::get<0>(tup);
-  auto packIdx = std::get<1>(tup);
+  //const auto tup = SparsePack<>::Get(md, control_vars, {Metadata::Sparse});
+  //auto pack = std::get<0>(tup);
+  //auto packIdx = std::get<1>(tup);
+  auto desc = MakePackDescriptor(md->GetMeshPointer()->resolved_packages.get(), control_vars, {Metadata::Sparse}); 
+  auto pack = desc.MakePack(md); 
+  auto packIdx = desc.GetMap(); 
 
   ParArray2D<bool> is_zero("IsZero", pack.GetNBlocks(), pack.GetMaxNumberOfVars());
   const int Ni = ib.e + 1 - ib.s;

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -154,7 +154,7 @@ TaskStatus SparseDealloc(MeshData<Real> *md) {
   // auto packIdx = std::get<1>(tup);
   auto desc = MakePackDescriptor(md->GetMeshPointer()->resolved_packages.get(),
                                  control_vars, {Metadata::Sparse});
-  auto pack = desc.MakePack(md);
+  auto pack = desc.GetPack(md);
   auto packIdx = desc.GetMap();
 
   ParArray2D<bool> is_zero("IsZero", pack.GetNBlocks(), pack.GetMaxNumberOfVars());

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -149,9 +149,6 @@ TaskStatus SparseDealloc(MeshData<Real> *md) {
   const IndexRange kb = md->GetBoundsK(IndexDomain::entire);
 
   auto control_vars = md->GetMeshPointer()->resolved_packages->GetControlVariables();
-  // const auto tup = SparsePack<>::Get(md, control_vars, {Metadata::Sparse});
-  // auto pack = std::get<0>(tup);
-  // auto packIdx = std::get<1>(tup);
   auto desc = MakePackDescriptor(md->GetMeshPointer()->resolved_packages.get(),
                                  control_vars, {Metadata::Sparse});
   auto pack = desc.GetPack(md);

--- a/src/interface/update.cpp
+++ b/src/interface/update.cpp
@@ -147,14 +147,15 @@ TaskStatus SparseDealloc(MeshData<Real> *md) {
   const IndexRange ib = md->GetBoundsI(IndexDomain::entire);
   const IndexRange jb = md->GetBoundsJ(IndexDomain::entire);
   const IndexRange kb = md->GetBoundsK(IndexDomain::entire);
-  
+
   auto control_vars = md->GetMeshPointer()->resolved_packages->GetControlVariables();
-  //const auto tup = SparsePack<>::Get(md, control_vars, {Metadata::Sparse});
-  //auto pack = std::get<0>(tup);
-  //auto packIdx = std::get<1>(tup);
-  auto desc = MakePackDescriptor(md->GetMeshPointer()->resolved_packages.get(), control_vars, {Metadata::Sparse}); 
-  auto pack = desc.MakePack(md); 
-  auto packIdx = desc.GetMap(); 
+  // const auto tup = SparsePack<>::Get(md, control_vars, {Metadata::Sparse});
+  // auto pack = std::get<0>(tup);
+  // auto packIdx = std::get<1>(tup);
+  auto desc = MakePackDescriptor(md->GetMeshPointer()->resolved_packages.get(),
+                                 control_vars, {Metadata::Sparse});
+  auto pack = desc.MakePack(md);
+  auto packIdx = desc.GetMap();
 
   ParArray2D<bool> is_zero("IsZero", pack.GetNBlocks(), pack.GetMaxNumberOfVars());
   const int Ni = ib.e + 1 - ib.s;

--- a/src/interface/update.hpp
+++ b/src/interface/update.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/update.hpp
+++ b/src/interface/update.hpp
@@ -321,7 +321,9 @@ TaskStatus InitNewlyAllocatedVars(T *rc) {
     // This pack will always be freshly built, since we only get here if sparse data
     // was allocated and hasn't been initialized, which in turn implies the cached
     // pack must be stale.
-    auto v = parthenon::SparsePack<variable_names::any>::Get(rc, {Metadata::Sparse});
+    auto desc = parthenon::MakePackDescriptor<variable_names::any>(rc->GetMeshPointer()->resolved_packages.get(), {Metadata::Sparse});
+    auto v = desc.GetPack(rc); 
+    //auto v = parthenon::SparsePack<variable_names::any>::Get(rc, {Metadata::Sparse});
 
     Kokkos::parallel_for(
         "Set newly allocated interior to default",

--- a/src/interface/update.hpp
+++ b/src/interface/update.hpp
@@ -324,7 +324,6 @@ TaskStatus InitNewlyAllocatedVars(T *rc) {
     auto desc = parthenon::MakePackDescriptor<variable_names::any>(
         rc->GetMeshPointer()->resolved_packages.get(), {Metadata::Sparse});
     auto v = desc.GetPack(rc);
-    // auto v = parthenon::SparsePack<variable_names::any>::Get(rc, {Metadata::Sparse});
 
     Kokkos::parallel_for(
         "Set newly allocated interior to default",

--- a/src/interface/update.hpp
+++ b/src/interface/update.hpp
@@ -321,9 +321,10 @@ TaskStatus InitNewlyAllocatedVars(T *rc) {
     // This pack will always be freshly built, since we only get here if sparse data
     // was allocated and hasn't been initialized, which in turn implies the cached
     // pack must be stale.
-    auto desc = parthenon::MakePackDescriptor<variable_names::any>(rc->GetMeshPointer()->resolved_packages.get(), {Metadata::Sparse});
-    auto v = desc.GetPack(rc); 
-    //auto v = parthenon::SparsePack<variable_names::any>::Get(rc, {Metadata::Sparse});
+    auto desc = parthenon::MakePackDescriptor<variable_names::any>(
+        rc->GetMeshPointer()->resolved_packages.get(), {Metadata::Sparse});
+    auto v = desc.GetPack(rc);
+    // auto v = parthenon::SparsePack<variable_names::any>::Get(rc, {Metadata::Sparse});
 
     Kokkos::parallel_for(
         "Set newly allocated interior to default",

--- a/src/interface/var_id.hpp
+++ b/src/interface/var_id.hpp
@@ -1,0 +1,56 @@
+//========================================================================================
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef INTERFACE_VAR_ID_HPP_
+#define INTERFACE_VAR_ID_HPP_
+
+#include <functional>
+#include <string>
+
+namespace parthenon {
+
+inline std::string MakeVarLabel(const std::string &base_name, int sparse_id) {
+  return base_name +
+         (sparse_id == InvalidSparseID ? "" : "_" + std::to_string(sparse_id));
+}
+
+/// We uniquely identify a variable by it's full label, i.e. base name plus sparse ID.
+/// However, sometimes we also need to be able to separate the base name from the sparse
+/// ID. Instead of relying on the fact that they are separated by a "_", we store them
+/// separately in VarID struct. This way we know that a dense variable "foo_3" does not
+/// have a sparse ID and a sparse field "foo_3" has base name "foo" and sparse ID 3,
+/// however, the two VarIDs representing them are still considered equal, so that we find
+/// such duplicates
+/// TODO(JMM): Using VarID machinery for prolongation/restriction
+/// implies that all vars in a sparse pool have the same custom
+/// prolongation/restriction operators.
+struct VarID {
+  std::string base_name;
+  int sparse_id;
+
+  explicit VarID(const std::string base_name, int sparse_id = InvalidSparseID)
+      : base_name(base_name), sparse_id(sparse_id) {}
+
+  std::string label() const { return MakeVarLabel(base_name, sparse_id); }
+
+  bool operator==(const VarID &other) const { return (label() == other.label()); }
+};
+
+struct VarIDHasher {
+  auto operator()(const VarID &vid) const {
+    return std::hash<std::string>{}(vid.label());
+  }
+};
+
+} // namespace parthenon
+
+#endif // INTERFACE_VAR_ID_HPP_

--- a/src/interface/var_id.hpp
+++ b/src/interface/var_id.hpp
@@ -23,7 +23,7 @@ inline std::string MakeVarLabel(const std::string &base_name, int sparse_id) {
          (sparse_id == InvalidSparseID ? "" : "_" + std::to_string(sparse_id));
 }
 
-/// We uniquely identify a variable by it's full label, i.e. base name plus sparse ID.
+/// We uniquely identify a variable by its full label, i.e. base name plus sparse ID.
 /// However, sometimes we also need to be able to separate the base name from the sparse
 /// ID. Instead of relying on the fact that they are separated by a "_", we store them
 /// separately in VarID struct. This way we know that a dense variable "foo_3" does not

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -41,6 +41,7 @@
 #include "basic_types.hpp"
 #include "defs.hpp"
 #include "interface/metadata.hpp"
+#include "interface/var_id.hpp"
 #include "parthenon_arrays.hpp"
 #include "prolong_restrict/prolong_restrict.hpp"
 #include "utils/error_checking.hpp"
@@ -51,11 +52,6 @@ namespace parthenon {
 class MeshBlock;
 template <typename T>
 class MeshBlockData;
-
-inline std::string MakeVarLabel(const std::string &base_name, int sparse_id) {
-  return base_name +
-         (sparse_id == InvalidSparseID ? "" : "_" + std::to_string(sparse_id));
-}
 
 template <typename T>
 class Variable {
@@ -102,9 +98,11 @@ class Variable {
   ///< retrieve label for variable
   inline const auto label() const { return MakeVarLabel(base_name_, sparse_id_); }
   inline const auto base_name() const { return base_name_; }
+  VarID GetVarID() const { return VarID(base_name_, sparse_id_); }
 
   ///< retrieve metadata for variable
-  inline Metadata metadata() const { return m_; }
+  inline const Metadata &metadata() const { return m_; }
+  inline Metadata metadata() { return m_; }
 
   /// Refinement functions owned in metadata
   inline bool IsRefined() const { return m_.IsRefined(); }

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -218,6 +218,9 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
             KOKKOS_LAMBDA(int k, int j, int i, int &ltot) {
               int lo = sparse_pack.GetLowerBound(b, v3());
               int hi = sparse_pack.GetUpperBound(b, v3());
+              // Make sure we can pull out pointers to the variables
+              auto [pv3, pv5] = sparse_pack.GetPtrs(b, parthenon::TopologicalElement::CC,
+                                                    k, j, i, v3(), v5());
               for (int c = 0; c <= hi - lo; ++c) {
                 Real n = i + 1e1 * j + 1e2 * k + 1e4 * c + 1e5 * v + 1e3 * b;
                 if (n != sparse_pack(b, lo + c, k, j, i)) ltot += 1;

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -124,10 +124,11 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       // Deallocate a variable on an arbitrary block
       block_list[2]->DeallocateSparse("v3");
 
-      THEN("A sparse pack can be loaded on this data and report sthe bounds for block 2 "
+      THEN("A sparse pack can be loaded on this data and report the bounds for block 2 "
            "appropriately.") {
-        auto pack =
-            parthenon::SparsePack<v3, v5>::Get(&mesh_data, {Metadata::WithFluxes});
+        auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {Metadata::WithFluxes}); 
+        auto pack = desc.MakePack(&mesh_data);
+            //parthenon::SparsePack<v3, v5>::Get(&mesh_data, {Metadata::WithFluxes});
         int lo = pack.GetLowerBoundHost(2);
         int hi = pack.GetUpperBoundHost(2);
         REQUIRE(lo == 0); // lo = 0 because always start at 0 on a block
@@ -137,15 +138,20 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "
            "blocks") {
         // Create a pack use type variables
-        auto sparse_pack =
-            parthenon::SparsePack<v5, v3>::Get(&mesh_data, {Metadata::WithFluxes});
-
+        //auto sparse_pack =
+        //    parthenon::SparsePack<v5, v3>::Get(&mesh_data, {Metadata::WithFluxes});
+        auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get(), {Metadata::WithFluxes}); 
+        auto sparse_pack = desc.MakePack(&mesh_data);
         // Create the same pack using strings
-        auto tup = parthenon::SparsePack<>::Get(
-            &mesh_data, std::vector<std::string>{"v5", "v3"},
-            std::vector<parthenon::MetadataFlag>{Metadata::WithFluxes});
-        parthenon::SparsePack<> sparse_pack_notype = std::get<0>(tup);
-        auto pack_map = std::get<1>(tup);
+        //auto tup = parthenon::SparsePack<>::Get(
+        //    &mesh_data, std::vector<std::string>{"v5", "v3"},
+        //    std::vector<parthenon::MetadataFlag>{Metadata::WithFluxes});
+        //parthenon::SparsePack<> sparse_pack_notype = std::get<0>(tup);
+        //auto pack_map = std::get<1>(tup);
+
+        auto desc_notype = parthenon::MakePackDescriptor(pkg.get(), std::vector<std::string>{"v5", "v3"}, {Metadata::WithFluxes});  
+        auto sparse_pack_notype = desc_notype.MakePack(&mesh_data);
+        auto pack_map = desc_notype.GetMap();
         parthenon::PackIdx iv3(pack_map["v3"]);
 
         // Make sure that we have only cached one pack, since these should be the
@@ -180,7 +186,9 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A flattened sparse pack can correctly load this data in a unified outer "
            "index space") {
         using parthenon::variable_names::any;
-        auto sparse_pack = parthenon::SparsePack<any>::GetFlatWithFluxes(&mesh_data);
+        //auto sparse_pack = parthenon::SparsePack<any>::GetFlatWithFluxes(&mesh_data);
+        auto desc = parthenon::MakePackDescriptor<any>(pkg.get(), {}, true, false, true); 
+        auto sparse_pack = desc.MakePack(&mesh_data);
         REQUIRE(sparse_pack.GetNBlocks() == 1);
         // v3 is deallocated on one block.
         REQUIRE(sparse_pack.GetMaxNumberOfVars() == 5 * NBLOCKS - 3);
@@ -190,7 +198,9 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         REQUIRE(sparse_pack.GetSize() == 5 * NBLOCKS - 3);
         AND_THEN("A flattened sparse pack starting with v3 has sensible lower/upper "
                  "bounds on the block where we deallocate") {
-          auto pack = parthenon::SparsePack<v3, v5>::GetFlatWithFluxes(&mesh_data);
+          //auto pack = parthenon::SparsePack<v3, v5>::GetFlatWithFluxes(&mesh_data);
+          auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {}, true, false, true); 
+          auto pack = desc.MakePack(&mesh_data);
           int lo = pack.GetLowerBoundHost(2);
           int hi = pack.GetUpperBoundHost(2);
           REQUIRE(lo == 4 - 1 + 4 + 1); // lo = index in flat pack where block 2 starts.
@@ -202,9 +212,10 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
 
       THEN("A sparse pack correctly loads this data and can be read from v3 on a single "
            "block") {
-        auto sparse_pack =
-            parthenon::SparsePack<v5, v3>::Get(block_list[0]->meshblock_data.Get().get());
-
+        //auto sparse_pack =
+        //    parthenon::SparsePack<v5, v3>::Get(block_list[0]->meshblock_data.Get().get());
+        auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get()); 
+        auto sparse_pack = desc.MakePack(block_list[0]->meshblock_data.Get().get());
         const int v = 1; // v3 is the second variable in the loop above so v = 1 there
         int nwrong = 0;
         int b = 0;
@@ -224,13 +235,18 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       }
 
       THEN("A sparse pack correctly reads based on a regex variable") {
-        auto sparse_pack =
-            parthenon::SparsePack<parthenon::variable_names::any>::Get(&mesh_data);
+        //auto sparse_pack =
+        //    parthenon::SparsePack<parthenon::variable_names::any>::Get(&mesh_data);
+        auto desc = parthenon::MakePackDescriptor<parthenon::variable_names::any>(pkg.get()); 
+        auto sparse_pack = desc.MakePack(&mesh_data);
 
-        auto tup = parthenon::SparsePack<>::Get(
-            &mesh_data, std::vector<std::pair<std::string, bool>>{{".*", true}});
-        auto sparse_pack_notype = std::get<0>(tup);
-        auto pack_map = std::get<1>(tup);
+        //auto tup = parthenon::SparsePack<>::Get(
+        //    &mesh_data, std::vector<std::pair<std::string, bool>>{{".*", true}});
+        //auto pack_map = std::get<1>(tup);
+        
+        auto desc_notype = MakePackDescriptor(pkg.get(), std::vector<std::pair<std::string, bool>>{{".*", true}});
+        auto sparse_pack_notype = desc_notype.MakePack(&mesh_data); 
+        auto pack_map = desc_notype.GetMap(); 
         parthenon::PackIdx iall(pack_map[".*"]);
 
         int nwrong = 0;

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -128,7 +128,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
            "appropriately.") {
         auto desc =
             parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {Metadata::WithFluxes});
-        auto pack = desc.MakePack(&mesh_data);
+        auto pack = desc.GetPack(&mesh_data);
         int lo = pack.GetLowerBoundHost(2);
         int hi = pack.GetUpperBoundHost(2);
         REQUIRE(lo == 0); // lo = 0 because always start at 0 on a block
@@ -140,11 +140,11 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         // Create a pack use type variables
         auto desc =
             parthenon::MakePackDescriptor<v5, v3>(pkg.get(), {Metadata::WithFluxes});
-        auto sparse_pack = desc.MakePack(&mesh_data);
+        auto sparse_pack = desc.GetPack(&mesh_data);
 
         auto desc_notype = parthenon::MakePackDescriptor(
             pkg.get(), std::vector<std::string>{"v5", "v3"}, {Metadata::WithFluxes});
-        auto sparse_pack_notype = desc_notype.MakePack(&mesh_data);
+        auto sparse_pack_notype = desc_notype.GetPack(&mesh_data);
         auto pack_map = desc_notype.GetMap();
         parthenon::PackIdx iv3(pack_map["v3"]);
 
@@ -183,7 +183,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         using parthenon::variable_names::any;
         auto desc = parthenon::MakePackDescriptor<any>(
             pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten});
-        auto sparse_pack = desc.MakePack(&mesh_data);
+        auto sparse_pack = desc.GetPack(&mesh_data);
         REQUIRE(sparse_pack.GetNBlocks() == 1);
         // v3 is deallocated on one block.
         REQUIRE(sparse_pack.GetMaxNumberOfVars() == 5 * NBLOCKS - 3);
@@ -195,7 +195,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
                  "bounds on the block where we deallocate") {
           auto desc = parthenon::MakePackDescriptor<v3, v5>(
               pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten});
-          auto pack = desc.MakePack(&mesh_data);
+          auto pack = desc.GetPack(&mesh_data);
           int lo = pack.GetLowerBoundHost(2);
           int hi = pack.GetUpperBoundHost(2);
           REQUIRE(lo == 4 - 1 + 4 + 1); // lo = index in flat pack where block 2 starts.
@@ -208,7 +208,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A sparse pack correctly loads this data and can be read from v3 on a single "
            "block") {
         auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get());
-        auto sparse_pack = desc.MakePack(block_list[0]->meshblock_data.Get().get());
+        auto sparse_pack = desc.GetPack(block_list[0]->meshblock_data.Get().get());
         const int v = 1; // v3 is the second variable in the loop above so v = 1 there
         int nwrong = 0;
         int b = 0;
@@ -230,11 +230,11 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A sparse pack correctly reads based on a regex variable") {
         auto desc =
             parthenon::MakePackDescriptor<parthenon::variable_names::any>(pkg.get());
-        auto sparse_pack = desc.MakePack(&mesh_data);
+        auto sparse_pack = desc.GetPack(&mesh_data);
 
         auto desc_notype = MakePackDescriptor(
             pkg.get(), std::vector<std::pair<std::string, bool>>{{".*", true}});
-        auto sparse_pack_notype = desc_notype.MakePack(&mesh_data);
+        auto sparse_pack_notype = desc_notype.GetPack(&mesh_data);
         auto pack_map = desc_notype.GetMap();
         parthenon::PackIdx iall(pack_map[".*"]);
 

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -128,7 +128,6 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
            "appropriately.") {
         auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {Metadata::WithFluxes}); 
         auto pack = desc.MakePack(&mesh_data);
-            //parthenon::SparsePack<v3, v5>::Get(&mesh_data, {Metadata::WithFluxes});
         int lo = pack.GetLowerBoundHost(2);
         int hi = pack.GetUpperBoundHost(2);
         REQUIRE(lo == 0); // lo = 0 because always start at 0 on a block
@@ -138,16 +137,8 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "
            "blocks") {
         // Create a pack use type variables
-        //auto sparse_pack =
-        //    parthenon::SparsePack<v5, v3>::Get(&mesh_data, {Metadata::WithFluxes});
         auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get(), {Metadata::WithFluxes}); 
         auto sparse_pack = desc.MakePack(&mesh_data);
-        // Create the same pack using strings
-        //auto tup = parthenon::SparsePack<>::Get(
-        //    &mesh_data, std::vector<std::string>{"v5", "v3"},
-        //    std::vector<parthenon::MetadataFlag>{Metadata::WithFluxes});
-        //parthenon::SparsePack<> sparse_pack_notype = std::get<0>(tup);
-        //auto pack_map = std::get<1>(tup);
 
         auto desc_notype = parthenon::MakePackDescriptor(pkg.get(), std::vector<std::string>{"v5", "v3"}, {Metadata::WithFluxes});  
         auto sparse_pack_notype = desc_notype.MakePack(&mesh_data);
@@ -186,8 +177,8 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A flattened sparse pack can correctly load this data in a unified outer "
            "index space") {
         using parthenon::variable_names::any;
-        //auto sparse_pack = parthenon::SparsePack<any>::GetFlatWithFluxes(&mesh_data);
-        auto desc = parthenon::MakePackDescriptor<any>(pkg.get(), {}, true, false, true); 
+        using parthenon::PDOpt;
+        auto desc = parthenon::MakePackDescriptor<any>(pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten}); 
         auto sparse_pack = desc.MakePack(&mesh_data);
         REQUIRE(sparse_pack.GetNBlocks() == 1);
         // v3 is deallocated on one block.
@@ -198,8 +189,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         REQUIRE(sparse_pack.GetSize() == 5 * NBLOCKS - 3);
         AND_THEN("A flattened sparse pack starting with v3 has sensible lower/upper "
                  "bounds on the block where we deallocate") {
-          //auto pack = parthenon::SparsePack<v3, v5>::GetFlatWithFluxes(&mesh_data);
-          auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {}, true, false, true); 
+          auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten}); 
           auto pack = desc.MakePack(&mesh_data);
           int lo = pack.GetLowerBoundHost(2);
           int hi = pack.GetUpperBoundHost(2);
@@ -212,8 +202,6 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
 
       THEN("A sparse pack correctly loads this data and can be read from v3 on a single "
            "block") {
-        //auto sparse_pack =
-        //    parthenon::SparsePack<v5, v3>::Get(block_list[0]->meshblock_data.Get().get());
         auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get()); 
         auto sparse_pack = desc.MakePack(block_list[0]->meshblock_data.Get().get());
         const int v = 1; // v3 is the second variable in the loop above so v = 1 there
@@ -235,15 +223,9 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       }
 
       THEN("A sparse pack correctly reads based on a regex variable") {
-        //auto sparse_pack =
-        //    parthenon::SparsePack<parthenon::variable_names::any>::Get(&mesh_data);
         auto desc = parthenon::MakePackDescriptor<parthenon::variable_names::any>(pkg.get()); 
         auto sparse_pack = desc.MakePack(&mesh_data);
 
-        //auto tup = parthenon::SparsePack<>::Get(
-        //    &mesh_data, std::vector<std::pair<std::string, bool>>{{".*", true}});
-        //auto pack_map = std::get<1>(tup);
-        
         auto desc_notype = MakePackDescriptor(pkg.get(), std::vector<std::pair<std::string, bool>>{{".*", true}});
         auto sparse_pack_notype = desc_notype.MakePack(&mesh_data); 
         auto pack_map = desc_notype.GetMap(); 

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -126,7 +126,8 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
 
       THEN("A sparse pack can be loaded on this data and report the bounds for block 2 "
            "appropriately.") {
-        auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {Metadata::WithFluxes}); 
+        auto desc =
+            parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {Metadata::WithFluxes});
         auto pack = desc.MakePack(&mesh_data);
         int lo = pack.GetLowerBoundHost(2);
         int hi = pack.GetUpperBoundHost(2);
@@ -137,10 +138,12 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "
            "blocks") {
         // Create a pack use type variables
-        auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get(), {Metadata::WithFluxes}); 
+        auto desc =
+            parthenon::MakePackDescriptor<v5, v3>(pkg.get(), {Metadata::WithFluxes});
         auto sparse_pack = desc.MakePack(&mesh_data);
 
-        auto desc_notype = parthenon::MakePackDescriptor(pkg.get(), std::vector<std::string>{"v5", "v3"}, {Metadata::WithFluxes});  
+        auto desc_notype = parthenon::MakePackDescriptor(
+            pkg.get(), std::vector<std::string>{"v5", "v3"}, {Metadata::WithFluxes});
         auto sparse_pack_notype = desc_notype.MakePack(&mesh_data);
         auto pack_map = desc_notype.GetMap();
         parthenon::PackIdx iv3(pack_map["v3"]);
@@ -176,9 +179,10 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
 
       THEN("A flattened sparse pack can correctly load this data in a unified outer "
            "index space") {
-        using parthenon::variable_names::any;
         using parthenon::PDOpt;
-        auto desc = parthenon::MakePackDescriptor<any>(pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten}); 
+        using parthenon::variable_names::any;
+        auto desc = parthenon::MakePackDescriptor<any>(
+            pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten});
         auto sparse_pack = desc.MakePack(&mesh_data);
         REQUIRE(sparse_pack.GetNBlocks() == 1);
         // v3 is deallocated on one block.
@@ -189,7 +193,8 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         REQUIRE(sparse_pack.GetSize() == 5 * NBLOCKS - 3);
         AND_THEN("A flattened sparse pack starting with v3 has sensible lower/upper "
                  "bounds on the block where we deallocate") {
-          auto desc = parthenon::MakePackDescriptor<v3, v5>(pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten}); 
+          auto desc = parthenon::MakePackDescriptor<v3, v5>(
+              pkg.get(), {}, {PDOpt::WithFluxes, PDOpt::Flatten});
           auto pack = desc.MakePack(&mesh_data);
           int lo = pack.GetLowerBoundHost(2);
           int hi = pack.GetUpperBoundHost(2);
@@ -202,7 +207,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
 
       THEN("A sparse pack correctly loads this data and can be read from v3 on a single "
            "block") {
-        auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get()); 
+        auto desc = parthenon::MakePackDescriptor<v5, v3>(pkg.get());
         auto sparse_pack = desc.MakePack(block_list[0]->meshblock_data.Get().get());
         const int v = 1; // v3 is the second variable in the loop above so v = 1 there
         int nwrong = 0;
@@ -223,12 +228,14 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
       }
 
       THEN("A sparse pack correctly reads based on a regex variable") {
-        auto desc = parthenon::MakePackDescriptor<parthenon::variable_names::any>(pkg.get()); 
+        auto desc =
+            parthenon::MakePackDescriptor<parthenon::variable_names::any>(pkg.get());
         auto sparse_pack = desc.MakePack(&mesh_data);
 
-        auto desc_notype = MakePackDescriptor(pkg.get(), std::vector<std::pair<std::string, bool>>{{".*", true}});
-        auto sparse_pack_notype = desc_notype.MakePack(&mesh_data); 
-        auto pack_map = desc_notype.GetMap(); 
+        auto desc_notype = MakePackDescriptor(
+            pkg.get(), std::vector<std::pair<std::string, bool>>{{".*", true}});
+        auto sparse_pack_notype = desc_notype.MakePack(&mesh_data);
+        auto pack_map = desc_notype.GetMap();
         parthenon::PackIdx iall(pack_map[".*"]);
 
         int nwrong = 0;


### PR DESCRIPTION
## PR Summary

Implements the updates to the `SparsePack` interface as discussed by myself, @Yurlungur, @pdmullen, and @jdolence. `PackDescriptor`s are now exposed to users and can be created separately from the sparse pack itself. Now, when a pack is actually built based on a `PackDescriptor`, it is done based on the `Uid_t` of variables so there should be no expensive string comparisons. 

```c++
auto desc = parthenon::MakePackDescriptor<v1, v2>(&my_package_descriptor, {Metadata::WithFluxes}, {PDOpt::WithFluxes});
...
auto sparse_pack = desc.MakePack(&mesh_data);
```

Currently, everything is working but I think there are maybe a couple of features that I forgot to add that were discussed on Friday. Currently, it lets you define a variable selector function in a `MakePackDescriptor` free function so that it is straightforward to write new selectors (e.g. if you are not a fan of regexes). It also adds a function to `SparsePack`s that allows you to pull out pointers to variables in a single line via a structured binding, as suggested by @pdmullen. 

One thing we could do is explicitly sort the variables within each variable group in a pack (by allowing for a custom comparator to be passed to `PackDescriptor`). This would allow downstream codes to guarantee ordering of variables within the pack, which is currently required in some downstream codes.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Updates tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
