### PR TITLE
WIP: Uniform Cylindrical and Spherical Coordinates

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -11,6 +11,7 @@
 # the public, perform publicly and display publicly, and to permit others to do so.
 #=========================================================================================
 
+
 add_subdirectory(stochastic_subgrid)
 add_subdirectory(advection)
 add_subdirectory(calculate_pi)
@@ -18,5 +19,11 @@ add_subdirectory(kokkos_pi)
 add_subdirectory(particles)
 add_subdirectory(particle_leapfrog)
 add_subdirectory(particle_tracers)
-add_subdirectory(poisson)
 add_subdirectory(sparse_advection)
+
+
+# Not all tests will work with all coordinate systems. Add Cartesian-only tests
+# below
+if (${COORDINATE_TYPE} STREQUAL "UniformCartesian")
+    add_subdirectory(poisson)
+endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -85,12 +85,13 @@ else()
   set(PAR_LOOP_INNER_LAYOUT_TAG loop_pattern_undefined_tag)
 endif()
 
+set(COORDINATE_TYPE "UniformCartesian" CACHE STRING "UniformCartesian/UniformSpherical/UniformCylindrical")
+message(STATUS "COORDINATE_TYPE='${COORDINATE_TYPE}' Parthenon Coordinates_t class")
+
 set(EXCEPTION_HANDLING_OPTION ENABLE_EXCEPTIONS) # TODO: Add option to disable exceptions
 set(COMPILED_WITH ${CMAKE_CXX_COMPILER})
 set(COMPILER_COMMAND "<not-implemented>") # TODO: Put something more descriptive here
 set(COMPILER_FLAGS "<not-implemented>") # TODO: Put something more descriptive here
-
-set(COORDINATE_TYPE "UniformCartesian" CACHE STRING "UniformCartesian/UniformSpherical/UniformCylindrical")
 
 configure_file(config.hpp.in generated/config.hpp @ONLY)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -90,7 +90,7 @@ set(COMPILED_WITH ${CMAKE_CXX_COMPILER})
 set(COMPILER_COMMAND "<not-implemented>") # TODO: Put something more descriptive here
 set(COMPILER_FLAGS "<not-implemented>") # TODO: Put something more descriptive here
 
-set(COORDINATE_TYPE UniformCartesian) # TODO: Make this an option when more are available
+set(COORDINATE_TYPE "UniformCartesian" CACHE STRING "UniformCartesian/UniformSpherical/UniformCylindrical")
 
 configure_file(config.hpp.in generated/config.hpp @ONLY)
 

--- a/src/coordinates/coordinates.hpp
+++ b/src/coordinates/coordinates.hpp
@@ -16,6 +16,8 @@
 #include "config.hpp"
 
 #include "uniform_cartesian.hpp"
+#include "uniform_cylindrical.hpp"
+#include "uniform_spherical.hpp"
 
 namespace parthenon {
 

--- a/src/coordinates/uniform_cartesian.hpp
+++ b/src/coordinates/uniform_cartesian.hpp
@@ -120,11 +120,11 @@ class UniformCartesian {
   KOKKOS_FORCEINLINE_FUNCTION Real Xc(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
+    case X1DIR:
       return Xc<dir>(i);
-    case 2:
+    case X2DIR:
       return Xc<dir>(j);
-    case 3:
+    case X3DIR:
       return Xc<dir>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
@@ -149,11 +149,11 @@ class UniformCartesian {
   KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
+    case X1DIR:
       return Xf<dir, face>(i);
-    case 2:
+    case X2DIR:
       return Xf<dir, face>(j);
-    case 3:
+    case X3DIR:
       return Xf<dir, face>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
@@ -171,17 +171,32 @@ class UniformCartesian {
   KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
+    case X1DIR:
       return Xf<dir>(i);
-    case 2:
+    case X2DIR:
       return Xf<dir>(j);
-    case 3:
+    case X3DIR:
       return Xf<dir>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
       return 0; // To appease compiler
     }
   }
+  
+  //----------------------------------------
+  // Xs: Area averaged positions
+  //----------------------------------------
+  template <int dir, int side>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xs(const int idx) const {
+    assert(dir > 0 && dir < 4 && side > 0 && side < 4);
+    return Xc<dir>(idx);
+  }
+  template <int dir, int side>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xs(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4 && side > 0 && side < 4);
+    return Xc<dir>(k,j,i);
+  }
+
 
   template <int dir, TopologicalElement el>
   KOKKOS_FORCEINLINE_FUNCTION Real X(const int idx) const {

--- a/src/coordinates/uniform_cylindrical.hpp
+++ b/src/coordinates/uniform_cylindrical.hpp
@@ -332,7 +332,7 @@ class UniformCylindrical {
       case X3DIR:
         return Coord_vol_i_(i)*dx_[1]; //d(r^2/2)*dphi
     }
-
+    return NAN; //To appease compiler
   }
   template <class... Args>
   KOKKOS_FORCEINLINE_FUNCTION Real FaceAreaFA(const int dir, const int k, const int j, const int i) const {
@@ -345,6 +345,7 @@ class UniformCylindrical {
       case X3DIR:
         return Coord_vol_i_(i)*dx_[1]; //d(r^2/2)*dphi
     }
+    return NAN; //To appease compiler
   }
 
   //----------------------------------------
@@ -459,6 +460,35 @@ class UniformCylindrical {
       : istart_[2];
   }
 
+  //----------------------------------------
+  // Terms for Source Terms
+  //----------------------------------------
+
+  KOKKOS_INLINE_FUNCTION Real Coord_vol_i_(const int i) const {
+      const Real rm = xmin_[0] + i * dx_[0];
+      const Real rp = xmin_[0] + (i+1) * dx_[0];
+      return 0.5*(rp*rp - rm*rm);
+  }
+
+  KOKKOS_INLINE_FUNCTION Real CoordSrc1i(const int i) const {
+    return Dxf<1,1>(i)/Coord_vol_i_(i);
+  }
+  KOKKOS_INLINE_FUNCTION Real CoordSrc2i(const int i) const {
+    const Real rm = xmin_[0] + i * dx_[0];
+    const Real rp = xmin_[0] + (i+1) * dx_[0];
+    return Dxf<1,1>(i)/( (rm + rp)*Coord_vol_i_(i));
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  Real PhySrc1i(const int i) const {
+    return 1./( Xc<1>(i)*Xf<1>(i) );
+  }
+
+  KOKKOS_INLINE_FUNCTION
+  Real PhySrc2i(const int i) const {
+    return 1./( Xc<1>(i)*Xf<1>(i+1) );
+  }
+
   const std::array<Real, 3> &GetXmin() const { return xmin_; }
   const std::array<int, 3> &GetStartIndex() const { return istart_; }
   const char *Name() const { return name_; }
@@ -476,11 +506,6 @@ class UniformCylindrical {
       const Real rm = xmin_[0] + i * dx_[0];
       const Real rp = xmin_[0] + (i+1) * dx_[0];
       return TWO_3RD*(rp*rp*rp - rm*rm*rm)/(SQR(rp) - SQR(rm));
-  }
-  KOKKOS_INLINE_FUNCTION Real Coord_vol_i_(const int i) const {
-      const Real rm = xmin_[0] + i * dx_[0];
-      const Real rp = xmin_[0] + (i+1) * dx_[0];
-      return 0.5*(rp*rp - rm*rm);
   }
   KOKKOS_INLINE_FUNCTION Real Cos_phi_c_(const int j) const {
       const Real Phi = xmin_[1] + (j + 0.5) * dx_[1];

--- a/src/coordinates/uniform_cylindrical.hpp
+++ b/src/coordinates/uniform_cylindrical.hpp
@@ -489,7 +489,9 @@ class UniformCylindrical {
     return 1./( Xc<1>(i)*Xf<1>(i+1) );
   }
 
+  KOKKOS_INLINE_FUNCTION
   const std::array<Real, 3> &GetXmin() const { return xmin_; }
+  KOKKOS_INLINE_FUNCTION
   const std::array<int, 3> &GetStartIndex() const { return istart_; }
   const char *Name() const { return name_; }
 

--- a/src/coordinates/uniform_cylindrical.hpp
+++ b/src/coordinates/uniform_cylindrical.hpp
@@ -85,23 +85,54 @@ class UniformCylindrical {
   // Dxc<1> returns distance between cell centroids in r
   //----------------------------------------
   template <int dir>
-  KOKKOS_FORCEINLINE_FUNCTION Real Dxc(const int k, const int j, const int i) const {
+  KOKKOS_FORCEINLINE_FUNCTION Real Dxc(const int idx) const {
     assert(dir > 0 && dir < 4);
     if( dir == X1DIR ){
-      return r_c_(i+1) - r_c_(i);
+      return r_c_(idx+1) - r_c_(idx);
     } else {
       return dx_[dir-1];
     }
   }
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real Dxc(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case X1DIR:
+      return Dxc<X1DIR>(i);
+    case X2DIR:
+      return Dxc<X2DIR>(j);
+    case X3DIR:
+      return Dxc<X3DIR>(k);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+
+  KOKKOS_FORCEINLINE_FUNCTION Real DxcFA(const int dir, const int idx) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case X1DIR:
+      return Dxc<X1DIR>(idx);
+    case X2DIR:
+      return Dxc<X2DIR>(idx);
+    case X3DIR:
+      return Dxc<X3DIR>(idx);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+
   KOKKOS_FORCEINLINE_FUNCTION Real DxcFA(const int dir, const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
-      return Dxc<1>(k,j,i);
-    case 2:
-      return Dxc<2>(k,j,j);
-    case 3:
-      return Dxc<3>(k,j,k);
+    case X1DIR:
+      return Dxc<X1DIR>(i);
+    case X2DIR:
+      return Dxc<X2DIR>(j);
+    case X3DIR:
+      return Dxc<X3DIR>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
       return 0; // To appease compiler
@@ -139,17 +170,18 @@ class UniformCylindrical {
   KOKKOS_FORCEINLINE_FUNCTION Real Xc(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
+    case X1DIR:
       return Xc<dir>(i);
-    case 2:
+    case X2DIR:
       return Xc<dir>(j);
-    case 3:
+    case X3DIR:
       return Xc<dir>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
       return 0; // To appease compiler
     }
   }
+
 
   //----------------------------------------
   // Xf: Positions on Faces
@@ -168,11 +200,11 @@ class UniformCylindrical {
   KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
+    case X1DIR:
       return Xf<dir, face>(i);
-    case 2:
+    case X2DIR:
       return Xf<dir, face>(j);
-    case 3:
+    case X3DIR:
       return Xf<dir, face>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
@@ -190,16 +222,30 @@ class UniformCylindrical {
   KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
     switch (dir) {
-    case 1:
+    case X1DIR:
       return Xf<dir>(i);
-    case 2:
+    case X2DIR:
       return Xf<dir>(j);
-    case 3:
+    case X3DIR:
       return Xf<dir>(k);
     default:
       PARTHENON_FAIL("Unknown dir");
       return 0; // To appease compiler
     }
+  }
+
+  //----------------------------------------
+  // Xs: Area averaged positions
+  //----------------------------------------
+  template <int dir, int side>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xs(const int idx) const {
+    assert(dir > 0 && dir < 4 && side > 0 && side < 4);
+    return Xc<dir>(idx);
+  }
+  template <int dir, int side>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xs(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4 && side > 0 && side < 4);
+    return Xc<dir>(k,j,i);
   }
 
   template <int dir, TopologicalElement el>

--- a/src/coordinates/uniform_cylindrical.hpp
+++ b/src/coordinates/uniform_cylindrical.hpp
@@ -10,8 +10,8 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
-#ifndef COORDINATES_UNIFORM_CARTESIAN_HPP_
-#define COORDINATES_UNIFORM_CARTESIAN_HPP_
+#ifndef COORDINATES_UNIFORM_CYLINDRICAL_HPP_
+#define COORDINATES_UNIFORM_CYLINDRICAL_HPP_
 
 #include <array>
 #include <cassert>
@@ -25,40 +25,41 @@
 
 namespace parthenon {
 
-class UniformCartesian {
+class UniformCylindrical {
  public:
-  UniformCartesian() = default;
-  UniformCartesian(const RegionSize &rs, ParameterInput *pin) {
+  UniformCylindrical() = default;
+  UniformCylindrical(const RegionSize &rs, ParameterInput *pin) {
     dx_[0] = (rs.x1max - rs.x1min) / rs.nx1;
     dx_[1] = (rs.x2max - rs.x2min) / rs.nx2;
     dx_[2] = (rs.x3max - rs.x3min) / rs.nx3;
     area_[0] = dx_[1] * dx_[2];
     area_[1] = dx_[0] * dx_[2];
     area_[2] = dx_[0] * dx_[1];
-    cell_volume_ = dx_[0] * dx_[1] * dx_[2];
     istart_[0] = Globals::nghost;
     istart_[1] = (rs.nx2 > 1 ? Globals::nghost : 0);
     istart_[2] = (rs.nx3 > 1 ? Globals::nghost : 0);
     xmin_[0] = rs.x1min - istart_[0] * dx_[0];
     xmin_[1] = rs.x2min - istart_[1] * dx_[1];
     xmin_[2] = rs.x3min - istart_[2] * dx_[2];
-    ndim_  = (rs.nx1 != 1) + (rs.nx2 != 1) + (rs.nx3 != 1);
+    nx_[0] = rs.nx1;
+    nx_[1] = rs.nx2;
+    nx_[2] = rs.nx3;
 
-    std::string coord_type_str = pin->GetOrAddString("parthenon/mesh", "coord", "cartesian");
-    //REMOVE ME
-    //if (coord_type_str == "cartesian") {
-    //  coord_type = parthenon::uniformOrthMesh::cartesian;
-    //} else 
-    if (coord_type_str == "cylindrical") {
-      PARTHENON_THROW(" Please rebuild with -DCOORDINATE_TYPE=UniformCylindrical");
-    } else if (coord_type_str == "spherical_polar") {
-      PARTHENON_THROW(" Please rebuild with -DCOORDINATE_TYPE=UniformSpherical");
-    } else {
-      PARTHENON_THROW("Invalid coord input in <parthenon/mesh>.");
+    std::string coord_type_str = pin->GetOrAddString("parthenon/mesh", "coord", "cylindrical");
+    if( coord_type_str != "cylindrical" ){
+      if (coord_type_str == "cartesian") {
+        PARTHENON_THROW(" Please rebuild with -DCOORDINATE_TYPE=UniformCartesian");
+      } else if (coord_type_str == "spherical") {
+        PARTHENON_THROW(" Please rebuild with -DCOORDINATE_TYPE=UniformSpherical");
+      } else {
+        PARTHENON_THROW("Invalid coord input in <parthenon/mesh>.");
+      }
     }
 
+    //Initialized cached coordinates
+    InitCachedArrays();
   }
-  UniformCartesian(const UniformCartesian &src, int coarsen)
+  UniformCylindrical(const UniformCylindrical &src, int coarsen)
       : istart_(src.GetStartIndex()) {
     dx_ = src.Dx_();
     xmin_ = src.GetXmin();
@@ -71,27 +72,40 @@ class UniformCartesian {
     area_[0] = dx_[1] * dx_[2];
     area_[1] = dx_[0] * dx_[2];
     area_[2] = dx_[0] * dx_[1];
-    cell_volume_ = dx_[0] * dx_[1] * dx_[2];
-    ndim_ = src.ndim_;
+    nx_[0] = src.nx_[0] / ( coarsen ? 2 : 1 );
+    nx_[1] = src.nx_[1] / ( coarsen ? 2 : 1 );
+    nx_[2] = src.nx_[2] / ( coarsen ? 2 : 1 );
+
+    //Initialized cached coordinates
+    InitCachedArrays();
   }
 
   //----------------------------------------
   // Dxc: Distance between cell centers
+  // Dxc<1> returns distance between cell centroids in r
   //----------------------------------------
   template <int dir>
-  KOKKOS_FORCEINLINE_FUNCTION Real Dxc() const {
+  KOKKOS_FORCEINLINE_FUNCTION Real Dxc(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
-    return dx_[dir - 1];
+    if( dir == X1DIR ){
+      return r_c_(i+1) - r_c_(i);
+    } else {
+      return dx_[dir-1];
+    }
   }
-  template <int dir, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real Dxc(Args... args) const {
+  KOKKOS_FORCEINLINE_FUNCTION Real DxcFA(const int dir, const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
-    return dx_[dir - 1];
-  }
-  template <class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real DxcFA(const int dir, Args... args) const {
-    assert(dir > 0 && dir < 4);
-    return dx_[dir - 1];
+    switch (dir) {
+    case 1:
+      return Dxc<1>(k,j,i);
+    case 2:
+      return Dxc<2>(k,j,j);
+    case 3:
+      return Dxc<3>(k,j,k);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
   }
 
   //----------------------------------------
@@ -109,12 +123,17 @@ class UniformCartesian {
   }
 
   //----------------------------------------
-  // Xf: Positions at cell centers
+  // Xc: Positions at cell centers
+  // Xc<1> returns r of cell centroid
   //----------------------------------------
   template <int dir>
   KOKKOS_FORCEINLINE_FUNCTION Real Xc(const int idx) const {
     assert(dir > 0 && dir < 4);
-    return xmin_[dir - 1] + (idx + 0.5) * dx_[dir - 1];
+    if( dir == X1DIR ){
+      return r_c_(idx);
+    } else {
+      return xmin_[dir - 1] + (idx + 0.5) * dx_[dir - 1];
+    }
   }
   template <int dir>
   KOKKOS_FORCEINLINE_FUNCTION Real Xc(const int k, const int j, const int i) const {
@@ -218,74 +237,104 @@ class UniformCartesian {
   }
 
   //----------------------------------------
-  // CellWidth: Width of cells at cell centers
+  // CellWidth: Physical width of cells at cell centers
   //----------------------------------------
-  template <int dir, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real CellWidth(Args... args) const {
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real CellWidth(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
-    return dx_[dir - 1];
+    if( dir == X2DIR ){
+      return Xf<1>(k, j, i)*dx_[1]; //r*dphi
+    } else {
+      return dx_[dir-1];
+    }
   }
-  template <class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real CellWidthFA(const int dir, Args... args) const {
+  KOKKOS_FORCEINLINE_FUNCTION Real CellWidthFA(const int dir,const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
-    return dx_[dir - 1];
-  }
-
-  //----------------------------------------
-  // EdgeLength: Length of cell edges
-  //----------------------------------------
-  template <int dir, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real EdgeLength(Args... args) const {
-    assert(dir > 0 && dir < 4);
-    return CellWidth<dir>();
-  }
-  template <class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real EdgeLengthFA(const int dir, Args... args) const {
-    return CellWidthFA(dir);
+    if( dir == X2DIR ){
+      return Xf<1>(k, j, i)*dx_[1]; //r*dphi
+    } else {
+      return dx_[dir-1];
+    }
   }
 
   //----------------------------------------
-  // FaceArea: Area of cell areas
+  // EdgeLength: Physical length of cell edges
+  //----------------------------------------
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real EdgeLength(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    if( dir == X2DIR ){
+      return Xf<1>(k, j, i)*dx_[1]; //r*dphi
+    } else {
+      return dx_[dir-1];
+    }
+  }
+  KOKKOS_FORCEINLINE_FUNCTION Real EdgeLengthFA(const int dir, const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    if( dir == X2DIR ){
+      return Xf<1>(k, j, i)*dx_[1]; //r*dphi
+    } else {
+      return dx_[dir-1];
+    }
+  }
+
+  //----------------------------------------
+  // FaceArea: Physical area of cell areas
   //----------------------------------------
   template <int dir, class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real FaceArea(Args... args) const {
+  KOKKOS_FORCEINLINE_FUNCTION Real FaceArea(const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
-    return area_[dir - 1];
+    switch(dir) {
+      case X1DIR:
+        return X<dir, TE::F1>(i)*area_[0]; //r*dphi*dz
+      case X2DIR:
+        return area_[1]; //dr*dz
+      case X3DIR:
+        return coord_vol_i_(i)*dx_[1]; //d(r^2/2)*dphi
+    }
+
   }
   template <class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real FaceAreaFA(const int dir, Args... args) const {
+  KOKKOS_FORCEINLINE_FUNCTION Real FaceAreaFA(const int dir, const int k, const int j, const int i) const {
     assert(dir > 0 && dir < 4);
-    return area_[dir - 1];
+    switch(dir) {
+      case X1DIR:
+        return X<1, TE::F1>(i)*area_[0]; //r*dphi*dz
+      case X2DIR:
+        return area_[1]; //dr*dz
+      case X3DIR:
+        return coord_vol_i_(i)*dx_[1]; //d(r^2/2)*dphi
+    }
   }
 
   //----------------------------------------
   // CellVolume
   //----------------------------------------
   template <class... Args>
-  KOKKOS_FORCEINLINE_FUNCTION Real CellVolume(Args... args) const {
-    return cell_volume_;
+  KOKKOS_FORCEINLINE_FUNCTION Real CellVolume(const int k, const int j, const int i) const {
+    return coord_vol_i_(i)*area_[0];
   }
 
   //----------------------------------------
-  // Generalized volume
+  // Generalized physical volume
   //----------------------------------------
   template <TopologicalElement el, class... Args>
   KOKKOS_FORCEINLINE_FUNCTION Real Volume(Args... args) const {
     using TE = TopologicalElement;
     if constexpr (el == TE::CC) {
-      return cell_volume_;
+      return CellVolume(args...);
     } else if constexpr (el == TE::F1) {
-      return area_[X1DIR - 1];
+      return FaceArea<X1DIR>(args...);
     } else if constexpr (el == TE::F2) {
-      return area_[X2DIR - 1];
+      return FaceArea<X2DIR>(args...);
     } else if constexpr (el == TE::F3) {
-      return area_[X3DIR - 1];
+      return FaceArea<X3DIR>(args...);
     } else if constexpr (el == TE::E1) {
-      return dx_[X1DIR - 1];
+      return EdgeLength<X1DIR>(args...);
     } else if constexpr (el == TE::E2) {
-      return dx_[X2DIR - 1];
+      return EdgeLength<X2DIR>(args...);
     } else if constexpr (el == TE::E3) {
-      return dx_[X3DIR - 1];
+      return EdgeLength<X3DIR>(args...);
     } else if constexpr (el == TE::NN) {
       return 1.0;
     }
@@ -300,43 +349,123 @@ class UniformCartesian {
   // TODO
 
   //----------------------------------------
-  // h*v, h*f, dh*vd*, etc.
-  // These might only be needed for viscocity and conduction and so might exist downstream
+  // Geometric Terms (Find better names for these!)
   //----------------------------------------
-  // TODO
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h2v(const int i) const { return r_c_(i); };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h2f(const int i) const { return Xf<1>(i); };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h31v(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h31f(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh2vd1(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh2fd1(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh31vd1(const int i) const { return 0.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh31fd1(const int i) const { return 0.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h32v(const int j) const { return 1.0; }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h32f(const int j) const { return 1.0; }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh32vd2(const int j) const { return 0.0; }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh32fd2(const int j) const { return 0.0; }
+
+  //What is this?
+  KOKKOS_FORCEINLINE_FUNCTION
+  void GetAcc(const int k, const int j, const int i, const Real &rp,
+	      const Real &cosphip, const Real &sinphip, const Real &zp,
+	      Real &acc1, Real &acc2, Real &acc3) const
+  {
+    const Real cosdphi = cosphi_c_(j)*cosphip - sinphi_c_(j)*sinphip; //cos(x3v(k)-phip)
+    const Real sindphi = sinphi_c_(j)*cosphip - cosphi_c_(j)*sinphip; //sin(x3v(k)-phip)
+    //Psi = - 1.0/sqrt(r0^2 + rp^2 - 2r0*rp*cos(phi-phip) + (z-zp)^2)
+    acc1 = (r_c_(i) - rp*cosdphi); //acc1 = dPsi/dr, Psi=-1/dist2
+    acc2 = rp*sindphi;        //acc2 = dPsi/(r*dphi) 
+    acc3 = Xc<3>(k)-zp;   
+  }
 
   //----------------------------------------
   // Position to Cell index
   //----------------------------------------
   KOKKOS_INLINE_FUNCTION
-  void Xtoijk(const Real &x, const Real &y, const Real &z, int &i, int &j, int &k) const {
-    i = static_cast<int>(
-            std::floor((x - xmin_[0]) / dx_[0])) +
-        istart_[0];
-    j = (ndim_ > 1) ? static_cast<int>(std::floor(
-                          (y - xmin_[1]) / dx_[1])) +
-                          istart_[1]
-                    : istart_[1];
-    k = (ndim_ > 2) ? static_cast<int>(std::floor(
-                          (z - xmin_[2]) / dx_[2])) +
-                          istart_[2]
-                    : istart_[2];
+  void Xtoijk(const Real &r, const Real &theta, const Real &z, int &i, int &j, int &k) const {
+    i = (nx_[0] != 1) ? static_cast<int>(
+        std::floor((r - xmin_[0]) / dx_[0])) +
+      istart_[0] : istart_[0] ;
+    j = (nx_[1] != 1) ? static_cast<int>(std::floor(
+          (theta - xmin_[1]) / dx_[1])) +
+      istart_[1]
+      : istart_[1];
+    k = (nx_[2] != 1)? static_cast<int>(std::floor(
+          (z - xmin_[2]) / dx_[2])) +
+      istart_[2]
+      : istart_[2];
   }
 
   const std::array<Real, 3> &GetXmin() const { return xmin_; }
   const std::array<int, 3> &GetStartIndex() const { return istart_; }
   const char *Name() const { return name_; }
 
- private:
+ //private:
   std::array<int, 3> istart_;
-  std::array<Real, 3> xmin_, dx_, area_;
-  int ndim_;
-  Real cell_volume_;
-  constexpr static const char *name_ = "UniformCartesian";
+  std::array<Real, 3> xmin_, dx_, area_, nx_;
+  constexpr static const char *name_ = "UniformCylindrical";
 
   const std::array<Real, 3> &Dx_() const { return dx_; }
+
+  ParArrayND<Real> r_c_, coord_vol_i_, cosphi_c_, sinphi_c_;
+
+  void InitCachedArrays() {
+    int nx1_tot = nx_[0]+2*Globals::nghost+1;
+    r_c_ = ParArrayND<Real>("r_c_", nx1_tot-1);
+    coord_vol_i_ = ParArrayND<Real>("", nx1_tot-1);
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "UniformCylindrical::InitCachedArrays(r)", 
+      parthenon::DevExecSpace(), 0, nx1_tot-2,
+      KOKKOS_LAMBDA(const int &i) {
+      Real rm = xmin_[0] + i * dx_[0];
+      Real rp = xmin_[0] + (i+1) * dx_[0];
+      r_c_(i) = TWO_3RD*(rp*rp*rp - rm*rm*rm)/(SQR(rp) - SQR(rm));
+      coord_vol_i_(i) = 0.5*(rp*rp - rm*rm);
+      });
+    int nx2_tot = nx_[1]+1;
+
+    if (istart_[1] > 0) {
+      nx2_tot += 2*Globals::nghost;
+    }
+    sinphi_c_ = ParArrayND<Real>("sin(phi_c)", nx2_tot-1);
+    cosphi_c_ = ParArrayND<Real>("cos(phi_c)", nx2_tot-1);
+
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "UniformCylindrical::InitCachedArrays(phi)", 
+      parthenon::DevExecSpace(), 0, nx2_tot-2,
+      KOKKOS_LAMBDA(const int &j) {
+      Real Phi = xmin_[1] + (j + 0.5) * dx_[1];
+      cosphi_c_(j) = std::cos(Phi);
+      sinphi_c_(j) = std::sin(Phi);
+      });
+  }
+
 };
+
 
 } // namespace parthenon
 
-#endif // COORDINATES_UNIFORM_CARTESIAN_HPP_
+#endif // COORDINATES_UNIFORM_CYLINDRICAL_HPP_

--- a/src/coordinates/uniform_spherical.hpp
+++ b/src/coordinates/uniform_spherical.hpp
@@ -540,7 +540,9 @@ class UniformSpherical {
     return Dxf<X1DIR,X1DIR>(i)/( (rm + rp)*Coord_vol_i_(i));
   }
 
+  KOKKOS_INLINE_FUNCTION
   const std::array<Real, 3> &GetXmin() const { return xmin_; }
+  KOKKOS_INLINE_FUNCTION
   const std::array<int, 3> &GetStartIndex() const { return istart_; }
   const char *Name() const { return name_; }
 

--- a/src/coordinates/uniform_spherical.hpp
+++ b/src/coordinates/uniform_spherical.hpp
@@ -519,6 +519,27 @@ class UniformSpherical {
       : istart_[2];
   }
 
+  //----------------------------------------
+  // Terms for Source Terms
+  //----------------------------------------
+
+  KOKKOS_INLINE_FUNCTION Real Coord_vol_i_(const int i) const {
+    const Real rm = Xf<X1DIR>(i);
+    const Real rp = Xf<X1DIR>(i+1);
+    return ONE_3RD*( std::pow(rp,3) - std::pow(rm,3));
+  }
+
+  KOKKOS_INLINE_FUNCTION Real CoordSrc1i(const int i) const {
+    const Real rm = Xf<X1DIR>(i);
+    const Real rp = Xf<X1DIR>(i+1);
+    return 0.5*(SQR(rp) - SQR(rm))/Coord_vol_i_(i);
+  }
+  KOKKOS_INLINE_FUNCTION Real CoordSrc2i(const int i) const {
+    const Real rm = Xf<X1DIR>(i);
+    const Real rp = Xf<X1DIR>(i+1);
+    return Dxf<X1DIR,X1DIR>(i)/( (rm + rp)*Coord_vol_i_(i));
+  }
+
   const std::array<Real, 3> &GetXmin() const { return xmin_; }
   const std::array<int, 3> &GetStartIndex() const { return istart_; }
   const char *Name() const { return name_; }
@@ -545,25 +566,6 @@ class UniformSpherical {
       const Real rm = xmin_[0] + i * dx_[0];
       const Real rp = rm + dx_[0];
       return TWO_3RD*(std::pow(rp,3) - std::pow(rm,3))/(SQR(rp) - SQR(rm));
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  Real Coord_vol_i_(const int i) const {
-      const Real rm = xmin_[0] + i * dx_[0];
-      const Real rp = rm + dx_[0];
-      return  (ONE_3RD)*(rp*rp*rp - rm*rm*rm);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  Real Coord_area2_i_(const int i) const {
-      const Real rm = xmin_[0] + i * dx_[0];
-      const Real rp = rm + dx_[0];
-      return  (ONE_3RD)*(rp*rp*rp - rm*rm*rm);
-  }
-
-  KOKKOS_INLINE_FUNCTION
-  Real Coord_area1_j_(const int j) const {
-       return std::abs( Cos_theta_f_(j) - Cos_theta_f_(j+1));
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/src/coordinates/uniform_spherical.hpp
+++ b/src/coordinates/uniform_spherical.hpp
@@ -1,0 +1,561 @@
+//========================================================================================
+// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#ifndef COORDINATES_UNIFORM_SPHERICAL_HPP_
+#define COORDINATES_UNIFORM_SPHERICAL_HPP_
+
+#include <array>
+#include <cassert>
+
+#include "basic_types.hpp"
+#include "defs.hpp"
+#include "globals.hpp"
+#include "parameter_input.hpp"
+
+#include <Kokkos_Macros.hpp>
+
+namespace parthenon {
+
+class UniformSpherical {
+ public:
+  UniformSpherical() = default;
+  UniformSpherical(const RegionSize &rs, ParameterInput *pin) {
+    dx_[0] = (rs.x1max - rs.x1min) / rs.nx1;
+    dx_[1] = (rs.x2max - rs.x2min) / rs.nx2;
+    dx_[2] = (rs.x3max - rs.x3min) / rs.nx3;
+    area_[0] = dx_[1] * dx_[2];
+    area_[1] = dx_[0] * dx_[2];
+    area_[2] = dx_[0] * dx_[1];
+    istart_[0] = Globals::nghost;
+    istart_[1] = (rs.nx2 > 1 ? Globals::nghost : 0);
+    istart_[2] = (rs.nx3 > 1 ? Globals::nghost : 0);
+    xmin_[0] = rs.x1min - istart_[0] * dx_[0];
+    xmin_[1] = rs.x2min - istart_[1] * dx_[1];
+    xmin_[2] = rs.x3min - istart_[2] * dx_[2];
+
+    std::string coord_type_str = pin->GetOrAddString("parthenon/mesh", "coord", "cartesian");
+    //REMOVE ME
+    //if (coord_type_str == "cartesian") {
+    //  coord_type = parthenon::uniformOrthMesh::cartesian;
+    //} else 
+    if( coord_type_str != "spherical" ){
+      if (coord_type_str == "cartesian") {
+        PARTHENON_THROW(" Please rebuild with -DCOORDINATE_TYPE=UniformCartesian");
+      } else if (coord_type_str == "cylindrical") {
+        PARTHENON_THROW(" Please rebuild with -DCOORDINATE_TYPE=UniformCylindrical");
+      } else {
+        PARTHENON_THROW("Invalid coord input in <parthenon/mesh>.");
+      }
+    }
+
+    //Initialized cached coordinates
+    InitCachedArrays();
+  }
+  UniformSpherical(const UniformSpherical &src, int coarsen)
+      : istart_(src.GetStartIndex()) {
+    dx_ = src.Dx_();
+    xmin_ = src.GetXmin();
+    xmin_[0] += istart_[0] * dx_[0] * (1 - coarsen);
+    xmin_[1] += istart_[1] * dx_[1] * (1 - coarsen);
+    xmin_[2] += istart_[2] * dx_[2] * (1 - coarsen);
+    dx_[0] *= coarsen;
+    dx_[1] *= (istart_[1] > 0 ? coarsen : 1);
+    dx_[2] *= (istart_[2] > 0 ? coarsen : 1);
+    area_[0] = dx_[1] * dx_[2];
+    area_[1] = dx_[0] * dx_[2];
+    area_[2] = dx_[0] * dx_[1];
+
+    //Initialized cached coordinates
+    InitCachedArrays();
+  }
+
+  //----------------------------------------
+  // Dxc: Distance between cell centers
+  // Dxc<1> and Dxc<2> returns distance between cell centroids
+  //----------------------------------------
+  template <int dir, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real Dxc(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir){
+      case X1DIR:
+        return r_c_(i+1) - r_c_(i);
+      case X2DIR:
+        return theta_c_(j+1) - theta_c_(j);
+      default:
+        return dx_[2];
+    }
+  }
+  template <class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real DxcFA(const int dir, const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir){
+      case X1DIR:
+        return r_c_(i+1) - r_c_(i);
+      case X2DIR:
+        return theta_c_(j+1) - theta_c_(j);
+      default:
+        return dx_[2];
+    }
+  }
+
+  //----------------------------------------
+  // Dxf: Distance between cell faces
+  //----------------------------------------
+  template <int dir, int face, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real Dxf(Args... args) const {
+    assert(dir > 0 && dir < 4 && face > 0 && face < 4);
+    //(forrestglines): Double check how dir and face are used
+    return dx_[face - 1];
+  }
+  template <int dir, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real Dxf(Args... args) const {
+    assert(dir > 0 && dir < 4);
+    return dx_[dir - 1];
+  }
+
+  //----------------------------------------
+  // Xc: Positions at cell centers
+  // Xc<1> returns r of cell centroid
+  //----------------------------------------
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xc(const int idx) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case 1:
+      return r_c_(idx);
+    case 2:
+      return theta_c_(idx);
+    case 3:
+      return xmin_[dir - 1] + (idx + 0.5) * dx_[dir - 1];
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xc(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case 1:
+      return Xc<dir>(i);
+    case 2:
+      return Xc<dir>(j);
+    case 3:
+      return Xc<dir>(k);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+
+  //----------------------------------------
+  // Xf: Positions on Faces
+  //----------------------------------------
+  template <int dir, int face>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int idx) const {
+    assert(dir > 0 && dir < 4 && face > 0 && face < 4);
+    // Return position in direction "dir" along index "idx" on face "face"
+    if constexpr (dir == face) {
+      return xmin_[dir - 1] + idx * dx_[dir - 1];
+    } else {
+      return Xc<dir>(idx);
+    }
+  }
+  template <int dir, int face>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case 1:
+      return Xf<dir, face>(i);
+    case 2:
+      return Xf<dir, face>(j);
+    case 3:
+      return Xf<dir, face>(k);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int idx) const {
+    assert(dir > 0 && dir < 4);
+    // Return position in direction "dir" along index "idx" on face "dir"
+    return xmin_[dir - 1] + idx * dx_[dir - 1];
+  }
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real Xf(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case 1:
+      return Xf<dir>(i);
+    case 2:
+      return Xf<dir>(j);
+    case 3:
+      return Xf<dir>(k);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+
+  template <int dir, TopologicalElement el>
+  KOKKOS_FORCEINLINE_FUNCTION Real X(const int idx) const {
+    using TE = TopologicalElement;
+    bool constexpr X1EDGE = el == TE::F1 || el == TE::E2 || el == TE::E3 || el == TE::NN;
+    bool constexpr X2EDGE = el == TE::F2 || el == TE::E3 || el == TE::E1 || el == TE::NN;
+    bool constexpr X3EDGE = el == TE::F3 || el == TE::E1 || el == TE::E2 || el == TE::NN;
+    if constexpr (dir == X1DIR && X1EDGE) {
+      return xmin_[dir - 1] + idx * dx_[dir - 1]; // idx - 1/2
+    } else if constexpr (dir == X2DIR && X2EDGE) {
+      return xmin_[dir - 1] + idx * dx_[dir - 1]; // idx - 1/2
+    } else if constexpr (dir == X3DIR && X3EDGE) {
+      return xmin_[dir - 1] + idx * dx_[dir - 1]; // idx - 1/2
+    } else {
+      return xmin_[dir - 1] + (idx + 0.5) * dx_[dir - 1]; // idx
+    }
+    return 0; // This should never be reached, but w/o it some compilers generate warnings
+  }
+
+  template <int dir, TopologicalElement el>
+  KOKKOS_FORCEINLINE_FUNCTION Real X(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch (dir) {
+    case 1:
+      return X<dir, el>(i);
+    case 2:
+      return X<dir, el>(j);
+    case 3:
+      return X<dir, el>(k);
+    default:
+      PARTHENON_FAIL("Unknown dir");
+      return 0; // To appease compiler
+    }
+  }
+
+  //----------------------------------------
+  // CellWidth: Physical width of cells at cell centers
+  //----------------------------------------
+  template <int dir, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real CellWidth(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir){
+      case X1DIR:
+        return Dxf<1>(k,j,i);
+      case X2DIR:
+        return Xc<1>(k,j,i)*Dxf<2>(k,j,i);//r*dphi;
+      case X3DIR:
+        return Xc<1>(k,j,i)*sintht_c_(j)*Dxf<3>(k,j,i); //r*sin(th)*dphi
+      default:
+        PARTHENON_FAIL("Unknown dir");
+        return 0; // To appease compiler
+    }
+  }
+  KOKKOS_FORCEINLINE_FUNCTION Real CellWidthFA(const int dir, const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    if( dir == X2DIR ){
+      return Xf<1>( k, j, i)*dx_[1]; //r*dphi
+    } else {
+      return dx_[dir-1];
+    }
+  }
+
+  //----------------------------------------
+  // EdgeLength: Physical length of cell edges
+  //----------------------------------------
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real EdgeLength(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir){
+      case X1DIR:
+        return Dxf<1>(k,j,i);
+      case X2DIR:
+        return Xf<1>(k,j,i)*Dxf<2>(k,j,i);//r*dphi;
+      case X3DIR:
+        return Xf<1>(k,j,i)*sintht_f_(j)*Dxf<3>(k,j,i); //r*sin(th)*dphi
+      default:
+        PARTHENON_FAIL("Unknown dir");
+        return 0; // To appease compiler
+    }
+  }
+  KOKKOS_FORCEINLINE_FUNCTION Real EdgeLengthFA(const int dir, const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir){
+      case X1DIR:
+        return EdgeLength<X1DIR>(k, j, i);
+      case X2DIR:
+        return EdgeLength<X2DIR>(k, j, i);
+      case X3DIR:
+        return EdgeLength<X3DIR>(k, j, i);
+      default:
+        PARTHENON_FAIL("Unknown dir");
+        return 0; // To appease compiler
+    }
+  }
+
+  //----------------------------------------
+  // FaceArea: Physical area of cell areas
+  //----------------------------------------
+  //(How is this different from Area(dir, k, j, i)?
+  template <int dir>
+  KOKKOS_FORCEINLINE_FUNCTION Real FaceArea(const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir) {
+      case X1DIR:
+        return (Xf<1>(i)*Xf<1>(i)*(costht_f_(j)-costht_f_(j+1))*dx_[2]); //r^2*d[-cos(tht)]*dph
+      case X2DIR:
+        return (coord_area2_i_(i)*sintht_f_(j)*dx_[2]);//rdr*sin(th)*dph
+      case X3DIR:
+        return (coord_area2_i_(i)*dx_[1]); //d(r^2/2)*dtheta;
+    }
+
+  }
+  KOKKOS_FORCEINLINE_FUNCTION Real FaceAreaFA(const int dir, const int k, const int j, const int i) const {
+    assert(dir > 0 && dir < 4);
+    switch(dir){
+      case X1DIR:
+        return FaceArea<X1DIR>(k, j, i);
+      case X2DIR:
+        return FaceArea<X2DIR>(k, j, i);
+      case X3DIR:
+        return FaceArea<X3DIR>(k, j, i);
+      default:
+        PARTHENON_FAIL("Unknown dir");
+        return 0; // To appease compiler
+    }
+  }
+
+  //----------------------------------------
+  // CellVolume
+  //----------------------------------------
+  template <class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real CellVolume(const int k, const int j, const int i) const {
+    return (coord_vol_i_(i)*coord_area1_j_(j)*dx_[2]);
+  }
+
+  //----------------------------------------
+  // Generalized physical volume
+  //----------------------------------------
+  template <TopologicalElement el, class... Args>
+  KOKKOS_FORCEINLINE_FUNCTION Real Volume(Args... args) const {
+    using TE = TopologicalElement;
+    if constexpr (el == TE::CC) {
+      return CellVolume(args...);
+    } else if constexpr (el == TE::F1) {
+      return FaceArea<X1DIR>(args...);
+    } else if constexpr (el == TE::F2) {
+      return FaceArea<X2DIR>(args...);
+    } else if constexpr (el == TE::F3) {
+      return FaceArea<X3DIR>(args...);
+    } else if constexpr (el == TE::E1) {
+      return EdgeLength<X1DIR>(args...);
+    } else if constexpr (el == TE::E2) {
+      return EdgeLength<X2DIR>(args...);
+    } else if constexpr (el == TE::E3) {
+      return EdgeLength<X3DIR>(args...);
+    } else if constexpr (el == TE::NN) {
+      return 1.0;
+    }
+    PARTHENON_FAIL("If you reach this point, someone has added a new value to the the "
+                   "TopologicalElement enum.");
+    return 0.0;
+  }
+
+  //----------------------------------------
+  // Cylindrical+Spherical Conversions
+  //----------------------------------------
+  // TODO
+
+  //----------------------------------------
+  // Area Averaged Positions (for CT MHD?) AMR
+  //----------------------------------------
+  // TODO
+  // x1s2
+  // x1s3
+  // x2s1
+  // etc.
+
+  //----------------------------------------
+  // Coordinate source terms?
+  //----------------------------------------
+  // TODO
+  // coord_src1_i
+  // coord_src2_i
+  // coord_area1_j
+  // coord_area2_j
+
+  //----------------------------------------
+  // Geometric Terms (Find better names for these!)
+  //----------------------------------------
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h2v(const int i) const { return r_c_(i); };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h2f(const int i) const { return Xf<1>(i); };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h31v(const int i) const { return r_c_(i); };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h31f(const int i) const { return Xf<1>(i); };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh2vd1(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh2fd1(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh31vd1(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh31fd1(const int i) const { return 1.0; };
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h32v(const int j) const { return sintht_c_(j); }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real h32f(const int j) const { return sintht_f_(j); }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh32vd2(const int j) const { return costht_c_(j); }
+
+  KOKKOS_FORCEINLINE_FUNCTION
+  Real dh32fd2(const int j) const { return costht_f_(j); }
+
+  //What is this?
+  KOKKOS_FORCEINLINE_FUNCTION
+  void GetAcc(const int k, const int j, const int i, const Real &rp,
+	      const Real &cosphip, const Real &sinphip, const Real &zp,
+	      Real &acc1, Real &acc2, Real &acc3) const
+  {
+    const Real cosdphi = cosphi_c_(j)*cosphip - sinphi_c_(j)*sinphip; //cos(x3v(k)-phip)
+    const Real sindphi = sinphi_c_(j)*cosphip - cosphi_c_(j)*sinphip; //sin(x3v(k)-phip)
+    //Psi = - 1.0/sqrt(r0^2 + rp^2 - 2r0*rp*sin(tht)cos(phi-phip) + zp^2- 2*r0*cos(tht)*zp
+    acc1 = (r_c_(i) - rp*sintht_c_(j)*cosdphi - costht_c_(j)*zp); //dPsi/dr0
+    acc2 = (-rp*costht_c_(j)*cosdphi + sintht_c_(j)*zp); //dPsi/(r0*dtht)
+    acc3 = (rp*sindphi);  //dPsi/(r0*sintht*dphi)
+  }
+
+  //----------------------------------------
+  // Position to Cell index
+  //----------------------------------------
+  KOKKOS_INLINE_FUNCTION
+  void Xtoijk(const Real &r, const Real &theta, const Real &phi, int &i, int &j, int &k) const {
+    i = (nx_[0] != 1) ? static_cast<int>(
+        std::floor((r - xmin_[0]) / dx_[0])) +
+      istart_[0] : istart_[0];
+    j = (nx_[1] != 1) ? static_cast<int>(std::floor(
+          (theta - xmin_[1]) / dx_[1])) +
+      istart_[1]
+      : istart_[1];
+    k = (nx_[2] != 1)? static_cast<int>(std::floor(
+          (phi - xmin_[2]) / dx_[2])) +
+      istart_[2]
+      : istart_[2];
+  }
+
+  const std::array<Real, 3> &GetXmin() const { return xmin_; }
+  const std::array<int, 3> &GetStartIndex() const { return istart_; }
+  const char *Name() const { return name_; }
+
+ //private:
+  std::array<int, 3> istart_, nx_;
+  std::array<Real, 3> xmin_, dx_, area_;
+  constexpr static const char *name_ = "UniformCylindrical";
+
+  const std::array<Real, 3> &Dx_() const { return dx_; }
+
+  ParArrayND<Real> r_c_, theta_c_, x1s2_, coord_vol_i_, coord_area2_i_, costht_f_, sintht_f_, sintht_c_, costht_c_, coord_area1_j_, cosphi_c_, sinphi_c_;
+  void InitCachedArrays() {
+    int nx1_tot = nx_[0]+2*Globals::nghost+1;
+    r_c_ = ParArrayND<Real>("centroid(r)", nx1_tot-1);
+    x1s2_ = ParArrayND<Real>("area1(r)", nx1_tot-1);
+    coord_vol_i_ = ParArrayND<Real>("volume(r)", nx1_tot-1);
+    coord_area2_i_ = ParArrayND<Real>("area2(r)", nx1_tot-1);
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "initializeArraySph_r", 
+      parthenon::DevExecSpace(), 0, nx1_tot-2,
+      KOKKOS_LAMBDA(const int &i) {
+  //for (int i = 0; i < nx1_tot-1; i++) {
+      Real rm = xmin_[0] + i * dx_[0];
+      Real rp = rm + dx_[0];
+      r_c_(i) = 0.75*(std::pow(rp, 4) - std::pow(rm, 4)) /
+  (std::pow(rp, 3) - std::pow(rm, 3));
+      x1s2_(i) = TWO_3RD*(std::pow(rp,3) - std::pow(rm,3))/(SQR(rp) - SQR(rm));
+      coord_vol_i_(i) = (ONE_3RD)*(rp*rp*rp - rm*rm*rm);
+      coord_area2_i_(i) = 0.5*(rp*rp - rm*rm);
+      });
+
+    int nx2_tot = nx_[1]+1;
+    if (istart_[1] > 0) {
+      nx2_tot += 2*Globals::nghost;
+    }
+    costht_f_ = ParArrayND<Real>("cos(theta_f)", nx2_tot);
+    sintht_f_ = ParArrayND<Real>("sin(theta_f)", nx2_tot);
+    sintht_c_ = ParArrayND<Real>("sin(theta_c)", nx2_tot-1);
+    costht_c_ = ParArrayND<Real>("cos(theta_c)", nx2_tot-1);
+    coord_area1_j_ = ParArrayND<Real>("dcos(theta)", nx2_tot-1);
+    theta_c_     = ParArrayND<Real>("centroid-theta", std::max(2,nx2_tot-1));
+
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "initializeArraySph_th1", 
+      parthenon::DevExecSpace(), 0, nx2_tot-1,
+      KOKKOS_LAMBDA(const int &j) {
+  //for (int j = 0; j < nx2_tot; j++) {
+      Real theta = xmin_[1] + j * dx_[1];
+      costht_f_(j) = std::cos(theta);
+      sintht_f_(j) = std::sin(theta);
+      });
+
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "initializeArraySph_th2", 
+      parthenon::DevExecSpace(), 0, nx2_tot-2,
+      KOKKOS_LAMBDA(const int &j) {
+  //for (int j = 0; j < nx2_tot-1; j++) {
+      coord_area1_j_(j) = std::abs(costht_f_(j  ) - costht_f_(j+1));
+      Real tm = xmin_[1] + j * dx_[1];
+      Real tp = tm + dx_[1];
+      theta_c_(j) = (((sintht_f_(j+1) - tp*costht_f_(j+1)) -
+      (sintht_f_(j  ) - tm*costht_f_(j  )))/
+      (costht_f_(j  ) - costht_f_(j+1)));
+      sintht_c_(j) = std::sin(theta_c_(j));
+      costht_c_(j) = std::cos(theta_c_(j));
+      });
+
+    if (nx2_tot==2) {
+      theta_c_(1) = theta_c_(0) + dx_[1];
+    }
+
+    //phi-direction
+    int nx3_tot = nx_[2]+1;
+    if (istart_[2] > 0) {
+      nx3_tot += 2*Globals::nghost;
+    }
+    sinphi_c_ = ParArrayND<Real>("sin(phi_c)", nx3_tot-1);
+    cosphi_c_ = ParArrayND<Real>("cos(phi_c)", nx3_tot-1);
+    parthenon::par_for(
+      parthenon::loop_pattern_flatrange_tag, "initializeArraySph_ph", 
+      parthenon::DevExecSpace(), 0, nx3_tot-2,
+      KOKKOS_LAMBDA(const int &k) {
+  //for (int k = 0; k < nx3_tot-1; k++) {
+      Real Phi = xmin_[2] + (k + 0.5) * dx_[2];
+      cosphi_c_(k) = std::cos(Phi);
+      sinphi_c_(k) = std::sin(Phi);
+      });
+  }
+
+};
+
+} // namespace parthenon
+
+#endif // COORDINATES_UNIFORM_SPHERICAL_HPP_

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -86,17 +86,7 @@ class SwarmDeviceContext {
   // TODO(BRR) This logic will change for non-uniform cartesian meshes
   KOKKOS_INLINE_FUNCTION
   void Xtoijk(const Real &x, const Real &y, const Real &z, int &i, int &j, int &k) const {
-    i = static_cast<int>(
-            std::floor((x - x_min_) / coords_.Dxc<CoordinateDirection::X1DIR>())) +
-        ib_s_;
-    j = (ndim_ > 1) ? static_cast<int>(std::floor(
-                          (y - y_min_) / coords_.Dxc<CoordinateDirection::X2DIR>())) +
-                          jb_s_
-                    : jb_s_;
-    k = (ndim_ > 2) ? static_cast<int>(std::floor(
-                          (z - z_min_) / coords_.Dxc<CoordinateDirection::X3DIR>())) +
-                          kb_s_
-                    : kb_s_;
+    coords_.Xtoijk(x,y,z,i,j,k);
   }
 
   KOKKOS_INLINE_FUNCTION

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -444,11 +444,11 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       local_count[vinfo.tensor_rank + 3] = global_count[vinfo.tensor_rank + 3] = nx1;
 
 #ifndef PARTHENON_DISABLE_HDF5_COMPRESSION
-      if (output_params.hdf5_compression_level > 0) {
+      // if (output_params.hdf5_compression_level > 0) {
         for (int i = ndim - 3; i < ndim; i++) {
           chunk_size[i] = local_count[i];
         }
-      }
+      // }
 #endif
     } else if (vinfo.where == MetadataFlag(Metadata::None)) {
       ndim = vinfo.tensor_rank + 1;
@@ -457,12 +457,12 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       }
 
 #ifndef PARTHENON_DISABLE_HDF5_COMPRESSION
-      if (output_params.hdf5_compression_level > 0) {
+      // if (output_params.hdf5_compression_level > 0) {
         int nchunk_indices = std::min<int>(vinfo.tensor_rank, 3);
         for (int i = ndim - nchunk_indices; i < ndim; i++) {
           chunk_size[i] = alldims[6 - nchunk_indices + i];
         }
-      }
+      // }
 #endif
     } else {
       PARTHENON_THROW("Only Cell and None locations supported!");


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

_Very_  WIP PR to support uniform cylindrical and spherical coordinates in Parthenon. 

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

Many potential AthenaPK users need treatments of spherical and cylindrical coordinates that can preserve angular momentum. Most of the machinery for these coordinates should belong in Parthenon. This PR is an update of Shengtai's work to match changes to Parthenon's coordinate renaming.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
