### PR TITLE
Fix Bugs in Sparse Communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 890]](https://github.com/parthenon-hpc-lab/parthenon/pull/890) Fix bugs in sparse communication and prolongation
 
 ### Infrastructure (changes irrelevant to downstream codes)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 18 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 19 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=193f205b5ebd8dc193dabc7f8e2d3f12bf4f9c34f84312aaaa201f8e19a07342d61f7f07d0119e6de1f2af00f067c20cb4d71edad076b583c102bf4dddb2ade2"
+  "SHA512=e1d1a06b9cf9b761d42d0b6b241056ac75658db90138b6b867b1ca7ead4308af4f980285af092b40aee1dbbfb68b4e8cb15efcc9b83d7930c18bf992ae95c729"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,8 +248,6 @@ if (NOT TARGET Kokkos::kokkos)
   endif()
 endif()
 
-message(STATUS "CUDA: ${Kokkos_ENABLE_CUDA}")
-
 # After we have imported Kokkos we can now report/check our config as Kokkos_ENABLE_XXX
 # is also availalbe when imported.
 if (Kokkos_ENABLE_SYCL)

--- a/src/bvals/boundary_conditions.cpp
+++ b/src/bvals/boundary_conditions.cpp
@@ -51,21 +51,20 @@ TaskStatus ApplyBoundaryConditionsOnCoarseOrFine(std::shared_ptr<MeshBlockData<R
   return TaskStatus::complete;
 }
 
-namespace BoundaryFunction {
-
 TaskStatus ApplyBoundaryConditionsMD(std::shared_ptr<MeshData<Real>> &pmd) {
   for (int b = 0; b < pmd->NumBlocks(); ++b)
     ApplyBoundaryConditions(pmd->GetBlockData(b));
   return TaskStatus::complete;
 }
 
-inline TaskStatus
-ApplyBoundaryConditionsOnCoarseOrFineMD(std::shared_ptr<MeshData<Real>> &pmd,
-                                        bool coarse) {
+TaskStatus ApplyBoundaryConditionsOnCoarseOrFineMD(std::shared_ptr<MeshData<Real>> &pmd,
+                                                   bool coarse) {
   for (int b = 0; b < pmd->NumBlocks(); ++b)
     ApplyBoundaryConditionsOnCoarseOrFine(pmd->GetBlockData(b), coarse);
   return TaskStatus::complete;
 }
+
+namespace BoundaryFunction {
 
 void OutflowInnerX1(std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse) {
   GenericBC<X1DIR, BCSide::Inner, BCType::Outflow, variable_names::any>(rc, coarse);

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -48,6 +48,7 @@ struct BndInfo {
 
   CoordinateDirection dir;
   bool allocated = true;
+  bool buf_allocated = true;
   RefinementOp_t refinement_op = RefinementOp_t::None;
   Coordinates_t coords, coarse_coords; // coords
 

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -252,16 +252,6 @@ TaskStatus SetBounds(std::shared_ptr<MeshData<Real>> &md) {
     auto pmb = md->GetBlockData(0)->GetBlockPointer();
     StateDescriptor *resolved_packages = pmb->resolved_packages.get();
     refinement::Restrict(resolved_packages, cache, pmb->cellbounds, pmb->c_cellbounds);
-
-    // Apply coarse boundary conditions
-    for (int block = 0; block < md->NumBlocks(); ++block) {
-      ApplyBoundaryConditionsOnCoarseOrFine(md->GetBlockData(block), true);
-    }
-
-    // Prolongate from coarse buffer
-    refinement::Prolongate(resolved_packages, cache, pmb->cellbounds, pmb->c_cellbounds);
-    refinement::ProlongateInternal(resolved_packages, cache, pmb->cellbounds,
-                                   pmb->c_cellbounds);
   }
   Kokkos::Profiling::popRegion(); // Task_SetInternalBoundaries
   return TaskStatus::complete;
@@ -310,6 +300,16 @@ TaskStatus ApplyCoarseBoundaryConditions(std::shared_ptr<MeshData<Real>> &md) {
   return stat;
 }
 
+TaskStatus ApplyFineBoundaryConditions(std::shared_ptr<MeshData<Real>> &md) {
+  if (!md->GetMeshPointer()->multilevel) return TaskStatus::complete;
+  TaskStatus stat = TaskStatus::complete;
+  for (int block = 0; block < md->NumBlocks(); ++block) {
+    auto bstat = ApplyBoundaryConditionsOnCoarseOrFine(md->GetBlockData(block), false);
+    // if (bstat != TaskStatus::complete) stat = bstat;
+  }
+  return stat;
+}
+
 // Adds all relevant boundary communication to a single task list
 TaskID AddBoundaryExchangeTasks(TaskID dependency, TaskList &tl,
                                 std::shared_ptr<MeshData<Real>> &md, bool multilevel) {
@@ -317,31 +317,21 @@ TaskID AddBoundaryExchangeTasks(TaskID dependency, TaskList &tl,
   const auto local = BoundaryType::local;
   const auto nonlocal = BoundaryType::nonlocal;
 
-  // auto send = tl.AddTask(dependency, SendBoundBufs<nonlocal>, md);
-  // auto send_local = tl.AddTask(dependency, SendBoundBufs<local>, md);
+  auto send = tl.AddTask(dependency, SendBoundBufs<nonlocal>, md);
+  auto send_local = tl.AddTask(dependency, SendBoundBufs<local>, md);
 
-  // auto recv_local = tl.AddTask(dependency, ReceiveBoundBufs<local>, md);
-  // auto set_local = tl.AddTask(recv_local, SetBounds<local>, md);
+  auto recv_local = tl.AddTask(dependency, ReceiveBoundBufs<local>, md);
+  auto set_local = tl.AddTask(recv_local, SetBounds<local>, md);
 
-  // auto recv = tl.AddTask(dependency, ReceiveBoundBufs<nonlocal>, md);
-  // auto set = tl.AddTask(recv, SetBounds<nonlocal>, md);
+  auto recv = tl.AddTask(dependency, ReceiveBoundBufs<nonlocal>, md);
+  auto set = tl.AddTask(recv, SetBounds<nonlocal>, md);
+  
+  auto cbound = tl.AddTask(set | set_local, ApplyCoarseBoundaryConditions, md);
 
-  // auto cbound = tl.AddTask(set, ApplyCoarseBoundaryConditions, md);
+  auto pro_local = tl.AddTask(cbound, ProlongateBounds<local>, md);
+  auto pro = tl.AddTask(cbound, ProlongateBounds<nonlocal>, md);
 
-  // auto pro_local = tl.AddTask(cbound | set_local | set, ProlongateBounds<local>, md);
-  // auto pro = tl.AddTask(cbound | set_local | set, ProlongateBounds<nonlocal>, md);
-
-  // auto out = (pro_local | pro);
-
-  // TODO(LFR): Splitting up the boundary tasks while doing prolongation in one
-  //            breaks things, which I haven't completely figured out yet. To
-  //            move to the commented out code above, this needs to be fixed and
-  //            the prolongation and physical boundary conditions need to be removed
-  //            from the end of SetBounds
-  auto send = tl.AddTask(dependency, SendBoundBufs<any>, md);
-  auto recv = tl.AddTask(dependency, ReceiveBoundBufs<any>, md);
-  auto set = tl.AddTask(recv, SetBounds<any>, md);
-
-  return set;
+  auto out = (pro_local | pro);
+  return out;  
 }
 } // namespace parthenon

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -302,12 +302,11 @@ TaskStatus ApplyCoarseBoundaryConditions(std::shared_ptr<MeshData<Real>> &md) {
 
 TaskStatus ApplyFineBoundaryConditions(std::shared_ptr<MeshData<Real>> &md) {
   if (!md->GetMeshPointer()->multilevel) return TaskStatus::complete;
-  TaskStatus stat = TaskStatus::complete;
   for (int block = 0; block < md->NumBlocks(); ++block) {
-    auto bstat = ApplyBoundaryConditionsOnCoarseOrFine(md->GetBlockData(block), false);
-    // if (bstat != TaskStatus::complete) stat = bstat;
+    ApplyBoundaryConditionsOnCoarseOrFine(md->GetBlockData(block), false);
   }
-  return stat;
+  // ApplyBoundaryConditions is guaranteed to return complete, so this is safe
+  return TaskStatus::complete;
 }
 
 // Adds all relevant boundary communication to a single task list

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -322,6 +322,6 @@ TaskID AddBoundaryExchangeTasks(TaskID dependency, TaskList &tl,
   auto pro = tl.AddTask(cbound, ProlongateBounds<any>, md);
   auto fbound = tl.AddTask(pro, ApplyFineBoundaryConditions, md);
 
-  return fbound;  
+  return fbound;
 }
 } // namespace parthenon

--- a/src/bvals/comms/bvals_in_one.hpp
+++ b/src/bvals/comms/bvals_in_one.hpp
@@ -65,8 +65,6 @@ TaskStatus ProlongateBounds(std::shared_ptr<MeshData<Real>> &md);
 inline TaskStatus ProlongateBoundaries(std::shared_ptr<MeshData<Real>> &md) {
   return ProlongateBounds<BoundaryType::any>(md);
 }
-TaskStatus ApplyCoarseBoundaryConditions(std::shared_ptr<MeshData<Real>> &md);
-TaskStatus ApplyFineBoundaryConditions(std::shared_ptr<MeshData<Real>> &md);
 
 TaskStatus StartReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
 TaskStatus LoadAndSendFluxCorrections(std::shared_ptr<MeshData<Real>> &md);

--- a/src/bvals/comms/bvals_in_one.hpp
+++ b/src/bvals/comms/bvals_in_one.hpp
@@ -60,6 +60,14 @@ inline TaskStatus SetBoundaries(std::shared_ptr<MeshData<Real>> &md) {
   return SetBounds<BoundaryType::any>(md);
 }
 
+template <BoundaryType bound_type>
+TaskStatus ProlongateBounds(std::shared_ptr<MeshData<Real>> &md);
+inline TaskStatus ProlongateBoundaries(std::shared_ptr<MeshData<Real>> &md) {
+  return ProlongateBounds<BoundaryType::any>(md);
+}
+TaskStatus ApplyCoarseBoundaryConditions(std::shared_ptr<MeshData<Real>> &md);
+TaskStatus ApplyFineBoundaryConditions(std::shared_ptr<MeshData<Real>> &md);
+
 TaskStatus StartReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
 TaskStatus LoadAndSendFluxCorrections(std::shared_ptr<MeshData<Real>> &md);
 TaskStatus ReceiveFluxCorrections(std::shared_ptr<MeshData<Real>> &md);

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -141,7 +141,7 @@ inline auto CheckSendBufferCacheForRebuild(std::shared_ptr<MeshData<Real>> md) {
     }
 
     if (ibuf < cache.bnd_info_h.size()) {
-      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true; 
+      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true;
       rebuild = rebuild || !UsingSameResource(cache.bnd_info_h(ibuf).buf, buf.buffer());
     } else {
       rebuild = true;
@@ -165,9 +165,9 @@ inline auto CheckReceiveBufferCacheForRebuild(std::shared_ptr<MeshData<Real>> md
     const std::size_t ibuf = cache.idx_vec[nbound];
     auto &buf = *cache.buf_vec[ibuf];
     if (ibuf < cache.bnd_info_h.size()) {
-      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true; 
+      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true;
       rebuild = rebuild || !UsingSameResource(cache.bnd_info_h(ibuf).buf, buf.buffer());
-      
+
       if ((buf.GetState() == BufferState::received) &&
           !cache.bnd_info_h(ibuf).buf_allocated) {
         rebuild = true;

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -141,6 +141,7 @@ inline auto CheckSendBufferCacheForRebuild(std::shared_ptr<MeshData<Real>> md) {
     }
 
     if (ibuf < cache.bnd_info_h.size()) {
+      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true; 
       rebuild = rebuild || !UsingSameResource(cache.bnd_info_h(ibuf).buf, buf.buffer());
     } else {
       rebuild = true;
@@ -164,13 +165,16 @@ inline auto CheckReceiveBufferCacheForRebuild(std::shared_ptr<MeshData<Real>> md
     const std::size_t ibuf = cache.idx_vec[nbound];
     auto &buf = *cache.buf_vec[ibuf];
     if (ibuf < cache.bnd_info_h.size()) {
+      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true; 
       rebuild = rebuild || !UsingSameResource(cache.bnd_info_h(ibuf).buf, buf.buffer());
+      
       if ((buf.GetState() == BufferState::received) &&
-          !cache.bnd_info_h(ibuf).allocated) {
+          !cache.bnd_info_h(ibuf).buf_allocated) {
         rebuild = true;
       }
+
       if ((buf.GetState() == BufferState::received_null) &&
-          cache.bnd_info_h(ibuf).allocated) {
+          cache.bnd_info_h(ibuf).buf_allocated) {
         rebuild = true;
       }
     } else {

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -1144,7 +1144,7 @@ void Mesh::FinishRecvSameLevel(MeshBlock *pmb, BufArray1D<Real> &recvbuf) {
       ParArray4D<Real> var_cc_ = pvar_cc->data.Get<4>();
       BufferUtility::UnpackData(recvbuf, var_cc_, 0, nu, ib.s, ib.e, jb.s, jb.e, kb.s,
                                 kb.e, p, pmb);
-      pvar_cc->dealloc_count = (int)(alloc_subview_h(i) - 1.0);
+      pvar_cc->dealloc_count = static_cast<int>(alloc_subview_h(i) - 1.0);
     } else {
       // increment offset
       p += (nu + 1) * (ib.e + 1 - ib.s) * (jb.e + 1 - jb.s) * (kb.e + 1 - kb.s);

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -868,7 +868,7 @@ void Mesh::PrepareSendSameLevel(MeshBlock *pmb, BufArray1D<Real> &sendbuf) {
   // container with std::reference_wrapper; could use auto var_cc_r = var_cc.get())
   for (int i = 0; i < pmb->vars_cc_.size(); ++i) {
     auto &pvar_cc = pmb->vars_cc_[i];
-    alloc_subview_h(i) = pvar_cc->IsAllocated() ? 1.0 : 0.0;
+    alloc_subview_h(i) = pvar_cc->IsAllocated() ? 1.0 + pvar_cc->dealloc_count : 0.0;
     int nu = pvar_cc->GetDim(4) - 1;
     if (pvar_cc->IsAllocated()) {
       ParArray4D<Real> var_cc = pvar_cc->data.Get<4>();
@@ -1131,7 +1131,7 @@ void Mesh::FinishRecvSameLevel(MeshBlock *pmb, BufArray1D<Real> &recvbuf) {
     auto &pvar_cc = pmb->vars_cc_[i];
     int nu = pvar_cc->GetDim(4) - 1;
 
-    if (alloc_subview_h(i) == 1.0) {
+    if (alloc_subview_h(i) > 0.0) {
       // allocated on sending block
       if (!pvar_cc->IsAllocated()) {
         // need to allocate locally
@@ -1144,6 +1144,7 @@ void Mesh::FinishRecvSameLevel(MeshBlock *pmb, BufArray1D<Real> &recvbuf) {
       ParArray4D<Real> var_cc_ = pvar_cc->data.Get<4>();
       BufferUtility::UnpackData(recvbuf, var_cc_, 0, nu, ib.s, ib.e, jb.s, jb.e, kb.s,
                                 kb.e, p, pmb);
+      pvar_cc->dealloc_count = (int)(alloc_subview_h(i) - 1.0);
     } else {
       // increment offset
       p += (nu + 1) * (ib.e + 1 - ib.s) * (jb.e + 1 - jb.s) * (kb.e + 1 - kb.s);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1087,12 +1087,17 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
     // send FillGhost variables
     bool can_delete;
+    int test_iters = 0;
     do {
       can_delete = true;
       for (auto &[k, comm] : boundary_comm_map) {
         can_delete = comm.IsSafeToDelete() && can_delete;
       }
-    } while (!can_delete);
+      test_iters++;
+    } while (!can_delete && test_iters < 1e10);
+    if (test_iters >= 1e10)
+      PARTHENON_FAIL(
+          "Too many iterations waiting to delete boundary communication buffers.");
 
     boundary_comm_map.clear();
     boundary_comm_flxcor_map.clear();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1097,7 +1097,6 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     boundary_comm_map.clear();
     boundary_comm_flxcor_map.clear();
 
-    MPI_Barrier(MPI_COMM_WORLD);
     for (int i = 0; i < num_partitions; i++) {
       auto &md = mesh_data.GetOrAdd("base", i);
       BuildBoundaryBuffers(md);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1088,22 +1088,44 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     // send FillGhost variables
     boundary_comm_map.clear();
     boundary_comm_flxcor_map.clear();
+
+    MPI_Barrier(MPI_COMM_WORLD); 
     for (int i = 0; i < num_partitions; i++) {
       auto &md = mesh_data.GetOrAdd("base", i);
       BuildBoundaryBuffers(md);
-      SendBoundaryBuffers(md);
-    }
+    } 
+
+    std::vector<bool> sent(num_partitions, false); 
+    bool all_sent;
+    do {
+      all_sent = true;
+      for (int i = 0; i < num_partitions; i++) {
+        auto &md = mesh_data.GetOrAdd("base", i);
+        if (!sent[i]) { 
+          if (SendBoundaryBuffers(md) != TaskStatus::complete) {
+            all_sent = false;
+          } else { 
+            sent[i] = true;
+          }
+        }
+      }
+    } while (!all_sent);
 
     // wait to receive FillGhost variables
     // TODO(someone) evaluate if ReceiveWithWait kind of logic is better, also related to
     // https://github.com/lanl/parthenon/issues/418
-    bool all_received = true;
+    std::vector<bool> received(num_partitions, false); 
+    bool all_received;
     do {
       all_received = true;
       for (int i = 0; i < num_partitions; i++) {
         auto &md = mesh_data.GetOrAdd("base", i);
-        if (ReceiveBoundaryBuffers(md) != TaskStatus::complete) {
-          all_received = false;
+        if (!received[i]) { 
+          if (ReceiveBoundaryBuffers(md) != TaskStatus::complete) {
+            all_received = false;
+          } else { 
+            received[i] = true;
+          }
         }
       }
     } while (!all_received);
@@ -1115,16 +1137,21 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     }
 
     //  Now do prolongation, compute primitives, apply BCs
-    for (int i = 0; i < nmb; ++i) {
-      auto &mbd = block_list[i]->meshblock_data.Get();
-      ApplyBoundaryConditions(mbd);
-      // Call MeshBlockData based FillDerived functions
-      Update::FillDerived(mbd.get());
-    }
     for (int i = 0; i < num_partitions; i++) {
       auto &md = mesh_data.GetOrAdd("base", i);
+      if (multilevel) {
+        ApplyCoarseBoundaryConditions(md);
+        ProlongateBoundaries(md);
+      }
+      ApplyFineBoundaryConditions(md);
       // Call MeshData based FillDerived functions
       Update::FillDerived(md.get());
+    }
+
+    for (int i = 0; i < nmb; ++i) {
+      auto &mbd = block_list[i]->meshblock_data.Get();
+      // Call MeshBlockData based FillDerived functions
+      Update::FillDerived(mbd.get());
     }
 
     if (init_problem && adaptive) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1089,30 +1089,30 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     bool can_delete;
     do {
       can_delete = true;
-      for (auto &[k, comm] : boundary_comm_map) { 
+      for (auto &[k, comm] : boundary_comm_map) {
         can_delete = comm.IsSafeToDelete() && can_delete;
       }
-    } while (!can_delete); 
-    
+    } while (!can_delete);
+
     boundary_comm_map.clear();
     boundary_comm_flxcor_map.clear();
 
-    MPI_Barrier(MPI_COMM_WORLD); 
+    MPI_Barrier(MPI_COMM_WORLD);
     for (int i = 0; i < num_partitions; i++) {
       auto &md = mesh_data.GetOrAdd("base", i);
       BuildBoundaryBuffers(md);
-    } 
+    }
 
-    std::vector<bool> sent(num_partitions, false); 
+    std::vector<bool> sent(num_partitions, false);
     bool all_sent;
     do {
       all_sent = true;
       for (int i = 0; i < num_partitions; i++) {
         auto &md = mesh_data.GetOrAdd("base", i);
-        if (!sent[i]) { 
+        if (!sent[i]) {
           if (SendBoundaryBuffers(md) != TaskStatus::complete) {
             all_sent = false;
-          } else { 
+          } else {
             sent[i] = true;
           }
         }
@@ -1122,16 +1122,16 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     // wait to receive FillGhost variables
     // TODO(someone) evaluate if ReceiveWithWait kind of logic is better, also related to
     // https://github.com/lanl/parthenon/issues/418
-    std::vector<bool> received(num_partitions, false); 
+    std::vector<bool> received(num_partitions, false);
     bool all_received;
     do {
       all_received = true;
       for (int i = 0; i < num_partitions; i++) {
         auto &md = mesh_data.GetOrAdd("base", i);
-        if (!received[i]) { 
+        if (!received[i]) {
           if (ReceiveBoundaryBuffers(md) != TaskStatus::complete) {
             all_received = false;
-          } else { 
+          } else {
             received[i] = true;
           }
         }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1085,16 +1085,17 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
     // send FillGhost variables
     bool can_delete;
-    int test_iters = 0;
+    std::int64_t test_iters = 0;
+    constexpr std::int64_t max_it = 1e10;
     do {
       can_delete = true;
       for (auto &[k, comm] : boundary_comm_map) {
         can_delete = comm.IsSafeToDelete() && can_delete;
       }
       test_iters++;
-    } while (!can_delete && test_iters < 1e10);
+    } while (!can_delete && test_iters < max_it);
     PARTHENON_REQUIRE(
-        test_iters < 1.e10,
+        test_iters < max_it,
         "Too many iterations waiting to delete boundary communication buffers.");
 
     boundary_comm_map.clear();
@@ -1107,7 +1108,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
     std::vector<bool> sent(num_partitions, false);
     bool all_sent;
-    int send_iters = 0;
+    std::int64_t send_iters = 0;
     do {
       all_sent = true;
       for (int i = 0; i < num_partitions; i++) {
@@ -1121,9 +1122,9 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
         }
       }
       send_iters++;
-    } while (!all_sent && send_iters < 1e10);
+    } while (!all_sent && send_iters < max_it);
     PARTHENON_REQUIRE(
-        send_iters < 1.e10,
+        send_iters < max_it,
         "Too many iterations waiting to send boundary communication buffers.");
 
     // wait to receive FillGhost variables
@@ -1131,7 +1132,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     // https://github.com/lanl/parthenon/issues/418
     std::vector<bool> received(num_partitions, false);
     bool all_received;
-    int receive_iters;
+    std::int64_t receive_iters = 0;
     do {
       all_received = true;
       for (int i = 0; i < num_partitions; i++) {
@@ -1145,9 +1146,9 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
         }
       }
       receive_iters++;
-    } while (!all_received && receive_iters < 1.e10);
+    } while (!all_received && receive_iters < max_it);
     PARTHENON_REQUIRE(
-        receive_iters < 1.e10,
+        receive_iters < max_it,
         "Too many iterations waiting to receive boundary communication buffers.");
 
     for (int i = 0; i < num_partitions; i++) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1150,10 +1150,10 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     for (int i = 0; i < num_partitions; i++) {
       auto &md = mesh_data.GetOrAdd("base", i);
       if (multilevel) {
-        ApplyCoarseBoundaryConditions(md);
+        ApplyBoundaryConditionsOnCoarseOrFineMD(md, true);
         ProlongateBoundaries(md);
       }
-      ApplyFineBoundaryConditions(md);
+      ApplyBoundaryConditionsOnCoarseOrFineMD(md, false);
       // Call MeshData based FillDerived functions
       Update::FillDerived(md.get());
     }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1086,6 +1086,14 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
     }
 
     // send FillGhost variables
+    bool can_delete;
+    do {
+      can_delete = true;
+      for (auto &[k, comm] : boundary_comm_map) { 
+        can_delete = comm.IsSafeToDelete() && can_delete;
+      }
+    } while (!can_delete); 
+    
     boundary_comm_map.clear();
     boundary_comm_flxcor_map.clear();
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -511,6 +511,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                 vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
           }
           memset(tmpData.data() + index, 0, varSize * sizeof(OutT));
+          for (int i = 0; i < varSize; ++i) (tmpData.data() + index)[i] = std::numeric_limits<Real>::quiet_NaN(); 
           index += varSize;
         } else {
           std::stringstream msg;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -511,7 +511,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                 vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
           }
           memset(tmpData.data() + index, 0, varSize * sizeof(OutT));
-          for (int i = 0; i < varSize; ++i) (tmpData.data() + index)[i] = std::numeric_limits<Real>::quiet_NaN(); 
+          for (int i = 0; i < varSize; ++i)
+            (tmpData.data() + index)[i] = std::numeric_limits<Real>::quiet_NaN();
           index += varSize;
         } else {
           std::stringstream msg;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -539,8 +539,6 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                 vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
           }
           memset(tmpData.data() + index, 0, varSize * sizeof(OutT));
-          for (int i = 0; i < varSize; ++i)
-            (tmpData.data() + index)[i] = std::numeric_limits<Real>::quiet_NaN();
           index += varSize;
         } else {
           std::stringstream msg;

--- a/src/utils/communication_buffer.hpp
+++ b/src/utils/communication_buffer.hpp
@@ -116,7 +116,13 @@ class CommBuffer {
 
   void TryStartReceive() noexcept;
   bool TryReceive() noexcept;
-
+  bool IsSafeToDelete() {
+    if (*comm_type_ == BuffCommType::sparse_receiver || *comm_type_ == BuffCommType::receiver) { 
+      return *state_ == BufferState::stale;
+    } else { 
+      return IsAvailableForWrite();
+    }
+  }
   void Stale();
 };
 

--- a/src/utils/communication_buffer.hpp
+++ b/src/utils/communication_buffer.hpp
@@ -117,9 +117,10 @@ class CommBuffer {
   void TryStartReceive() noexcept;
   bool TryReceive() noexcept;
   bool IsSafeToDelete() {
-    if (*comm_type_ == BuffCommType::sparse_receiver || *comm_type_ == BuffCommType::receiver) { 
+    if (*comm_type_ == BuffCommType::sparse_receiver ||
+        *comm_type_ == BuffCommType::receiver) {
       return *state_ == BufferState::stale;
-    } else { 
+    } else {
       return IsAvailableForWrite();
     }
   }


### PR DESCRIPTION
## PR Summary

This fixes a couple of bugs in sparse communication:

1. Because the field `BndInfo::allocated` was being repurposed to refer to the block being allocated for send `BndInfo` and to refer to the buffer being allocated for receive `BndInfo`, in some cases boundary prolongation would not occur when it should for sparse variables. Through a chain of events, this could show up as a dependence of results on the number of ranks that sparse problems were run on (although the differences were of order the sparse threshold). 
2. In thinking through this, I also realized that for sparse fields splitting the boundary communication into local and nonlocal is not safe, since a field can be allocated by one set of boundary communication after the other boundary communication has finished. This may not have been a real issue to date, as we have always assumed the default value to fill sparse fields with is zero, but if the default value was non-zero it could (maybe?) cause an issue.
3. The `dealloc_count` of fields was not passed during different rank, same-to-same communication during AMR. This meant that the step at which a particular block was deallocated could vary with the number of ranks.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
