### PR TITLE
Add sparse seed nans flag to output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 902]](https://github.com/parthenon-hpc-lab/parthenon/pull/902) Add ability to output NaNs for de-allocated sparse fields
 - [[PR 887]](https://github.com/parthenon-hpc-lab/parthenon/pull/887) Add ability to dump more types of params and read them from restarts
 - [[PR 884]](https://github.com/parthenon-hpc-lab/parthenon/pull/884) Add constant derivative BC and expose GenericBC
 - [[PR 892]](https://github.com/parthenon-hpc-lab/parthenon/pull/892) Cost-based load balancing and memory diagnostics

--- a/doc/sphinx/src/outputs.rst
+++ b/doc/sphinx/src/outputs.rst
@@ -59,6 +59,13 @@ look like
    file_number_width = 6 # default: 5
    use_final_label = true # default: true
 
+   # Sparse variables may not be allocated on every block. By default
+   # parthenon outputs de-allocated variables as 0 in the output
+   # file. However, it is often convenient to output them as NaN
+   # instead, marking deallocated and allocated but zero as
+   # separate. This flag turns this functionality on.
+   sparse_seed_nans = false # default false
+
 This will produce an hdf5 (``.phdf``) output file every 1 units of
 simulation time containing the density, velocity, and energy of each
 cell. The files will be identified by a 6-digit ID, and the output file

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -152,8 +152,11 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       if (is_hdf5_output) {
         op.single_precision_output =
             pin->GetOrAddBoolean(op.block_name, "single_precision_output", false);
+        op.sparse_seed_nans =
+            pin->GetOrAddBoolean(op.block_name, "sparse_seed_nans", false);
       } else {
         op.single_precision_output = false;
+        op.sparse_seed_nans = false;
 
         if (pin->DoesParameterExist(op.block_name, "single_precision_output")) {
           std::stringstream warn;

--- a/src/outputs/outputs.hpp
+++ b/src/outputs/outputs.hpp
@@ -59,12 +59,14 @@ struct OutputParameters {
   int file_number;
   bool include_ghost_zones, cartesian_vector;
   bool single_precision_output;
+  bool sparse_seed_nans;
   int hdf5_compression_level;
   // TODO(felker): some of the parameters in this class are not initialized in constructor
   OutputParameters()
       : block_number(0), next_time(0.0), dt(-1.0), file_number(0),
         include_ghost_zones(false), cartesian_vector(false),
-        single_precision_output(false), hdf5_compression_level(5) {}
+        single_precision_output(false), sparse_seed_nans(false),
+        hdf5_compression_level(5) {}
 };
 
 //----------------------------------------------------------------------------------------

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -539,7 +539,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                 vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
           }
           auto fill_val = output_params.sparse_seed_nans
-                              ? std::numeric_limits<OutT>::signaling_NaN()
+                              ? std::numeric_limits<OutT>::quiet_NaN()
                               : 0;
           std::fill(tmpData.data() + index, tmpData.data() + index + varSize, fill_val);
           index += varSize;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -538,9 +538,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
             varSize =
                 vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
           }
-          auto fill_val = output_params.sparse_seed_nans
-                              ? std::numeric_limits<OutT>::quiet_NaN()
-                              : 0;
+          auto fill_val =
+              output_params.sparse_seed_nans ? std::numeric_limits<OutT>::quiet_NaN() : 0;
           std::fill(tmpData.data() + index, tmpData.data() + index + varSize, fill_val);
           index += varSize;
         } else {

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -538,7 +538,10 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
             varSize =
                 vinfo.nx6 * vinfo.nx5 * vinfo.nx4 * vinfo.nx3 * vinfo.nx2 * vinfo.nx1;
           }
-          memset(tmpData.data() + index, 0, varSize * sizeof(OutT));
+          auto fill_val = output_params.sparse_seed_nans
+                              ? std::numeric_limits<OutT>::signaling_NaN()
+                              : 0;
+          std::fill(tmpData.data() + index, tmpData.data() + index + varSize, fill_val);
           index += varSize;
         } else {
           std::stringstream msg;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When debugging sparse variables, it's useful to be able to output where sparse variables are specifically de-allocated, as opposed to just exactly zero. This small PR adds a tiny tweak to parthenon_hdf5 output which allows the user to output NaNs for sparse variables which are de-allocated, making them easy to find in output.

This is essentially a debugging tool and it's opt-in. However, it does have the advantage that by replacing `memset` with `std::fill` we could change what that fill value is at a later date to, for example, set it to whatever value the sparse field would be initialized to, if that value is not zero.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
