### PR TITLE
param restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 Date: 2023-05-26
 
 ### Added (new features/APIs/variables/...)
+- [[PR 887]](https://github.com/parthenon-hpc-lab/parthenon/pull/887) Add ability to dump more types of params and read them from restarts
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 - [[PR 830]](https://github.com/parthenon-hpc-lab/parthenon/pull/830) Add particle output
 - [[PR 840]](https://github.com/parthenon-hpc-lab/parthenon/pull/840) Generalized integrators infrastructure in a backwards compatible way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 887]](https://github.com/parthenon-hpc-lab/parthenon/pull/887) Add ability to dump more types of params and read them from restarts
 - [[PR 872]](https://github.com/parthenon-hpc-lab/parthenon/pull/872) Boundary communication for non-cell centered fields
 - [[PR 877]](https://github.com/parthenon-hpc-lab/parthenon/pull/877) Add flat sparse packs
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
@@ -20,7 +21,6 @@
 Date: 2023-05-26
 
 ### Added (new features/APIs/variables/...)
-- [[PR 887]](https://github.com/parthenon-hpc-lab/parthenon/pull/887) Add ability to dump more types of params and read them from restarts
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 - [[PR 830]](https://github.com/parthenon-hpc-lab/parthenon/pull/830) Add particle output
 - [[PR 840]](https://github.com/parthenon-hpc-lab/parthenon/pull/840) Generalized integrators infrastructure in a backwards compatible way

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 17 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 18 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=075658d5fe71e2216f3301d5d8873b2ba588120d2a3b8a2e4ac1940c50719640f4c26d99c94021b6c4f7499544ccaf58f57db5e07ee6c7f75a04ab8d88d9ec89"
+          "SHA512=193f205b5ebd8dc193dabc7f8e2d3f12bf4f9c34f84312aaaa201f8e19a07342d61f7f07d0119e6de1f2af00f067c20cb4d71edad076b583c102bf4dddb2ade2"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,7 +72,7 @@ include(cmake/Lint.cmake)
 # regression test reference data
 set(REGRESSION_GOLD_STANDARD_VER 18 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-          "SHA512=193f205b5ebd8dc193dabc7f8e2d3f12bf4f9c34f84312aaaa201f8e19a07342d61f7f07d0119e6de1f2af00f067c20cb4d71edad076b583c102bf4dddb2ade2"
+  "SHA512=193f205b5ebd8dc193dabc7f8e2d3f12bf4f9c34f84312aaaa201f8e19a07342d61f7f07d0119e6de1f2af00f067c20cb4d71edad076b583c102bf4dddb2ade2"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/doc/sphinx/src/inputs.rst
+++ b/doc/sphinx/src/inputs.rst
@@ -31,16 +31,16 @@ General parthenon options such as problem name and parameter handling.
 
 Options related to time-stepping and printing of diagnostic data.
 
-+------------------------------+---------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| Option                       | Default | Type   | Description                                                                                                                                                                                                                                 |
-+==============================+=========+========+=============================================================================================================================================================================================================================================+
-|| tlim                        || none   || float || Stop criterion on simulation time.                                                                                                                                                                                                         |
-|| nlim                        || -1     || int   || Stop criterion on total number of steps taken. Ignored if < 0.                                                                                                                                                                             |
-|| perf_cycle_offset           || 0      || int   || Skip the first N cycles when calculating the final performance (e.g., zone-cycles/wall_second). Allows to hide the initialization overhead in Parthenon, which usually takes place in the first cycles when Containers are allocated, etc. |
-|| ncycle_out                  || 1      || int   || Number of cycles between short diagnostic output to standard out containing, e.g., current time, dt, zone-update/wsec. Default: 1 (i.e, every cycle).                                                                                      |
-|| ncycle_out_mesh             || 0      || int   || Number of cycles between printing the mesh structure (e.g., total number of MeshBlocks and number of MeshBlocks per level) to standard out. Use a negative number to also print every time the mesh was modified. Default: 0 (i.e, off).   |
-|| ncrecv_bdry_buf_timeout_sec || -1.0   || Real  || Timeout in seconds for the `ReceiveBoundaryBuffers` tasks. Disabed (negative) by default. Typically no need in production runs. Useful for debugging MPI calls.                                                       |
-+------------------------------+---------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
++------------------------------+---------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| Option                       | Default | Type   | Description                                                                                                                                                           |
++==============================+=========+========+=======================================================================================================================================================================+
+|| tlim                        || none   || float || Stop criterion on simulation time.                                                                                                                                   |
+|| nlim                        || -1     || int   || Stop criterion on total number of steps taken. Ignored if < 0.                                                                                                       |
+|| perf_cycle_offset           || 0      || int   || Skip the first N cycles when calculating the final performance (e.g., zone-cycles/wall_second). Allows to hide the initialization overhead in Parthenon.             |
+|| ncycle_out                  || 1      || int   || Number of cycles between short diagnostic output to standard out containing, e.g., current time, dt, zone-update/wsec. Default: 1 (i.e, every cycle).                |
+|| ncycle_out_mesh             || 0      || int   || Number of cycles between printing the mesh structure to standard out. Use a negative number to also print every time the mesh was modified. Default: 0 (i.e, off).   |
+|| ncrecv_bdry_buf_timeout_sec || -1.0   || Real  || Timeout in seconds for the `ReceiveBoundaryBuffers` tasks. Disabed (negative) by default. Typically no need in production runs. Useful for debugging MPI calls.      |
++------------------------------+---------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
 ``<parthenon/mesh>``

--- a/doc/sphinx/src/interface/sparse.rst
+++ b/doc/sphinx/src/interface/sparse.rst
@@ -421,14 +421,14 @@ meshblock may vary with meshblock. Each ``MeshBlock`` object keeps a
 running total of its memory footprint. You can get the footprint of an
 individual meshblock by calling:
 
-.. cpp:function::
+.. code:: cpp
 
    std::uint64_t MeshBlock::ReportMemUsage();
 
 If desired, you may also manually change the recorded memory footprint
 of a given meshblock with the function:
 
-.. cpp:function::
+.. code:: cpp
 
    void MeshBlock::LogMemUsage(std::int64_t delta);
 

--- a/doc/sphinx/src/interface/state.rst
+++ b/doc/sphinx/src/interface/state.rst
@@ -38,10 +38,22 @@ several useful features and functions.
   all blocks just like dense variables, however, in a future upgrade, they
   will only be allocated on those blocks where the user explicitly
   allocates them or non-zero values are advected into.
-- ``void AddParam<T>(const std::string& key, T& value, bool is_mutable)``
-  adds a parameter (e.g., a timestep control coefficient, refinement
-  tolerance, etc.) with name ``key`` and value ``value``. If
-  ``is_mutable`` is true, parameters can be more easily modified.
+- ``void AddParam<T>(const std::string& key, T& value, Mutability
+  mutability)`` adds a parameter (e.g., a timestep control
+  coefficient, refinement tolerance, etc.) with name ``key`` and value
+  ``value``. The enum ``mutability`` can take on three values:
+  ``Mutability::Immutable``, ``Mutability::Mutable``, and
+  ``Mutability::Restart``. Paramters that are ``Immutable`` cannot be
+  modified. Parameters that are ``Mutable`` or ``Restart`` can be
+  modified via the ``MutableParam`` and ``UpdateParam``
+  options. Parameters that are ``Restart`` will be re-read from the
+  restart file and updated upon restart. In contrast, ``Mutable``
+  params not marked ``Restart`` are updated only by user code, not
+  automatically. Note that not all parameter types can be output to
+  HDF5 file. However, most common scalar, vector, and ``Kokkos`` view
+  types are supported. Note also that by default the ``Mesh`` object
+  and each ``MeshBlock`` object all own their own copies of all
+  packages.
 - ``void UpdateParam<T>(const std::string& key, T& value)``\ updates a
   parameter (e.g., a timestep control coefficient, refinement tolerance,
   etc.) with name ``key`` and value ``value``. A parameter of the same

--- a/doc/sphinx/src/interface/state.rst
+++ b/doc/sphinx/src/interface/state.rst
@@ -38,8 +38,8 @@ several useful features and functions.
   all blocks just like dense variables, however, in a future upgrade, they
   will only be allocated on those blocks where the user explicitly
   allocates them or non-zero values are advected into.
-- ``void AddParam<T>(const std::string& key, T& value, Mutability
-  mutability)`` adds a parameter (e.g., a timestep control
+- ``void AddParam<T>(const std::string& key, T& value, Mutability mutability)``
+  adds a parameter (e.g., a timestep control
   coefficient, refinement tolerance, etc.) with name ``key`` and value
   ``value``. The enum ``mutability`` can take on three values:
   ``Mutability::Immutable``, ``Mutability::Mutable``, and
@@ -54,6 +54,9 @@ several useful features and functions.
   types are supported. Note also that if the value of a ``Param`` is
   different on different MPI ranks, this will result in undefined
   behaviour.
+- ``void AddParam<T>(const std::string& key, T& value, bool is_mutable=false)``
+  is the same as above, but adds only ``Immutable`` or ``Mutable`` params,
+  not ``Restart`` params.
 - ``void UpdateParam<T>(const std::string& key, T& value)``\ updates a
   parameter (e.g., a timestep control coefficient, refinement tolerance,
   etc.) with name ``key`` and value ``value``. A parameter of the same

--- a/doc/sphinx/src/interface/state.rst
+++ b/doc/sphinx/src/interface/state.rst
@@ -51,9 +51,9 @@ several useful features and functions.
   params not marked ``Restart`` are updated only by user code, not
   automatically. Note that not all parameter types can be output to
   HDF5 file. However, most common scalar, vector, and ``Kokkos`` view
-  types are supported. Note also that by default the ``Mesh`` object
-  and each ``MeshBlock`` object all own their own copies of all
-  packages.
+  types are supported. Note also that if the value of a ``Param`` is
+  different on different MPI ranks, this will result in undefined
+  behaviour.
 - ``void UpdateParam<T>(const std::string& key, T& value)``\ updates a
   parameter (e.g., a timestep control coefficient, refinement tolerance,
   etc.) with name ``key`` and value ``value``. A parameter of the same

--- a/doc/sphinx/src/load_balancing.rst
+++ b/doc/sphinx/src/load_balancing.rst
@@ -11,7 +11,7 @@ modified.
 On a per ``MeshBlock`` basis, you call the
 function
 
-.. cpp:function::
+.. code:: cpp
 
    void MeshBlock::SetCostForLoadBalancing(double cost);
 

--- a/doc/sphinx/src/tests.rst
+++ b/doc/sphinx/src/tests.rst
@@ -1,0 +1,119 @@
+.. _tests:
+
+How to add tests to Parthenon
+==============================
+
+Unit Tests
+-----------
+
+Unit tests are straightforward to implement. Open the ``tst/unit``
+directory to see the current test suites. You may either add a new
+file to this directory (and the associated ``CMakeLists.txt`` file, or
+extend an existing file.
+
+Parthenon uses the `Catch2`_ unit test framework. Tests are typically
+written in the following format:
+
+.. code:: cpp
+
+   TEST_CASE("Name", "[category1][category2]") {
+     GIVEN("Set up code") {
+       // some code
+       WHEN("Trigger") {
+         THEN("Condition") {
+           REQUIRE(some_bool_expression);
+         }
+       }
+     }
+   }
+
+See the Catch documentation for more details.
+
+.. _Catch2: https://github.com/catchorg/Catch2/tree/v2.x
+
+Regression Tests
+-----------------
+
+The regression test infrastructure is more complicated, and our
+regression test infrastructure is built on a mix of Python and
+CMake. Each test is defined by a *test suite*. You can find the test
+suites in the ``tst/regression/test_suites`` directory. Each test
+suite is a Python module that defines a ``TestCase`` class, which
+inherits from the abstract base class provided by the
+``utils.test_case`` module included in the test suite. A ``TestCase``
+class must implement the following methods:
+
+* ``Prepare(self, parameters, step)`` is the python code which sets up
+  a simulation run. It modifies an included input deck for a given
+  test, based on the test design. The ``parameters`` input contains a
+  list of command line arguments that should modify the parthenon
+  run. These are passed in to the test infrastructure via CMake
+  (described below). The ``step`` argument is an integer. It is used
+  for regression tests that require multiple simulation runs, such as
+  a convergence test.
+
+* ``Analyze(self, parameters)`` is the post-processing step that
+  checks whether or not the test passed. Some tests compare to gold
+  files (described further below) and some simply compare to a known
+  solution.
+
+A test suite needs to have not only the python file containing the
+``TestCase`` class, but an empty ``__init__.py`` file to match the
+Python module API.
+
+After adding a module, you must also modify the file
+``tst/regression/CMakeLists.txt``. In particular for a new regression
+test, you must add a set of arguments like these:
+
+::
+
+   list(APPEND TEST_DIRS name_of_folder )
+   list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
+   list(APPEND TEST_ARGS args_to_pass_to_run_test.py )
+   list(APPEND EXTRA_TEST_LABELS "my-awesome-test")
+
+The first argument specifies the name of the folder containing the new
+python module for the new test. The second argument specifies number
+of MPI ranks if the test should be run with MPI (specify 1 if
+not). The third argument specifies arguments to pass to your test
+suite, for example
+
+::
+
+   "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/advection_performance/parthinput.advection_performance --num_steps 4"
+
+which would specify which application to run for the test, as well as the input deck and the number of steps.
+
+The final argument specifies labels attached to the test for use with
+CTest.
+
+Gold Files
+-----------
+
+Many tests use so-called *gold files*, files are files containing
+known results to compare against. Parthenon bundles its gold files as
+part of releases. These files are automatically downloaded and are
+located in ``tst/regression/gold_standard``. To add a new gold file
+(or update an old one), place it in this directory.
+
+To make the new (or updated) test official, you must add it to the
+official test suite. First update
+``tst/regression/gold_standard/README.rst`` and add a new version of
+the test suite, corresponding to the commit where you added the
+relevant test code and an explanation for why the gold files needed to
+change. Then run the script ```make_tarball.sh`` as
+
+::
+
+   bash make_tarball.sh NEW_VERSION
+
+where ``NEW_VERSION`` is the new version of the gold files (not
+necessarily tied to the version of the code release). You can then ask
+a maintainer to create a new goldfile release and attach the resultant
+tarball to the release.
+
+As a sanity check, Parthenon checks against the ``sha512`` hash of the
+tarball. The make tarball script will output the hash. The new version
+and new hash must be set as the default values of the
+``REGRESSION_GOLD_STANDARD_VER`` and ``REGRESSION_GOLD_STANDARD_HASH``
+in the top level ``CMakeLists.txt`` file.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -137,6 +137,7 @@ add_library(parthenon
   interface/metadata.cpp
   interface/metadata.hpp
   interface/packages.hpp
+  interface/params.cpp
   interface/params.hpp
   interface/sparse_pack.hpp
   interface/sparse_pack_base.cpp

--- a/src/interface/packages.hpp
+++ b/src/interface/packages.hpp
@@ -33,6 +33,7 @@ class Packages_t {
   const Dictionary<std::shared_ptr<StateDescriptor>> &AllPackages() const {
     return packages_;
   }
+  Dictionary<std::shared_ptr<StateDescriptor>> &AllPackages() { return packages_; }
 
  private:
   Dictionary<std::shared_ptr<StateDescriptor>> packages_;

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -16,6 +16,7 @@
 #include "utils/error_checking.hpp"
 
 #include "kokkos_abstraction.hpp"
+#include "parthenon_arrays.hpp"
 
 #ifdef ENABLE_HDF5
 #include "outputs/parthenon_hdf5.hpp"
@@ -32,9 +33,9 @@ namespace parthenon {
 // that into function calls. Preprocessor seems easier, given we're
 // not manipulating this list in any way.
 #define VALID_VEC_TYPES(T)                                                               \
-  T, std::vector<T>, ParArray0D<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,         \
+  T, std::vector<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,                        \
       ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,         \
-      HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,    \
+      HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,                    \
       HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,                 \
       Kokkos::View<T **>, ParArrayND<T>, ParArrayHost<T>
 

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -26,7 +26,7 @@
 namespace parthenon {
 
 // JMM: This could probably be done with template magic but I think
-// using a macro is honestly the simplest and cleanest solution here/
+// using a macro is honestly the simplest and cleanest solution here.
 // Template solution would be to define a variatic class to conain the
 // list of types and then a hierarchy of structs/functions to turn
 // that into function calls. Preprocessor seems easier, given we're

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -33,11 +33,11 @@ namespace parthenon {
 // that into function calls. Preprocessor seems easier, given we're
 // not manipulating this list in any way.
 #define VALID_VEC_TYPES(T)                                                               \
-  T, std::vector<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,                        \
-      ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,         \
-      HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,                    \
-      HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,                 \
-      Kokkos::View<T **>, ParArrayND<T>, ParArrayHost<T>
+  T, std::vector<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>, ParArray4D<T>,         \
+      ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>, HostArray1D<T>,        \
+      HostArray2D<T>, HostArray3D<T>, HostArray4D<T>, HostArray5D<T>, HostArray6D<T>,    \
+      HostArray7D<T>, Kokkos::View<T *>, Kokkos::View<T **>, ParArrayND<T>,              \
+      ParArrayHost<T>
 
 #ifdef ENABLE_HDF5
 

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -57,19 +57,67 @@ void Params::WriteToHDF5AllParamsOfTypeOrVec(const std::string &prefix,
       Kokkos::View<T **>>(prefix, group);
 }
 
+template <typename T>
+void Params::ReadFromHDF5AllParamsOfType(const std::string &prefix,
+                                         const HDF5::H5G &group) {
+  for (auto &p : myParams_) {
+    auto &key = p.first;
+    auto type = myTypes_.at(key);
+    auto mutability = myMutable_.at(key);
+    if (type == std::type_index(typeid(T)) && mutability == Mutability::Restart) {
+      auto typed_ptr = dynamic_cast<Params::object_t<T> *>((p.second).get());
+      auto &val = *(typed_ptr->pValue);
+      HDF5::HDF5ReadAttribute(group, prefix + "/" + key, val);
+      Update(key, val);
+    }
+  }
+}
+
 template <typename... Ts>
-void Params::WriteToHDF5AllParamsOfMultipleTypesOrVec(const std::string &prefix,
-                                                      const HDF5::H5G &group) const {
-  ([&] { WriteToHDF5AllParamsOfTypeOrVec<Ts>(prefix, group); }(), ...);
+void Params::ReadFromHDF5AllParamsOfMultipleTypes(const std::string &prefix,
+                                                  const HDF5::H5G &group) {
+  ([&] { ReadFromHDF5AllParamsOfType<Ts>(prefix, group); }(), ...);
+}
+
+template <typename T>
+void Params::ReadFromHDF5AllParamsOfTypeOrVec(const std::string &prefix,
+                                              const HDF5::H5G &group) {
+  ReadFromHDF5AllParamsOfMultipleTypes<
+      T, std::vector<T>, ParArray0D<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,
+      ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,
+      HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,
+      HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,
+      Kokkos::View<T **>>(prefix, group);
 }
 
 void Params::WriteAllToHDF5(const std::string &prefix, const HDF5::H5G &group) const {
   // views and vecs of scalar types
-  WriteToHDF5AllParamsOfMultipleTypesOrVec<bool, int32_t, int64_t, uint32_t, uint64_t,
-                                           float, double>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<bool>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<int32_t>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<int64_t>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<uint32_t>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<uint64_t>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<float>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<double>(prefix, group);
+
   // strings
   WriteToHDF5AllParamsOfType<std::string>(prefix, group);
   WriteToHDF5AllParamsOfType<std::vector<std::string>>(prefix, group);
+}
+
+void Params::ReadFromRestart(const std::string &prefix, const HDF5::H5G &group) {
+  // views and vecs of scalar types
+  ReadFromHDF5AllParamsOfTypeOrVec<bool>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<int32_t>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<int64_t>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<uint32_t>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<uint64_t>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<float>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<double>(prefix, group);
+
+  // strings
+  ReadFromHDF5AllParamsOfType<std::string>(prefix, group);
+  ReadFromHDF5AllParamsOfType<std::vector<std::string>>(prefix, group);
 }
 
 #endif // ifdef ENABLE_HDF5

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -36,7 +36,7 @@ namespace parthenon {
       ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,         \
       HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,    \
       HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,                 \
-      Kokkos::View<T **>
+      Kokkos::View<T **>, ParArrayND<T>, ParArrayHost<T>
 
 #ifdef ENABLE_HDF5
 

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -1,0 +1,77 @@
+//========================================================================================
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#include <string>
+
+#include "utils/error_checking.hpp"
+
+#include "kokkos_abstraction.hpp"
+
+#ifdef ENABLE_HDF5
+#include "outputs/parthenon_hdf5.hpp"
+#endif
+
+#include "params.hpp"
+
+namespace parthenon {
+
+#ifdef ENABLE_HDF5
+
+template <typename T>
+void Params::WriteToHDF5AllParamsOfType(const std::string &prefix,
+                                        const HDF5::H5G &group) const {
+  for (const auto &p : myParams_) {
+    const auto &key = p.first;
+    const auto type = myTypes_.at(key);
+    if (type == std::type_index(typeid(T))) {
+      auto typed_ptr = dynamic_cast<Params::object_t<T> *>((p.second).get());
+      HDF5::HDF5WriteAttribute(prefix + "/" + key, *typed_ptr->pValue, group);
+    }
+  }
+}
+
+template <typename... Ts>
+void Params::WriteToHDF5AllParamsOfMultipleTypes(const std::string &prefix,
+                                                 const HDF5::H5G &group) const {
+  ([&] { WriteToHDF5AllParamsOfType<Ts>(prefix, group); }(), ...);
+}
+
+template <typename T>
+void Params::WriteToHDF5AllParamsOfTypeOrVec(const std::string &prefix,
+                                             const HDF5::H5G &group) const {
+  WriteToHDF5AllParamsOfMultipleTypes<
+      T, std::vector<T>, ParArray0D<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,
+      ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,
+      HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,
+      HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,
+      Kokkos::View<T **>>(prefix, group);
+}
+
+template <typename... Ts>
+void Params::WriteToHDF5AllParamsOfMultipleTypesOrVec(const std::string &prefix,
+                                                      const HDF5::H5G &group) const {
+  ([&] { WriteToHDF5AllParamsOfTypeOrVec<Ts>(prefix, group); }(), ...);
+}
+
+void Params::WriteAllToHDF5(const std::string &prefix, const HDF5::H5G &group) const {
+  // views and vecs of scalar types
+  WriteToHDF5AllParamsOfMultipleTypesOrVec<bool, int32_t, int64_t, uint32_t, uint64_t,
+                                           float, double>(prefix, group);
+  // strings
+  WriteToHDF5AllParamsOfType<std::string>(prefix, group);
+  WriteToHDF5AllParamsOfType<std::vector<std::string>>(prefix, group);
+}
+
+#endif // ifdef ENABLE_HDF5
+
+} // namespace parthenon

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -25,6 +25,19 @@
 
 namespace parthenon {
 
+// JMM: This could probably be done with template magic but I think
+// using a macro is honestly the simplest and cleanest solution here/
+// Template solution would be to define a variatic class to conain the
+// list of types and then a hierarchy of structs/functions to turn
+// that into function calls. Preprocessor seems easier, given we're
+// not manipulating this list in any way.
+#define VALID_VEC_TYPES(T)                                                               \
+  T, std::vector<T>, ParArray0D<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,         \
+      ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,         \
+      HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,    \
+      HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,                 \
+      Kokkos::View<T **>
+
 #ifdef ENABLE_HDF5
 
 template <typename T>
@@ -49,12 +62,7 @@ void Params::WriteToHDF5AllParamsOfMultipleTypes(const std::string &prefix,
 template <typename T>
 void Params::WriteToHDF5AllParamsOfTypeOrVec(const std::string &prefix,
                                              const HDF5::H5G &group) const {
-  WriteToHDF5AllParamsOfMultipleTypes<
-      T, std::vector<T>, ParArray0D<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,
-      ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,
-      HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,
-      HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,
-      Kokkos::View<T **>>(prefix, group);
+  WriteToHDF5AllParamsOfMultipleTypes<VALID_VEC_TYPES(T)>(prefix, group);
 }
 
 template <typename T>
@@ -82,12 +90,7 @@ void Params::ReadFromHDF5AllParamsOfMultipleTypes(const std::string &prefix,
 template <typename T>
 void Params::ReadFromHDF5AllParamsOfTypeOrVec(const std::string &prefix,
                                               const HDF5::H5G &group) {
-  ReadFromHDF5AllParamsOfMultipleTypes<
-      T, std::vector<T>, ParArray0D<T>, ParArray1D<T>, ParArray2D<T>, ParArray3D<T>,
-      ParArray4D<T>, ParArray5D<T>, ParArray6D<T>, ParArray7D<T>, ParArray8D<T>,
-      HostArray0D<T>, HostArray1D<T>, HostArray2D<T>, HostArray3D<T>, HostArray4D<T>,
-      HostArray5D<T>, HostArray6D<T>, HostArray7D<T>, Kokkos::View<T *>,
-      Kokkos::View<T **>>(prefix, group);
+  ReadFromHDF5AllParamsOfMultipleTypes<VALID_VEC_TYPES(T)>(prefix, group);
 }
 
 void Params::WriteAllToHDF5(const std::string &prefix, const HDF5::H5G &group) const {

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -127,38 +127,26 @@ class Params {
 #ifdef ENABLE_HDF5
 
  private:
-  // will write all params with type T to the given HDF5 group as an attribute
+  // these can go in implementation file, since the only relevant
+  // instantiations are in that same implementation file.
   template <typename T>
   void WriteToHDF5AllParamsOfType(const std::string &prefix,
-                                  const HDF5::H5G &group) const {
-    for (const auto &p : myParams_) {
-      const auto &key = p.first;
-      const auto type = myTypes_.at(key);
-      if (type == std::type_index(typeid(T))) {
-        auto typed_ptr = dynamic_cast<Params::object_t<T> *>((p.second).get());
-        HDF5::HDF5WriteAttribute(prefix + "/" + key, *typed_ptr->pValue, group);
-      }
-    }
-  }
+                                  const HDF5::H5G &group) const;
+
+  template <typename... Ts>
+  void WriteToHDF5AllParamsOfMultipleTypes(const std::string &prefix,
+                                           const HDF5::H5G &group) const;
 
   template <typename T>
   void WriteToHDF5AllParamsOfTypeOrVec(const std::string &prefix,
-                                       const HDF5::H5G &group) const {
-    WriteToHDF5AllParamsOfType<T>(prefix, group);
-    WriteToHDF5AllParamsOfType<std::vector<T>>(prefix, group);
-  }
+                                       const HDF5::H5G &group) const;
+
+  template <typename... Ts>
+  void WriteToHDF5AllParamsOfMultipleTypesOrVec(const std::string &prefix,
+                                                const HDF5::H5G &group) const;
 
  public:
-  void WriteAllToHDF5(const std::string &prefix, const HDF5::H5G &group) const {
-    WriteToHDF5AllParamsOfTypeOrVec<bool>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<int32_t>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<int64_t>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<uint32_t>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<uint64_t>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<float>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<double>(prefix, group);
-    WriteToHDF5AllParamsOfTypeOrVec<std::string>(prefix, group);
-  }
+  void WriteAllToHDF5(const std::string &prefix, const HDF5::H5G &group) const;
 
 #endif // ifdef ENABLE_HDF5
 

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -106,6 +106,11 @@ class StateDescriptor {
   CreateResolvedStateDescriptor(Packages_t &packages);
 
   template <typename T>
+  void AddParam(const std::string &key, T value, Params::Mutability mutability) {
+    params_.Add<T>(key, value, mutability);
+  }
+
+  template <typename T>
   void AddParam(const std::string &key, T value, bool is_mutable = false) {
     params_.Add<T>(key, value, is_mutable);
   }

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -187,12 +187,12 @@ void Variable<T>::AllocateFluxesAndCoarse(std::weak_ptr<MeshBlock> wpmb) {
 
 template <typename T>
 std::int64_t Variable<T>::Deallocate() {
+  std::int64_t mem_size = 0;
 #ifdef ENABLE_SPARSE
   if (!IsAllocated()) {
     return 0;
   }
 
-  std::int64_t mem_size = 0;
   mem_size += data.size() * sizeof(T);
   data.Reset();
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -737,6 +737,11 @@ template void PHDF5Output::WriteOutputFileImpl<true>(Mesh *, ParameterInput *, S
 // Utility functions implemented
 namespace HDF5 {
 // template specializations for std::string
+void HDF5WriteAttribute(const std::string &name, const std::string &value,
+                        hid_t location) {
+  HDF5WriteAttribute(name, value.size(), value.c_str(), location);
+}
+
 template <>
 void HDF5WriteAttribute(const std::string &name, const std::vector<std::string> &values,
                         hid_t location) {

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -272,6 +272,11 @@ std::vector<T> HDF5ReadAttributeVec(hid_t location, const std::string &name) {
 template <>
 std::vector<std::string> HDF5ReadAttributeVec(hid_t location, const std::string &name);
 
+template <>
+std::vector<bool> HDF5ReadAttributeVec(hid_t location, const std::string &name);
+
+void HDF5ReadAttribute(hid_t location, const std::string &name, std::string &val);
+
 template <typename T, REQUIRES(implements<scalar(T)>::value)>
 void HDF5ReadAttribute(hid_t location, const std::string &name, T &val) {
   auto vec = HDF5ReadAttributeVec<T>(location, name);

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -283,7 +283,6 @@ void HDF5ReadAttribute(hid_t location, const std::string &name, T &view) {
   static_assert(std::is_same<typename T::array_layout, Kokkos::LayoutLeft>::value ||
                     std::is_same<typename T::array_layout, Kokkos::LayoutRight>::value,
                 "Currently can only read from contiguous views");
-  
   // attribute info
   H5A attr;
   auto [rank, dim, size] = HDF5GetAttributeInfo(location, name, attr);
@@ -292,12 +291,12 @@ void HDF5ReadAttribute(hid_t location, const std::string &name, T &view) {
   int view_rank = static_cast<size_t>(T::rank);
   PARTHENON_REQUIRE(rank == view_rank, "input and output view are same rank");
 
-  // resize view
+  // Resize view.
   typename T::array_layout layout;
   for (int d = 0; d < rank; ++d) {
     layout.dimension[d] = dim[d];
   }
-  Kokkos::resize(view, layout);
+  view = T(view.label(), layout);
 
   // pull out data pointer
   auto *pdata = view.data();
@@ -322,8 +321,10 @@ void HDF5ReadAttribute(hid_t location, const std::string &name, T &view) {
 }
 
 template <typename D, typename S>
-void HDF5ReadAttribute(hid_t location, const std::string &name, const ParArrayGeneric<D, S> &view) {
-  return HDF5ReadAttribute(location, name, view.KokkosView());
+void HDF5ReadAttribute(hid_t location, const std::string &name,
+                       ParArrayGeneric<D, S> &pararray) {
+  D view = pararray.KokkosView();
+  return HDF5ReadAttribute(location, name, view);
 }
 
 template <typename T>

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -329,6 +329,7 @@ template <typename D, typename S>
 void HDF5ReadAttribute(hid_t location, const std::string &name,
                        ParArrayGeneric<D, S> &pararray) {
   // forces compiler to pass by non-const reference into the next function
+  // Note this loses information stored in the `State` of the pararray.
   D &view = pararray.KokkosView();
   HDF5ReadAttribute(location, name, view);
 }

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -323,8 +323,9 @@ void HDF5ReadAttribute(hid_t location, const std::string &name, T &view) {
 template <typename D, typename S>
 void HDF5ReadAttribute(hid_t location, const std::string &name,
                        ParArrayGeneric<D, S> &pararray) {
-  D view = pararray.KokkosView();
-  return HDF5ReadAttribute(location, name, view);
+  // forces compiler to pass by non-const reference into the next function
+  D &view = pararray.KokkosView();
+  HDF5ReadAttribute(location, name, view);
 }
 
 template <typename T>

--- a/src/outputs/restart.cpp
+++ b/src/outputs/restart.cpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 #include "globals.hpp"
+#include "interface/params.hpp"
 #include "mesh/mesh.hpp"
 #include "mesh/meshblock.hpp"
 #include "outputs/outputs.hpp"
@@ -47,6 +48,7 @@ RestartReader::RestartReader(const char *filename) : filename_(filename) {
 #else  // HDF5 enabled
   // Open the HDF file in read only mode
   fh_ = H5F::FromHIDCheck(H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT));
+  params_group_ = H5G::FromHIDCheck(H5Oopen(fh_, "Params", H5P_DEFAULT));
 
   hasGhost = GetAttr<int>("Info", "IncludesGhost");
 #endif // ENABLE_HDF5
@@ -136,6 +138,12 @@ std::size_t RestartReader::GetSwarmCounts(const std::string &swarm,
   // Compute total count rank
   std::size_t total_count_on_rank = std::accumulate(counts.begin(), counts.end(), 0);
   return total_count_on_rank;
+#endif // ENABLE_HDF5
+}
+
+void RestartReader::ReadParams(const std::string &name, Params &p) {
+#ifdef ENABLE_HDF5
+  p.ReadFromRestart(name, params_group_);
 #endif // ENABLE_HDF5
 }
 

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -52,6 +52,7 @@ using H5S = UnusedPlaceholder;
 namespace parthenon {
 
 class Mesh;
+class Param;
 
 class RestartReader {
  public:
@@ -320,6 +321,8 @@ class RestartReader {
                              std::vector<std::size_t> &counts,
                              std::vector<std::size_t> &offsets);
 
+  void ReadParams(const std::string &name, Params &p);
+
   // closes out the restart file
   // perhaps belongs in a destructor?
   void Close();
@@ -334,6 +337,7 @@ class RestartReader {
   // Currently all restarts are HDF5 files
   // when that changes, this will be revisited
   H5F fh_;
+  H5G params_group_;
 #endif // ENABLE_HDF5
 };
 

--- a/src/parthenon_array_generic.hpp
+++ b/src/parthenon_array_generic.hpp
@@ -210,6 +210,8 @@ class ParArrayGeneric : public State {
 
   KOKKOS_INLINE_FUNCTION auto &KokkosView() { return data_; }
 
+  KOKKOS_INLINE_FUNCTION const auto &KokkosView() const { return data_; }
+
   KOKKOS_INLINE_FUNCTION auto size() const { return data_.size(); }
 
   // a function to get the total size of the array

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -396,6 +396,18 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     ReadSwarmVars_<int>(swarm, rm.block_list, count_on_rank, offsets[0]);
     ReadSwarmVars_<Real>(swarm, rm.block_list, count_on_rank, offsets[0]);
   }
+
+  // Params
+  // ============================================================
+  // JMM: Note that only the Params stored on the mesh are read and
+  // written. The downstream user must update mutable params per
+  // meshblock by hand if this is desired.  I don't know how to
+  // meaningfully do this on a per-meshblock basis without a
+  // significantly more complicated infrastructure.
+  for (auto &[name, pkg] : rm.packages.AllPackages()) {
+    auto &params = pkg->AllParams();
+    resfile.ReadParams(name, params);
+  }
 #endif // ifdef ENABLE_HDF5
 }
 

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -399,11 +399,8 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
 
   // Params
   // ============================================================
-  // JMM: Note that only the Params stored on the mesh are read and
-  // written. The downstream user must update mutable params per
-  // meshblock by hand if this is desired.  I don't know how to
-  // meaningfully do this on a per-meshblock basis without a
-  // significantly more complicated infrastructure.
+  // packages and params are owned by shared pointer, so reading from
+  // the mesh updates on all meshblocks.
   for (auto &[name, pkg] : rm.packages.AllPackages()) {
     auto &params = pkg->AllParams();
     resfile.ReadParams(name, params);

--- a/src/utils/concepts_lite.hpp
+++ b/src/utils/concepts_lite.hpp
@@ -193,6 +193,11 @@ struct integral_or_enum {
       -> void_t<ENABLEIF(std::is_integral<T>::value || std::is_enum<T>::value)>;
 };
 
+struct scalar {
+  template <class T>
+  auto requires_(T) -> void_t<ENABLEIF(std::is_scalar<T>::value)>;
+};
+
 template <typename>
 struct is_pair : std::false_type {};
 

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -141,12 +141,14 @@ TEST_CASE("when hasKey is called", "[hasKey]") {
 TEST_CASE("A set of params can be dumped to file", "[params][output]") {
   GIVEN("A params object with a few kinds of objects") {
     Params params;
+    const auto restart = Params::Mutability::Restart;
+    const auto only_mutable = Params::Mutability::Mutable;
 
     Real scalar = 3.0;
-    params.Add("scalar", scalar);
+    params.Add("scalar", scalar, restart);
 
     std::vector<int> vector = {0, 1, 2};
-    params.Add("vector", vector);
+    params.Add("vector", vector, only_mutable);
 
     parthenon::ParArray2D<Real> arr2d("myarr", 3, 2);
     auto arr2d_h = Kokkos::create_mirror_view(arr2d);
@@ -164,7 +166,7 @@ TEST_CASE("A set of params can be dumped to file", "[params][output]") {
         hostarr(i, j) = 2 * i + j + 1;
       }
     }
-    params.Add("hostarr2d", hostarr);
+    params.Add("hostarr2d", hostarr, restart);
 
     THEN("We can output to hdf5") {
       const std::string filename = "params_test.h5";
@@ -206,6 +208,48 @@ TEST_CASE("A set of params can be dumped to file", "[params][output]") {
             },
             nwrong);
         REQUIRE(nwrong == 0);
+      }
+
+      AND_THEN("We can restart a params object from the HDF5 file") {
+        Params rparams;
+
+        // init the params object to restart into
+        Real test_scalar = 0.0;
+        rparams.Add("scalar", test_scalar, restart);
+
+        std::vector<int> test_vector;
+        rparams.Add("vector", test_vector, only_mutable);
+
+        parthenon::ParArray2D<Real> test_arr2d("myarr", 1, 1);
+        rparams.Add("arr2d", test_arr2d);
+
+        parthenon::HostArray2D<Real> test_hostarr("hostarr2d", 1, 1);
+        rparams.Add("hostarr2d", test_hostarr, restart);
+
+        H5F file =
+            H5F::FromHIDCheck(H5Fopen(filename.c_str(), H5F_ACC_RDONLY, H5P_DEFAULT));
+        const H5G obj = H5G::FromHIDCheck(H5Oopen(file, groupname.c_str(), H5P_DEFAULT));
+        rparams.ReadFromRestart(prefix, obj);
+
+        AND_THEN("The values for the restartable params are updated to match the file") {
+          auto test_scalar = rparams.Get<Real>("scalar");
+          REQUIRE(std::abs(test_scalar - scalar) <= 1e-10);
+          auto test_hostarr = params.Get<parthenon::HostArray2D<Real>>("hostarr2d");
+          REQUIRE(test_hostarr.extent_int(0) == hostarr.extent_int(0));
+          REQUIRE(test_hostarr.extent_int(1) == hostarr.extent_int(1));
+          for (int i = 0; i < hostarr.extent_int(0); ++i) {
+            for (int j = 0; j < hostarr.extent_int(1); ++j) {
+              REQUIRE(test_hostarr(i, j) == hostarr(i, j));
+            }
+          }
+        }
+        AND_THEN("The values for non-restartable params have not been updated") {
+          auto test_vector = rparams.Get<std::vector<int>>("vector");
+          REQUIRE(test_vector.size() == 0);
+          auto test_arr2d = rparams.Get<parthenon::ParArray2D<Real>>("arr2d");
+          REQUIRE(test_arr2d.extent_int(0) == 1);
+          REQUIRE(test_arr2d.extent_int(1) == 1);
+        }
       }
     }
   }

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -19,6 +19,7 @@
 
 #include <catch2/catch.hpp>
 
+#include "config.hpp"
 #include "interface/params.hpp"
 
 using parthenon::Params;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

We've discussed previously that we now use `Params` for many purposes, including storing mesh-level data. In this PR, I implement scaffolding for this use case. In particular, I add:
- The ability to output `Kokkos::View` and `ParArray*D` params to disk
- The ability to read a mutable param from a restart file to set the value. In particular, a param can now be marked `Immutable`, `Mutable`, or `Restart`. Here `Mutable` is as it was before (though now this is an enum instead of a bool.) `Restart` is a superset of `Mutable`. A `Restart` param is mutable, but also re-read from the restart file upon restart. It is first set to whatever the package initialization provides, then overwritten.
- Unit tests for the new Param machinery.

This new machinery enables some important use-cases. For Phoebus, it lets us stash spacetime information in `Params`, which is useful in some cases. I imagine that for things like turbulent forcing, or derived integral quantities, the Athena-PK team may also be interested.

## Limitations, technical questions

- I needed to enumerate the types that can be written to/read from file. So it's a limited list.
- Because now more params are output, some regression tests are now failing, as the gold file contains less information. I can modify the tests to be less strict (I believe in large part the unit tests now cover the code paths they were checking), or I can create a new gold file. I don't know which is better. I'd like input. **Please let me know which option you would prefer.**
- Outputting `Params` or reading `Params` that differ on different MPI ranks is undefined behavior. This was already true, but I now document it. I think permitting different `Params` on different ranks would be a pretty big lift, and I recommend against. At least for now.
- On a related note, since params are treated as attributes in the HDF5 file, they must be written and read collectively and identically.

@bprather I know I've talked to you about this design. Please take a look at this and let me know if it meets your constraints. If I recall, there was some use-case you had, where you did *not* want the infrastructure to modify your mutable params, which is why I added the three mutability levels.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
