### PR TITLE
map instead of unordered_map for sparse pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 894]](https://github.com/parthenon-hpc-lab/parthenon/pull/894) Demand that sparse pool order sparse ids
 - [[PR 885]](https://github.com/parthenon-hpc-lab/parthenon/pull/885) Expose PackDescriptor and use uids in SparsePacks
 
 ### Fixed (not changing behavior/API/variables/...)

--- a/src/interface/sparse_pool.hpp
+++ b/src/interface/sparse_pool.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/sparse_pool.hpp
+++ b/src/interface/sparse_pool.hpp
@@ -13,9 +13,9 @@
 #ifndef INTERFACE_SPARSE_POOL_HPP_
 #define INTERFACE_SPARSE_POOL_HPP_
 
+#include <map>
 #include <string>
 #include <type_traits>
-#include <unordered_map>
 #include <vector>
 
 #include "metadata.hpp"
@@ -74,7 +74,7 @@ class SparsePool {
   const std::string &base_name() const { return base_name_; }
   const std::string &controller_base_name() const { return controller_base_name_; }
   const Metadata &shared_metadata() const { return shared_metadata_; }
-  const std::unordered_map<int, Metadata> &pool() const { return pool_; }
+  const std::map<int, Metadata> &pool() const { return pool_; }
   auto size() const { return pool_.size(); }
 
   // Add a new sparse ID to the pool with optional arguments:
@@ -117,7 +117,9 @@ class SparsePool {
 
   Metadata shared_metadata_;
   // Metadata per sparse id
-  std::unordered_map<int, Metadata> pool_;
+  // JMM: note that this map SHOULD be ordered as sparse ids, being
+  // integers, have an implicit ordering.
+  std::map<int, Metadata> pool_;
 };
 
 } // namespace parthenon

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -219,6 +219,14 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
             REQUIRE(pkg4->FieldMetadata("sparse", sparse_ids[i]) == (m_sparse_provides));
           }
         }
+        AND_THEN("The sparse ids in the sparse pool are sorted") {
+          auto &pool = (pkg4->GetSparsePool("sparse")).pool();
+          std::vector<int> local_ids;
+          for (auto &[id, m] : pool) {
+            local_ids.push_back(id);
+          }
+          REQUIRE(std::is_sorted(local_ids.begin(), local_ids.end()));
+        }
       }
     }
 

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The sparse pool uses an unordered map. However, sparse ids have an implicit ordering, they are integers after all. While not a bug exactly, the unordered map can mangle the ordering and can produce un-intuitive behavior where a user may request sparse IDs and expect the pool to return an ordered list. This PR changes the map to an ordered one (i.e., a heap) so traversal through it always produces sparse IDs sorted from smallest to largest. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
