### PR TITLE
Pack on a subset of blocks in a MeshData object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 931]](https://github.com/parthenon-hpc-lab/parthenon/pull/931) Allow SparsePacks with subsets of blocks
 - [[PR 921]](https://github.com/parthenon-hpc-lab/parthenon/pull/921) Add more flexible ways of adding and using MeshData/MeshBlockData objects to DataCollections
 - [[PR 900]](https://github.com/parthenon-hpc-lab/parthenon/pull/900) Add Morton numbers and expand functionality of LogicalLocation
 - [[PR 902]](https://github.com/parthenon-hpc-lab/parthenon/pull/902) Add ability to output NaNs for de-allocated sparse fields

--- a/doc/sphinx/src/interface/metadata.rst
+++ b/doc/sphinx/src/interface/metadata.rst
@@ -68,7 +68,7 @@ variable in relation to the problem.
    scale with volume.
 -  ``Metadata::Sparse`` implies that the variable is sparse and hence it
    may not be allocated on all blocks.
--  ``Metadata::AllocOnNewBlocks`` forces allocation of a sparse variable
+-  ``Metadata::ForceAllocOnNewBlocks`` forces allocation of a sparse variable
    on any new ``MeshBlock`` that may be created through AMR or load
    balancing.
 

--- a/doc/sphinx/src/interface/metadata.rst
+++ b/doc/sphinx/src/interface/metadata.rst
@@ -68,6 +68,9 @@ variable in relation to the problem.
    scale with volume.
 -  ``Metadata::Sparse`` implies that the variable is sparse and hence it
    may not be allocated on all blocks.
+-  ``Metadata::AllocOnNewBlocks`` forces allocation of a sparse variable
+   on any new ``MeshBlock`` that may be created through AMR or load
+   balancing.
 
 Output
 ------

--- a/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
+++ b/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
@@ -64,16 +64,10 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
 
   // sample number of iterations task
   {
-    const int pack_size = pmesh->DefaultPackSize();
-    auto partitions = partition::ToSizeN(blocks, pack_size);
-    for (int i = 0; i < partitions.size(); i++) {
-      auto md = pmesh->mesh_data.Add("num_iter_partition_" + std::to_string(i));
-      md->Set(partitions[i], "base");
-    }
-
-    TaskRegion &async_region = tc.AddRegion(partitions.size());
-    for (int i = 0; i < partitions.size(); i++) {
-      auto &md = pmesh->mesh_data.Get("num_iter_partition_" + std::to_string(i));
+    const int num_partitions = pmesh->DefaultNumPartitions();
+    TaskRegion &async_region = tc.AddRegion(num_partitions);
+    for (int i = 0; i < num_partitions; i++) {
+      auto &md = pmesh->mesh_data.GetOrAdd("base", i);
       async_region[i].AddTask(none, ComputeNumIter, md, pmesh->packages);
     }
   }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -127,6 +127,7 @@ add_library(parthenon
 
   interface/data_collection.cpp
   interface/data_collection.hpp
+  interface/mesh_data.cpp
   interface/mesh_data.hpp
   interface/meshblock_data.cpp
   interface/meshblock_data.hpp

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -34,17 +34,10 @@ DataCollection<T>::Add(const std::string &name, const std::shared_ptr<T> &src,
     return it->second;
   }
 
-  auto c = std::make_shared<T>();
+  auto c = std::make_shared<T>(name);
   c->Initialize(src.get(), field_names, shallow);
 
   Set(name, c);
-
-  if constexpr (std::is_same<T, MeshData<Real>>::value) {
-    for (int b = 0; b < pmy_mesh_->block_list.size(); b++) {
-      auto &mbd = pmy_mesh_->block_list[b]->meshblock_data;
-      mbd.Set(name, c->GetBlockData(b));
-    }
-  }
 
   return containers_[name];
 }
@@ -73,8 +66,8 @@ DataCollection<MeshData<Real>>::GetOrAdd(const std::string &mbd_label,
     auto partitions = partition::ToSizeN(pmy_mesh_->block_list, pack_size);
     for (auto i = 0; i < partitions.size(); i++) {
       const std::string md_label = mbd_label + "_part-" + std::to_string(i);
-      containers_[md_label] = std::make_shared<MeshData<Real>>();
-      containers_[md_label]->Set(partitions[i], mbd_label);
+      containers_[md_label] = std::make_shared<MeshData<Real>>(mbd_label);
+      containers_[md_label]->Set(partitions[i]);
     }
   }
   return containers_[label];

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -37,7 +37,7 @@ template <typename T>
 class DataCollection {
  public:
   DataCollection() {
-    containers_["base"] = std::make_shared<T>(); // always add "base" container
+    containers_["base"] = std::make_shared<T>("base"); // always add "base" container
     pmy_mesh_ = nullptr;
   }
 

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -10,8 +10,9 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
-#include "mesh/mesh.hpp"
 #include "mesh_data.hpp"
+
+#include "mesh/mesh.hpp"
 
 namespace parthenon {
 

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -1,0 +1,35 @@
+//========================================================================================
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#include "mesh_data.hpp"
+#include "mesh/mesh.hpp"
+
+namespace parthenon {
+
+template <typename T>
+void MeshData<T>::Initialize(const MeshData<T> *src,
+                             const std::vector<std::string> &names, const bool shallow) {
+  if (src == nullptr) {
+    PARTHENON_THROW("src points at null");
+  }
+  pmy_mesh_ = src->GetParentPointer();
+  const int nblocks = src->NumBlocks();
+  block_data_.resize(nblocks);
+  for (int i = 0; i < nblocks; i++) {
+    pmy_mesh_->block_list[i]->meshblock_data.Add(stage_name_, src->GetBlockData(i), names,
+                                                 shallow);
+  }
+}
+
+template class MeshData<Real>;
+
+} // namespace parthenon

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -25,8 +25,8 @@ void MeshData<T>::Initialize(const MeshData<T> *src,
   const int nblocks = src->NumBlocks();
   block_data_.resize(nblocks);
   for (int i = 0; i < nblocks; i++) {
-    pmy_mesh_->block_list[i]->meshblock_data.Add(stage_name_, src->GetBlockData(i), names,
-                                                 shallow);
+    block_data_[i] = pmy_mesh_->block_list[i]->meshblock_data.Add(
+        stage_name_, src->GetBlockData(i), names, shallow);
   }
 }
 

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -10,8 +10,8 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
-#include "mesh_data.hpp"
 #include "mesh/mesh.hpp"
+#include "mesh_data.hpp"
 
 namespace parthenon {
 

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -190,6 +190,7 @@ template <typename T>
 class MeshData {
  public:
   MeshData() = default;
+  explicit MeshData(const std::string &name) : stage_name_(name) {}
 
   const auto &StageName() const { return stage_name_; }
 
@@ -226,29 +227,17 @@ class MeshData {
     }
   }
 
-  void Set(BlockList_t blocks, const std::string &name) {
-    stage_name_ = name;
+  void Set(BlockList_t blocks) {
     const int nblocks = blocks.size();
     block_data_.resize(nblocks);
     SetMeshPointer(blocks[0]->pmy_mesh);
     for (int i = 0; i < nblocks; i++) {
-      block_data_[i] = blocks[i]->meshblock_data.Get(name);
+      block_data_[i] = blocks[i]->meshblock_data.Get(stage_name_);
     }
   }
 
-  template <typename... Args>
-  void Initialize(const MeshData<T> *src, Args &&...args) {
-    if (src == nullptr) {
-      PARTHENON_THROW("src points at null");
-    }
-    pmy_mesh_ = src->GetParentPointer();
-    const int nblocks = src->NumBlocks();
-    block_data_.resize(nblocks);
-    for (int i = 0; i < nblocks; i++) {
-      block_data_[i] = std::make_shared<MeshBlockData<T>>();
-      block_data_[i]->Initialize(src->GetBlockData(i).get(), std::forward<Args>(args)...);
-    }
-  }
+  void Initialize(const MeshData<T> *src, const std::vector<std::string> &names,
+                  const bool shallow);
 
   const std::shared_ptr<MeshBlockData<T>> &GetBlockData(int n) const {
     assert(n >= 0 && n < block_data_.size());

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -273,6 +273,14 @@ class MeshData {
     return all_initialized;
   }
 
+  std::vector<bool> AllocationStatus(const std::string &label) {
+    std::vector<bool> status(NumBlocks());
+    std::transform(
+        block_data_.begin(), block_data_.end(), status.begin(),
+        [&](std::shared_ptr<MeshBlockData<T>> mbd) { return mbd->IsAllocated(label); });
+    return status;
+  }
+
  private:
   template <typename... Args>
   const auto &PackVariablesAndFluxesImpl(PackIndexMap *map_out, Args &&...args) {

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -54,7 +54,7 @@ void MeshBlockData<T>::Initialize(
     AddField(q.first.base_name, q.second, q.first.sparse_id);
   }
 
-  Metadata::FlagCollection flags({Metadata::Sparse, Metadata::AllocOnNewBlocks});
+  Metadata::FlagCollection flags({Metadata::Sparse, Metadata::ForceAllocOnNewBlocks});
   auto vars = GetVariablesByFlag(flags);
   for (auto &v : vars.vars()) {
     AllocateSparse(v->label());

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -53,6 +53,12 @@ void MeshBlockData<T>::Initialize(
   for (auto const &q : resolved_packages->AllFields()) {
     AddField(q.first.base_name, q.second, q.first.sparse_id);
   }
+
+  Metadata::FlagCollection flags({Metadata::Sparse, Metadata::AllocOnNewBlocks});
+  auto vars = GetVariablesByFlag(flags);
+  for (auto &v : vars.vars()) {
+    AllocateSparse(v->label());
+  }
 }
 
 ///

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -58,6 +58,7 @@ class MeshBlockData {
   //-----------------
   /// Constructor
   MeshBlockData<T>() = default;
+  explicit MeshBlockData<T>(const std::string &name) : stage_name_(name) {}
 
   // Constructors for getting sub-containers
   // the variables returned are all shallow copies of the src container.
@@ -463,6 +464,7 @@ class MeshBlockData {
   std::weak_ptr<MeshBlock> pmy_block;
   std::shared_ptr<StateDescriptor> resolved_packages_;
   bool is_shallow_ = false;
+  const std::string stage_name_;
 
   VariableVector<T> varVector_; ///< the saved variable array
   std::map<Uid_t, std::shared_ptr<Variable<T>>> varUidMap_;

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -156,6 +156,7 @@ class MeshBlockData {
   inline bool IsAllocated(std::string const &base_name, int sparse_id) const noexcept {
     return IsAllocated(MakeVarLabel(base_name, sparse_id));
   }
+
 #else
   constexpr inline bool IsAllocated(std::string const & /*label*/) const noexcept {
     return true;
@@ -166,6 +167,10 @@ class MeshBlockData {
     return true;
   }
 #endif
+
+  std::vector<bool> AllocationStatus(const std::string &label) const noexcept {
+    return std::vector<bool>({IsAllocated(label)});
+  }
 
   using VarList = VarListWithKeys<T>;
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -111,7 +111,7 @@
   /** the variable needs to be communicated across ranks during remeshing */             \
   PARTHENON_INTERNAL_FOR_FLAG(ForceRemeshComm)                                           \
   /** the variable must always be allocated for new blocks **/                           \
-  PARTHENON_INTERNAL_FOR_FLAG(AllocOnNewBlocks)
+  PARTHENON_INTERNAL_FOR_FLAG(ForceAllocOnNewBlocks)
 namespace parthenon {
 
 namespace internal {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -109,7 +109,9 @@
   /** does variable have fluxes */                                                       \
   PARTHENON_INTERNAL_FOR_FLAG(WithFluxes)                                                \
   /** the variable needs to be communicated across ranks during remeshing */             \
-  PARTHENON_INTERNAL_FOR_FLAG(ForceRemeshComm)
+  PARTHENON_INTERNAL_FOR_FLAG(ForceRemeshComm)                                           \
+  /** the variable must always be allocated for new blocks **/                           \
+  PARTHENON_INTERNAL_FOR_FLAG(AllocOnNewBlocks)
 namespace parthenon {
 
 namespace internal {

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -131,8 +131,8 @@ class SparsePack : public SparsePackBase {
     // accessed on device via instance of types in the type list Ts...
     // The pack will be created and accessible on the device
     template <class T>
-    SparsePack GetPack(T *pmd) const {
-      return SparsePack(SparsePackBase::GetPack(pmd, *this));
+    SparsePack GetPack(T *pmd, const std::vector<bool> &include_block = {}) const {
+      return SparsePack(SparsePackBase::GetPack(pmd, *this, include_block));
     }
 
     SparsePackIdxMap GetMap() const {

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -49,16 +49,20 @@ void PackDescriptor::Print() const {
 namespace {
 // SFINAE for block iteration so that sparse packs can work for MeshBlockData and MeshData
 template <class T, class F>
-inline auto ForEachBlock(T *pmd, F func) -> decltype(T().GetBlockData(0), void()) {
+inline auto ForEachBlock(T *pmd, const std::vector<bool> &include_block, F func)
+    -> decltype(T().GetBlockData(0), void()) {
   for (int b = 0; b < pmd->NumBlocks(); ++b) {
-    auto &pmbd = pmd->GetBlockData(b);
-    func(b, pmbd.get());
+    if (include_block.size() == 0 || include_block[b]) {
+      auto &pmbd = pmd->GetBlockData(b);
+      func(b, pmbd.get());
+    }
   }
 }
 
 template <class T, class F>
-inline auto ForEachBlock(T *pmbd, F func) -> decltype(T().GetBlockPointer(), void()) {
-  func(0, pmbd);
+inline auto ForEachBlock(T *pmbd, const std::vector<bool> &include_block, F func)
+    -> decltype(T().GetBlockPointer(), void()) {
+  if (include_block.size() == 0 || include_block[0]) func(0, pmbd);
 }
 } // namespace
 
@@ -77,14 +81,15 @@ SparsePackIdxMap SparsePackBase::GetIdxMap(const impl::PackDescriptor &desc) {
 }
 
 template <class T>
-SparsePackBase::alloc_t SparsePackBase::GetAllocStatus(T *pmd,
-                                                       const PackDescriptor &desc) {
+SparsePackBase::alloc_t
+SparsePackBase::GetAllocStatus(T *pmd, const PackDescriptor &desc,
+                               const std::vector<bool> &include_block) {
   using mbd_t = MeshBlockData<Real>;
 
   int nvar = desc.nvar_groups;
 
   std::vector<int> astat;
-  ForEachBlock(pmd, [&](int b, mbd_t *pmbd) {
+  ForEachBlock(pmd, include_block, [&](int b, mbd_t *pmbd) {
     const auto &uid_map = pmbd->GetUidMap();
     for (int i = 0; i < nvar; ++i) {
       for (const auto &[var_name, uid] : desc.var_groups[i]) {
@@ -101,14 +106,15 @@ SparsePackBase::alloc_t SparsePackBase::GetAllocStatus(T *pmd,
 }
 
 // Specialize for the only two types this should work for
+template SparsePackBase::alloc_t SparsePackBase::GetAllocStatus<MeshBlockData<Real>>(
+    MeshBlockData<Real> *, const PackDescriptor &, const std::vector<bool> &);
 template SparsePackBase::alloc_t
-SparsePackBase::GetAllocStatus<MeshBlockData<Real>>(MeshBlockData<Real> *,
-                                                    const PackDescriptor &);
-template SparsePackBase::alloc_t
-SparsePackBase::GetAllocStatus<MeshData<Real>>(MeshData<Real> *, const PackDescriptor &);
+SparsePackBase::GetAllocStatus<MeshData<Real>>(MeshData<Real> *, const PackDescriptor &,
+                                               const std::vector<bool> &);
 
 template <class T>
-SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
+SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
+                                     const std::vector<bool> &include_block) {
   using mbd_t = MeshBlockData<Real>;
   int nvar = desc.nvar_groups;
 
@@ -124,7 +130,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
   int nblocks = 0;
   bool contains_face_or_edge = false;
   int size = 0; // local var used to compute size/block
-  ForEachBlock(pmd, [&](int b, mbd_t *pmbd) {
+  ForEachBlock(pmd, include_block, [&](int b, mbd_t *pmbd) {
     if (!desc.flat) {
       size = 0;
     }
@@ -173,12 +179,13 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
 
   // Fill the views
   int idx = 0;
-  ForEachBlock(pmd, [&](int block, mbd_t *pmbd) {
+  int blidx = 0;
+  ForEachBlock(pmd, include_block, [&](int block, mbd_t *pmbd) {
     int b = 0;
     const auto &uid_map = pmbd->GetUidMap();
     if (!desc.flat) {
       idx = 0;
-      b = block;
+      b = blidx;
       // JMM: This line could be unified with the coords_h line below,
       // but it would imply unnecessary copies in the case of non-flat
       // packs.
@@ -186,7 +193,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
     }
 
     for (int i = 0; i < nvar; ++i) {
-      pack.bounds_h_(0, block, i) = idx;
+      pack.bounds_h_(0, blidx, i) = idx;
       for (const auto &[var_name, uid] : desc.var_groups[i]) {
         if (uid_map.count(uid) > 0) {
           const auto pv = uid_map.at(uid);
@@ -239,16 +246,17 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
           }
         }
       }
-      pack.bounds_h_(1, block, i) = idx - 1;
-      if (pack.bounds_h_(1, block, i) < pack.bounds_h_(0, block, i)) {
+      pack.bounds_h_(1, blidx, i) = idx - 1;
+      if (pack.bounds_h_(1, blidx, i) < pack.bounds_h_(0, blidx, i)) {
         // Did not find any allocated variables meeting our criteria
-        pack.bounds_h_(0, block, i) = -1;
+        pack.bounds_h_(0, blidx, i) = -1;
         // Make the upper bound more negative so a for loop won't iterate once
-        pack.bounds_h_(1, block, i) = -2;
+        pack.bounds_h_(1, blidx, i) = -2;
       }
     }
     // Record the maximum for easy access
-    pack.bounds_h_(1, block, nvar) = idx - 1;
+    pack.bounds_h_(1, blidx, nvar) = idx - 1;
+    blidx++;
   });
   Kokkos::deep_copy(pack.pack_, pack_h);
   Kokkos::deep_copy(pack.bounds_, pack.bounds_h_);
@@ -259,47 +267,57 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc) {
 
 // Specialize for the only two types this should work for
 template SparsePackBase
-SparsePackBase::Build<MeshBlockData<Real>>(MeshBlockData<Real> *, const PackDescriptor &);
+SparsePackBase::Build<MeshBlockData<Real>>(MeshBlockData<Real> *, const PackDescriptor &,
+                                           const std::vector<bool> &);
 template SparsePackBase SparsePackBase::Build<MeshData<Real>>(MeshData<Real> *,
-                                                              const PackDescriptor &);
+                                                              const PackDescriptor &,
+                                                              const std::vector<bool> &);
 
 template <class T>
-SparsePackBase &SparsePackCache::Get(T *pmd, const PackDescriptor &desc) {
-  std::string ident = GetIdentifier(desc);
+SparsePackBase &SparsePackCache::Get(T *pmd, const PackDescriptor &desc,
+                                     const std::vector<bool> &include_block) {
+  std::string ident = GetIdentifier(desc, include_block);
   if (pack_map.count(ident) > 0) {
     auto &pack = pack_map[ident].first;
-    auto alloc_status_in = SparsePackBase::GetAllocStatus(pmd, desc);
+    auto alloc_status_in = SparsePackBase::GetAllocStatus(pmd, desc, include_block);
     auto &alloc_status = pack_map[ident].second;
     if (alloc_status.size() != alloc_status_in.size())
-      return BuildAndAdd(pmd, desc, ident);
+      return BuildAndAdd(pmd, desc, ident, include_block);
     for (int i = 0; i < alloc_status_in.size(); ++i) {
-      if (alloc_status[i] != alloc_status_in[i]) return BuildAndAdd(pmd, desc, ident);
+      if (alloc_status[i] != alloc_status_in[i])
+        return BuildAndAdd(pmd, desc, ident, include_block);
     }
     // Cached version is not stale, so just return a reference to it
     return pack_map[ident].first;
   }
-  return BuildAndAdd(pmd, desc, ident);
+  return BuildAndAdd(pmd, desc, ident, include_block);
 }
 template SparsePackBase &SparsePackCache::Get<MeshData<Real>>(MeshData<Real> *,
-                                                              const PackDescriptor &);
+                                                              const PackDescriptor &,
+                                                              const std::vector<bool> &);
 template SparsePackBase &
-SparsePackCache::Get<MeshBlockData<Real>>(MeshBlockData<Real> *, const PackDescriptor &);
+SparsePackCache::Get<MeshBlockData<Real>>(MeshBlockData<Real> *, const PackDescriptor &,
+                                          const std::vector<bool> &);
 
 template <class T>
 SparsePackBase &SparsePackCache::BuildAndAdd(T *pmd, const PackDescriptor &desc,
-                                             const std::string &ident) {
+                                             const std::string &ident,
+                                             const std::vector<bool> &include_block) {
   if (pack_map.count(ident) > 0) pack_map.erase(ident);
-  pack_map[ident] = {SparsePackBase::Build(pmd, desc),
-                     SparsePackBase::GetAllocStatus(pmd, desc)};
+  pack_map[ident] = {SparsePackBase::Build(pmd, desc, include_block),
+                     SparsePackBase::GetAllocStatus(pmd, desc, include_block)};
   return pack_map[ident].first;
 }
 template SparsePackBase &
 SparsePackCache::BuildAndAdd<MeshData<Real>>(MeshData<Real> *, const PackDescriptor &,
-                                             const std::string &);
+                                             const std::string &,
+                                             const std::vector<bool> &);
 template SparsePackBase &SparsePackCache::BuildAndAdd<MeshBlockData<Real>>(
-    MeshBlockData<Real> *, const PackDescriptor &, const std::string &);
+    MeshBlockData<Real> *, const PackDescriptor &, const std::string &,
+    const std::vector<bool> &);
 
-std::string SparsePackCache::GetIdentifier(const PackDescriptor &desc) const {
+std::string SparsePackCache::GetIdentifier(const PackDescriptor &desc,
+                                           const std::vector<bool> &include_block) const {
   std::string identifier("");
   for (const auto &vgroup : desc.var_groups) {
     for (const auto &[vid, uid] : vgroup) {
@@ -310,6 +328,9 @@ std::string SparsePackCache::GetIdentifier(const PackDescriptor &desc) const {
   identifier += std::to_string(desc.with_fluxes);
   identifier += std::to_string(desc.coarse);
   identifier += std::to_string(desc.flat);
+  for (const auto b : include_block) {
+    identifier += std::to_string(b);
+  }
   return identifier;
 }
 

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -62,9 +62,10 @@ class SparsePackBase {
   // Returns a SparsePackBase object that is either newly created or taken
   // from the cache in pmd. The cache itself handles the all of this logic
   template <class T>
-  static SparsePackBase GetPack(T *pmd, const impl::PackDescriptor &desc) {
+  static SparsePackBase GetPack(T *pmd, const impl::PackDescriptor &desc,
+                                const std::vector<bool> &include_block) {
     auto &cache = pmd->GetSparsePackCache();
-    return cache.Get(pmd, desc);
+    return cache.Get(pmd, desc, include_block);
   }
 
   // Return a map from variable names to pack variable indices
@@ -73,13 +74,15 @@ class SparsePackBase {
   // Get a list of booleans of the allocation status of every variable in pmd matching the
   // PackDescriptor desc
   template <class T>
-  static alloc_t GetAllocStatus(T *pmd, const impl::PackDescriptor &desc);
+  static alloc_t GetAllocStatus(T *pmd, const impl::PackDescriptor &desc,
+                                const std::vector<bool> &include_block);
 
   // Actually build a `SparsePackBase` (i.e. create a view of views, fill on host, and
   // deep copy the view of views to device) from the variables specified in desc contained
   // from the blocks contained in pmd (which can either be MeshBlockData/MeshData).
   template <class T>
-  static SparsePackBase Build(T *pmd, const impl::PackDescriptor &desc);
+  static SparsePackBase Build(T *pmd, const impl::PackDescriptor &desc,
+                              const std::vector<bool> &include_block);
 
   pack_t pack_;
   bounds_t bounds_;
@@ -106,13 +109,16 @@ class SparsePackCache {
 
  protected:
   template <class T>
-  SparsePackBase &Get(T *pmd, const impl::PackDescriptor &desc);
+  SparsePackBase &Get(T *pmd, const impl::PackDescriptor &desc,
+                      const std::vector<bool> &include_block);
 
   template <class T>
   SparsePackBase &BuildAndAdd(T *pmd, const impl::PackDescriptor &desc,
-                              const std::string &ident);
+                              const std::string &ident,
+                              const std::vector<bool> &include_block);
 
-  std::string GetIdentifier(const impl::PackDescriptor &desc) const;
+  std::string GetIdentifier(const impl::PackDescriptor &desc,
+                            const std::vector<bool> &include_block) const;
   std::unordered_map<std::string, std::pair<SparsePackBase, SparsePackBase::alloc_t>>
       pack_map;
 

--- a/src/interface/swarm_container.hpp
+++ b/src/interface/swarm_container.hpp
@@ -43,7 +43,8 @@ class SwarmContainer {
   // Public Methods
   //-----------------
   // Constructor does nothing
-  SwarmContainer() {}
+  SwarmContainer() = default;
+  explicit SwarmContainer(const std::string &name) : swarm_name_(name) {}
 
   /// Returns a shared pointer to a block
   std::shared_ptr<MeshBlock> GetBlockPointer() {
@@ -186,6 +187,7 @@ class SwarmContainer {
     }
   }
 
+  std::string swarm_name_;
   int debug = 0;
   std::weak_ptr<MeshBlock> pmy_block;
 

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -134,7 +134,9 @@ bool TryRecvCoarseToFine(int lid_recv, int send_rank, const LogicalLocation &fin
             });
       }
     } else {
-      if (pmb->IsAllocated(var->label())) pmb->DeallocateSparse(var->label());
+      if (pmb->IsAllocated(var->label()) &&
+          !var->metadata().IsSet(Metadata::AllocOnNewBlocks))
+        pmb->DeallocateSparse(var->label());
 #ifdef MPI_PARALLEL
       PARTHENON_MPI_CHECK(MPI_Recv(var->data.data(), 0, MPI_PARTHENON_REAL, send_rank,
                                    tag, comm, MPI_STATUS_IGNORE));
@@ -296,7 +298,9 @@ bool TryRecvSameToSame(int lid_recv, int send_rank, Variable<Real> *var, MeshBlo
       pmb->pmr->DereferenceCount() = counter_subview_h(0);
       var->dealloc_count = counter_subview_h(1);
     } else {
-      if (pmb->IsAllocated(var->label())) pmb->DeallocateSparse(var->label());
+      if (pmb->IsAllocated(var->label()) &&
+          !var->metadata().IsSet(Metadata::AllocOnNewBlocks))
+        pmb->DeallocateSparse(var->label());
       PARTHENON_MPI_CHECK(
           MPI_Recv(var->com_state, 2, MPI_INT, send_rank, tag, comm, MPI_STATUS_IGNORE));
       pmb->pmr->DereferenceCount() = var->com_state[0];

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -135,7 +135,7 @@ bool TryRecvCoarseToFine(int lid_recv, int send_rank, const LogicalLocation &fin
       }
     } else {
       if (pmb->IsAllocated(var->label()) &&
-          !var->metadata().IsSet(Metadata::AllocOnNewBlocks))
+          !var->metadata().IsSet(Metadata::ForceAllocOnNewBlocks))
         pmb->DeallocateSparse(var->label());
 #ifdef MPI_PARALLEL
       PARTHENON_MPI_CHECK(MPI_Recv(var->data.data(), 0, MPI_PARTHENON_REAL, send_rank,
@@ -299,7 +299,7 @@ bool TryRecvSameToSame(int lid_recv, int send_rank, Variable<Real> *var, MeshBlo
       var->dealloc_count = counter_subview_h(1);
     } else {
       if (pmb->IsAllocated(var->label()) &&
-          !var->metadata().IsSet(Metadata::AllocOnNewBlocks))
+          !var->metadata().IsSet(Metadata::ForceAllocOnNewBlocks))
         pmb->DeallocateSparse(var->label());
       PARTHENON_MPI_CHECK(
           MPI_Recv(var->com_state, 2, MPI_INT, send_rank, tag, comm, MPI_STATUS_IGNORE));

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1183,7 +1183,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
   } while (!init_done);
 
   // Initialize the "base" MeshData object
-  mesh_data.Get()->Set(block_list); //, "base");
+  mesh_data.Get()->Set(block_list);
 
   Kokkos::Profiling::popRegion(); // Mesh::Initialize
 }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1183,7 +1183,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
   } while (!init_done);
 
   // Initialize the "base" MeshData object
-  mesh_data.Get()->Set(block_list, "base");
+  mesh_data.Get()->Set(block_list); //, "base");
 
   Kokkos::Profiling::popRegion(); // Mesh::Initialize
 }

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -67,13 +67,13 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       auto &md_base = pm->mesh_data.Get();
       // Populated with all blocks
       if (md_base->NumBlocks() == 0) {
-        md_base->Set(pm->block_list, "base");
+        md_base->Set(pm->block_list);
       } else if (md_base->NumBlocks() != pm->block_list.size()) {
         PARTHENON_WARN(
             "Resetting \"base\" MeshData to contain all blocks. This indicates that "
             "the \"base\" MeshData container has been modified elsewhere. Double check "
             "that the modification was intentional and is compatible with this reset.")
-        md_base->Set(pm->block_list, "base");
+        md_base->Set(pm->block_list);
       }
       auto result = hist_var.hst_fun(md_base.get());
 #ifdef MPI_PARALLEL

--- a/tst/unit/test_mesh_data.cpp
+++ b/tst/unit/test_mesh_data.cpp
@@ -77,8 +77,8 @@ TEST_CASE("MeshData works as expected for simple packs", "[MeshData]") {
     pkg->AddField("v6", m_face);
     BlockList_t block_list = MakeBlockList(pkg, NBLOCKS, N, NDIM);
 
-    MeshData<Real> mesh_data;
-    mesh_data.Set(block_list, "base");
+    MeshData<Real> mesh_data("base");
+    mesh_data.Set(block_list);
 
     THEN("The number of blocks is correct") { REQUIRE(mesh_data.NumBlocks() == NBLOCKS); }
 

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -96,8 +96,8 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
     pkg->AddField(v5::name(), m);
     BlockList_t block_list = MakeBlockList(pkg, NBLOCKS, N, NDIM);
 
-    MeshData<Real> mesh_data;
-    mesh_data.Set(block_list, "base");
+    MeshData<Real> mesh_data("base");
+    mesh_data.Set(block_list);
 
     WHEN("We initialize the independent variables by hand and deallocate one") {
       auto ib = block_list[0]->cellbounds.GetBoundsI(IndexDomain::entire);

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -268,6 +268,16 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
             nwrong);
         REQUIRE(nwrong == 0);
       }
+
+      THEN("A sparse pack built with a subset of blocks is the right size") {
+        auto desc =
+            parthenon::MakePackDescriptor<parthenon::variable_names::any>(pkg.get());
+        std::vector<bool> include_blocks(NBLOCKS);
+        for (int i = 0; i < NBLOCKS; i++)
+          include_blocks[i] = (i % 2 == 0);
+        auto sparse_pack = desc.GetPack(&mesh_data, include_blocks);
+        REQUIRE(sparse_pack.GetNBlocks() == NBLOCKS / 2 + 1);
+      }
     }
   }
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
This PR includes three things:
- It slightly expands the capability of `SparsePacks` by adding a new optional argument to `GetPack` that is a `std::vector<bool>` of flags that determine which blocks in a `MeshData` object actually get packed.
- A new `MetadataFlag` was added, `Metadata::AllocOnNewBlocks`, intended to force allocation of sparse fields whenever a new `MeshBlock` is created through AMR/load balancing.
- A refactor of the `DataCollection` add functionality so that when `Add` is called on a `MeshData` object, it appropriately calls `Add` on the block-level `DataCollection`s.  The benefit of this is that it can avoid having to always make entirely new `MeshBlockData` objects, instead just using the previously created objects when they're available.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
