### PR TITLE
add precommfillderived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 Date: 2023-05-26
 
 ### Added (new features/APIs/variables/...)
+- [[PR 889]](https://github.com/parthenon-hpc-lab/parthenon/pull/889) Add PreCommFillDerived
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 - [[PR 830]](https://github.com/parthenon-hpc-lab/parthenon/pull/830) Add particle output
 - [[PR 840]](https://github.com/parthenon-hpc-lab/parthenon/pull/840) Generalized integrators infrastructure in a backwards compatible way

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 889]](https://github.com/parthenon-hpc-lab/parthenon/pull/889) Add PreCommFillDerived
 - [[PR 872]](https://github.com/parthenon-hpc-lab/parthenon/pull/872) Boundary communication for non-cell centered fields
 - [[PR 877]](https://github.com/parthenon-hpc-lab/parthenon/pull/877) Add flat sparse packs
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
@@ -20,7 +21,6 @@
 Date: 2023-05-26
 
 ### Added (new features/APIs/variables/...)
-- [[PR 889]](https://github.com/parthenon-hpc-lab/parthenon/pull/889) Add PreCommFillDerived
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 - [[PR 830]](https://github.com/parthenon-hpc-lab/parthenon/pull/830) Add particle output
 - [[PR 840]](https://github.com/parthenon-hpc-lab/parthenon/pull/840) Generalized integrators infrastructure in a backwards compatible way

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -325,6 +325,12 @@ class StateDescriptor {
 
   bool FlagsPresent(std::vector<MetadataFlag> const &flags, bool matchAny = false);
 
+  void PreCommFillDerived(MeshBlockData<Real> *rc) const {
+    if (PreCommFillDerivedBlock != nullptr) PreCommFillDerivedBlock(rc);
+  }
+  void PreCommFillDerived(MeshData<Real> *rc) const {
+    if (PreCommFillDerivedMesh != nullptr) PreCommFillDerivedMesh(rc);
+  }
   void PreFillDerived(MeshBlockData<Real> *rc) const {
     if (PreFillDerivedBlock != nullptr) PreFillDerivedBlock(rc);
   }
@@ -375,6 +381,8 @@ class StateDescriptor {
 
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
 
+  std::function<void(MeshBlockData<Real> *rc)> PreCommFillDerivedBlock = nullptr;
+  std::function<void(MeshData<Real> *rc)> PreCommFillDerivedMesh = nullptr;
   std::function<void(MeshBlockData<Real> *rc)> PreFillDerivedBlock = nullptr;
   std::function<void(MeshData<Real> *rc)> PreFillDerivedMesh = nullptr;
   std::function<void(MeshBlockData<Real> *rc)> PostFillDerivedBlock = nullptr;

--- a/src/interface/update.hpp
+++ b/src/interface/update.hpp
@@ -283,6 +283,17 @@ TaskStatus EstimateTimestep(T *rc) {
 }
 
 template <typename T>
+TaskStatus PreCommFillDerived(T *rc) {
+  Kokkos::Profiling::pushRegion("Task_PreCommFillDerived");
+  auto pm = rc->GetParentPointer();
+  for (const auto &pkg : pm->packages.AllPackages()) {
+    pkg.second->PreCommFillDerived(rc);
+  }
+  Kokkos::Profiling::popRegion();
+  return TaskStatus::complete;
+}
+
+template <typename T>
 TaskStatus FillDerived(T *rc) {
   Kokkos::Profiling::pushRegion("Task_FillDerived");
   auto pm = rc->GetParentPointer();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1071,6 +1071,16 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
                     [](auto &sp_block) { sp_block->SetAllVariablesToInitialized(); });
     }
 
+    // Pre comm fill derrived
+    for (int i = 0; i < nmb; ++i) {
+      auto &mbd = block_list[i]->meshblock_data.Get();
+      Update::PreCommFillDerived(mbd.get());
+    }
+    for (int i = 0; num_partitions; ++i) {
+      auto &md = mesh_data.GetOrAdd("base", i);
+      Update::PreCommFillDerived(md.get());
+    }
+
     // Build densely populated communication tags
     tag_map.clear();
     for (int i = 0; i < num_partitions; i++) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1076,7 +1076,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
       auto &mbd = block_list[i]->meshblock_data.Get();
       Update::PreCommFillDerived(mbd.get());
     }
-    for (int i = 0; num_partitions; ++i) {
+    for (int i = 0; i < num_partitions; ++i) {
       auto &md = mesh_data.GetOrAdd("base", i);
       Update::PreCommFillDerived(md.get());
     }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1071,7 +1071,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
                     [](auto &sp_block) { sp_block->SetAllVariablesToInitialized(); });
     }
 
-    // Pre comm fill derrived
+    // Pre comm fill derived
     for (int i = 0; i < nmb; ++i) {
       auto &mbd = block_list[i]->meshblock_data.Get();
       Update::PreCommFillDerived(mbd.get());


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a feature used by riot, that we'd like to bring into the parthenon develop branch, as we push towards bringing riot onto "standard" parthenon.

The basic idea here is that if you want to communicate derived quantities in ghost zones, for example pressure, you need to compute them first. You can do so in the precomm fill derived, which is a separate task the user can call if desired. This may also be interesting for the AthenaPK folks as a way to do pressure or other pimitive-based prolong/restrict if desired.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
