### PR TITLE
Meshblock Cost Function and Diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 892]](https://github.com/parthenon-hpc-lab/parthenon/pull/892) Cost-based load balancing and memory diagnostics
 - [[PR 872]](https://github.com/parthenon-hpc-lab/parthenon/pull/872) Boundary communication for non-cell centered fields
 - [[PR 877]](https://github.com/parthenon-hpc-lab/parthenon/pull/877) Add flat sparse packs
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing

--- a/doc/sphinx/src/interface/sparse.rst
+++ b/doc/sphinx/src/interface/sparse.rst
@@ -412,3 +412,29 @@ block. The remaining changes are as follows:
    it's not yet allocated on the receiving block. We then proceed to
    read the buffer only if the variable is allocated on the receiving
    block.
+
+Memory Footprint Reporting
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+With sparse variables (or particles), the memory footprint per
+meshblock may vary with meshblock. Each ``MeshBlock`` object keeps a
+running total of its memory footprint. You can get the footprint of an
+individual meshblock by calling:
+
+.. cpp:function::
+
+   std::uint64_t MeshBlock::ReportMemUsage();
+
+If desired, you may also manually change the recorded memory footprint
+of a given meshblock with the function:
+
+.. cpp:function::
+
+   void MeshBlock::LogMemUsage(std::int64_t delta);
+
+where ``delta`` is the change in memory.
+
+.. warning::
+
+   Call ``LogMemUsage`` with caution! Variable and swarm allocation
+   and de-allocation are automatically tracked.

--- a/doc/sphinx/src/load_balancing.rst
+++ b/doc/sphinx/src/load_balancing.rst
@@ -1,0 +1,41 @@
+.. _load_balancing:
+
+Load Balancing
+==============
+
+Parthenon supports some load balancing capabilities. By default load
+balancing is done "round robin" so that each MPI rank has a roughly
+equal number of ``MeshBlock`` s. However, this behaviour can be
+modified.
+
+On a per ``MeshBlock`` basis, you call the
+function
+
+.. cpp:function::
+
+   void MeshBlock::SetCostForLoadBalancing(double cost);
+
+where the cost is any positive real number. For example, you might
+call the above function in an application driver like:
+
+.. code:: cpp
+
+   for (int pmb : pmy_mesh->block_list) {
+     pmb->SetCostForLoadBalancing(SomeHeuristicFunction(pmb));
+   }
+
+Then, if you set the following block in your input file:
+
+::
+
+   <parthenon/loadbalancing>
+   balancer = manual
+
+parthenon will try to give each MPI rank a set of meshblocks with
+equal total cost. To disable this functionality and recover default
+behaviour, set the ``balancer`` option to ``default``.
+
+.. note::
+
+   Parthenon does not currently support timer based load balancing,
+   however this is a planned feature.

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -452,7 +452,9 @@ class MeshBlockData {
     //                         "Tried to deallocate non-sparse variable " + label);
 
     if (var->IsAllocated()) {
-      var->Deallocate();
+      std::int64_t bytes = var->Deallocate();
+      auto pmb = GetBlockPointer();
+      pmb->LogMemUsage(-bytes);
     }
   }
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -148,7 +148,7 @@ class Swarm {
   void increasePoolMax() { setPoolMax(2 * nmax_pool_); }
 
   /// Set max pool size
-  void setPoolMax(const int nmax_pool);
+  void setPoolMax(const std::int64_t nmax_pool);
 
   /// Check whether metadata bit is set
   bool IsSet(const MetadataFlag bit) const { return m_.IsSet(bit); }

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -197,6 +197,7 @@ std::int64_t Variable<T>::Deallocate() {
   data.Reset();
 
   if (IsSet(Metadata::WithFluxes)) {
+    mem_size += flux_data_.size() * sizeof(T);
     flux_data_.Reset();
     int n_outer = 1 + (GetDim(2) > 1) * (1 + (GetDim(3) > 1));
     for (int d = X1DIR; d <= n_outer; ++d) {
@@ -205,6 +206,7 @@ std::int64_t Variable<T>::Deallocate() {
   }
 
   if (IsSet(Metadata::FillGhost) || IsSet(Metadata::Independent)) {
+    mem_size += coarse_s.size() * sizeof(T);
     coarse_s.Reset();
   }
 

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -155,7 +155,7 @@ class Variable {
   void AllocateData(bool flag_uninitialized = false);
 
   // deallocate data, fluxes, and boundary variable
-  void Deallocate();
+  std::int64_t Deallocate();
 
   /// allocate fluxes (if Metadata::WithFluxes is set) and coarse data if
   /// (Metadata::FillGhost is set)

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -152,7 +152,8 @@ class Variable {
   int num_alloc_ = 0;
 
   // allocate data only
-  void AllocateData(bool flag_uninitialized = false);
+  void AllocateData(MeshBlock *pmb, bool flag_uninitialized = false);
+  void AllocateData(std::weak_ptr<MeshBlock> wpmb, bool flag_uninitialized = false);
 
   // deallocate data, fluxes, and boundary variable
   std::int64_t Deallocate();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1265,10 +1265,15 @@ void Mesh::RegisterLoadBalancing_(ParameterInput *pin) {
       pin->GetOrAddString("parthenon/loadbalancing", "balancer", "default",
                           std::vector<std::string>{"default", "automatic", "manual"});
   if (balancer == "automatic") {
+    // JMM: I am disabling timing based load balancing, as it's not
+    // threaded through the infrastructure. I think some thought needs
+    // to go into doing this right with loops over meshdata rather
+    // than loops over data on a single meshblock.
     PARTHENON_FAIL("Timing based load balancing is currently unavailable.");
     lb_automatic_ = true;
-  } else if (balancer == "manual")
+  } else if (balancer == "manual") {
     lb_manual_ = true;
+  }
   lb_tolerance_ = pin->GetOrAddReal("parthenon/loadbalancing", "tolerance", 0.5);
   lb_interval_ = pin->GetOrAddInteger("parthenon/loadbalancing", "interval", 10);
 #endif // MPI_PARALLEL

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -266,12 +266,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
   tree.CreateRootGrid();
 
   // Load balancing flag and parameters
-  if (pin->GetOrAddString("loadbalancing", "balancer", "default") == "automatic")
-    lb_automatic_ = true;
-  else if (pin->GetOrAddString("loadbalancing", "balancer", "default") == "manual")
-    lb_manual_ = true;
-  lb_tolerance_ = pin->GetOrAddReal("loadbalancing", "tolerance", 0.5);
-  lb_interval_ = pin->GetOrAddInteger("loadbalancing", "interval", 10);
+  RegisterLoadBalancing_(pin);
 
   // SMR / AMR:
   if (adaptive) {
@@ -647,14 +642,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   default_pack_size_ = pin->GetOrAddInteger("parthenon/mesh", "pack_size", -1);
 
   // Load balancing flag and parameters
-#ifdef MPI_PARALLEL
-  if (pin->GetOrAddString("parthenon/loadbalancing", "balancer", "default") == "automatic")
-    lb_automatic_ = true;
-  else if (pin->GetOrAddString("parthenon/loadbalancing", "balancer", "default") == "manual")
-    lb_manual_ = true;
-  lb_tolerance_ = pin->GetOrAddReal("parthenon/loadbalancing", "tolerance", 0.5);
-  lb_interval_ = pin->GetOrAddInteger("parthenon/loadbalancing", "interval", 10);
-#endif
+  RegisterLoadBalancing_(pin);
 
   // SMR / AMR
   if (adaptive) {
@@ -1269,6 +1257,22 @@ int Mesh::GetNumberOfMeshBlockCells() const {
   return block_list.front()->GetNumberOfMeshBlockCells();
 }
 const RegionSize &Mesh::GetBlockSize() const { return block_list.front()->block_size; }
+
+// Functionality re-used in mesh constructor
+void Mesh::RegisterLoadBalancing_(ParameterInput *pin) {
+#ifdef MPI_PARALLEL // JMM: Not sure this ifdef is needed
+  const std::string balancer =
+      pin->GetOrAddString("parthenon/loadbalancing", "balancer", "default",
+                          std::vector<std::string>{"default", "automatic", "manual"});
+  if (balancer == "automatic") {
+    PARTHENON_FAIL("Timing based load balancing is currently unavailable.");
+    lb_automatic_ = true;
+  } else if (balancer == "manual")
+    lb_manual_ = true;
+  lb_tolerance_ = pin->GetOrAddReal("parthenon/loadbalancing", "tolerance", 0.5);
+  lb_interval_ = pin->GetOrAddInteger("parthenon/loadbalancing", "interval", 10);
+#endif // MPI_PARALLEL
+}
 
 // Create separate communicators for all variables. Needs to be done at the mesh
 // level so that the communicators for each variable across all blocks is consistent.

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -648,12 +648,12 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
 
   // Load balancing flag and parameters
 #ifdef MPI_PARALLEL
-  if (pin->GetOrAddString("loadbalancing", "balancer", "default") == "automatic")
+  if (pin->GetOrAddString("parthenon/loadbalancing", "balancer", "default") == "automatic")
     lb_automatic_ = true;
-  else if (pin->GetOrAddString("loadbalancing", "balancer", "default") == "manual")
+  else if (pin->GetOrAddString("parthenon/loadbalancing", "balancer", "default") == "manual")
     lb_manual_ = true;
-  lb_tolerance_ = pin->GetOrAddReal("loadbalancing", "tolerance", 0.5);
-  lb_interval_ = pin->GetOrAddInteger("loadbalancing", "interval", 10);
+  lb_tolerance_ = pin->GetOrAddReal("parthenon/loadbalancing", "tolerance", 0.5);
+  lb_interval_ = pin->GetOrAddInteger("parthenon/loadbalancing", "interval", 10);
 #endif
 
   // SMR / AMR

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -279,6 +279,9 @@ class Mesh {
   void EnrollBndryFncts_(ApplicationInput *app_in);
   void EnrollUserMeshGenerator(CoordinateDirection dir, MeshGenFunc my_mg);
 
+  // Re-used functionality in constructor
+  void RegisterLoadBalancing_(ParameterInput *pin);
+
   void SetupMPIComms();
 };
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -196,6 +196,14 @@ class Mesh {
     }
   }
 
+  uint64_t GetBufferPoolSizeInBytes() const {
+    std::uint64_t buffer_memory = 0;
+    for (auto &p : pool_map) {
+      buffer_memory += p.second.SizeInBytes();
+    }
+    return buffer_memory;
+  }
+
  private:
   // data
   int root_level, max_level, current_level;

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -278,7 +278,7 @@ void MeshBlock::RegisterMeshBlockData(std::shared_ptr<Variable<Real>> pvar_cc) {
 void MeshBlock::AllocateSparse(std::string const &label, bool only_control,
                                bool flag_uninitialized) {
   auto &mbd = meshblock_data;
-  auto AllocateVar = [flag_uninitialized, &mbd](const std::string &l) {
+  auto AllocateVar = [this, flag_uninitialized, &mbd](const std::string &l) {
     // first allocate variable in base stage
     auto base_var = mbd.Get()->AllocateSparse(l, flag_uninitialized);
 
@@ -299,7 +299,7 @@ void MeshBlock::AllocateSparse(std::string const &label, bool only_control,
 
       if (!v->IsAllocated()) {
         // allocate data of target variable
-        v->AllocateData(flag_uninitialized);
+        v->AllocateData(this, flag_uninitialized);
 
         // copy fluxes and boundary variable from variable on base stage
         v->CopyFluxesAndBdryVar(base_var.get());

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -167,13 +167,10 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
   void SetCostForLoadBalancing(double cost);
 
   // Memory usage
-  void LogMemUsage(std::int64_t delta) {
-    mem_usage += delta;
-  }
+  // TODO(JMM): Currently swarm send/receive boundaries are not counted.
+  void LogMemUsage(std::int64_t delta) { mem_usage_ += delta; }
 
-  std::uint64_t ReportMemUsage() {
-    return mem_usage_;
-  }
+  std::uint64_t ReportMemUsage() { return mem_usage_; }
 
   //----------------------------------------------------------------------------------------
   //! \fn void MeshBlock::DeepCopy(const DstType& dst, const SrcType& src)

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -165,9 +165,6 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
   // functions
   // Load balancing
   void SetCostForLoadBalancing(double cost);
-  void ResetTimeMeasurement();
-  void StartTimeMeasurement();
-  void StopTimeMeasurement();
 
   // Memory usage
   void LogMemUsage(std::int64_t delta) {
@@ -448,6 +445,11 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
   // functions and variables for automatic load balancing based on timing
   Kokkos::Timer lb_timer;
   double cost_;
+  // JMM: these are private since the timing machinery only works
+  // per-meshblock nopt per-meshdata.
+  void ResetTimeMeasurement();
+  void StartTimeMeasurement();
+  void StopTimeMeasurement();
 
   // memory usage on a block
   std::uint64_t mem_usage_;

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -163,6 +163,20 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
   BoundaryFlag boundary_flag[6];
 
   // functions
+  // Load balancing
+  void SetCostForLoadBalancing(double cost);
+  void ResetTimeMeasurement();
+  void StartTimeMeasurement();
+  void StopTimeMeasurement();
+
+  // Memory usage
+  void LogMemUsage(std::int64_t delta) {
+    mem_usage += delta;
+  }
+
+  std::uint64_t ReportMemUsage() {
+    return mem_usage_;
+  }
 
   //----------------------------------------------------------------------------------------
   //! \fn void MeshBlock::DeepCopy(const DstType& dst, const SrcType& src)
@@ -419,8 +433,6 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
   void InitializeIndexShapesImpl(const int nx1, const int nx2, const int nx3,
                                  bool init_coarse, bool multilevel);
   void InitializeIndexShapes(const int nx1, const int nx2, const int nx3);
-  // functions
-  void SetCostForLoadBalancing(double cost);
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   static void ProblemGeneratorDefault(MeshBlock *pmb, ParameterInput *pin);
@@ -436,9 +448,9 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
   // functions and variables for automatic load balancing based on timing
   Kokkos::Timer lb_timer;
   double cost_;
-  void ResetTimeMeasurement();
-  void StartTimeMeasurement();
-  void StopTimeMeasurement();
+
+  // memory usage on a block
+  std::uint64_t mem_usage_;
 };
 
 using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -57,9 +57,19 @@ class ObjectPool {
 
   weak_t Get();
 
-  void PrintStatistics() {
+  void PrintStatistics() const {
     std::cout << available_.size() << " unused objects." << std::endl;
     std::cout << inuse_.size() << " used objects." << std::endl;
+  }
+
+  std::uint64_t SizeInBytes() const {
+    constexpr std::uint64_t datum_size = sizeof(typename base_t::value_type);
+    std::uint64_t object_size = 0;
+    if (inuse_.size() > 0)
+      object_size = inuse_.begin()->second.first.size();
+    else if (available_.size() > 0)
+      object_size = available_.top().size();
+    return datum_size * object_size * (inuse_.size() + available_.size());
   }
 
   // This should be used with care since it can't generically be


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Again part of the effort to get riot onto parthenon develop. Here I pull several features in from riot:

### Memory Diagnostics Per Meshblock

Whenever variables or swarms are allocated or deallocated, memory used on a given meshblock is updated in a running total. Note this is only "interior" data. I also add the ability to look at the comm buffer pool, but this is a per-mesh quantity since the pool is shared. Not per block. I also didn't add the equivalent logic for boundary swarms, as I didn't fully understand the swarm machinery, and it's probably a negligible contribution. @brryan should probably take a look at the memory diagnostic logic for swarms in case I missed something.

I showcase this capability by modifying the sparse example to show memory footprint in bytes per cycle.

### Manual load balancing

- I "made public" manual cost-based load balancing again. It's enabled in the input deck by setting `parthenon/loadbalancing/balancer=manual`. 
- I also explicitly disable timers based load balancing, as this isn't fully threaded through the infrastructure anymore. I think it's not trivial to figure out what to do here, and I created an issue, #891 to discuss.
- I clarify what it means to use the manual vs default load balancing. Automatic load balancing is timers. Manual is the cost-based where downstream codes are expected to call the meshblock handles. Default is just meshblock count.

I also document both of the above new features.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
