### PR TITLE
add GetOrAddFlag to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 932]](https://github.com/parthenon-hpc-lab/parthenon/pull/932) Add GetOrAddFlag to metadata
 - [[PR 931]](https://github.com/parthenon-hpc-lab/parthenon/pull/931) Allow SparsePacks with subsets of blocks
 - [[PR 921]](https://github.com/parthenon-hpc-lab/parthenon/pull/921) Add more flexible ways of adding and using MeshData/MeshBlockData objects to DataCollections
 - [[PR 900]](https://github.com/parthenon-hpc-lab/parthenon/pull/900) Add Morton numbers and expand functionality of LogicalLocation

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -335,6 +335,9 @@ class Metadata {
   static MetadataFlag AddUserFlag(const std::string &name);
   static bool FlagNameExists(const std::string &flagname);
   static MetadataFlag GetUserFlag(const std::string &flagname);
+  static MetadataFlag GetOrAddFlag(const std::string &name) {
+    return FlagNameExists(name) ? GetUserFlag(name) : AddUserFlag(name);
+  }
   static int num_flags;
 
   // Sparse threshold routines

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -96,6 +96,11 @@ TEST_CASE("A Metadata flag is allocated", "[Metadata]") {
 
     // It should throw an error if you try to allocate a new flag with the same name.
     REQUIRE_THROWS_AS(Metadata::AddUserFlag(name), std::runtime_error);
+
+    // We can get or add a flag
+    auto const f3 = Metadata::GetOrAddFlag("ImFlexible");
+    auto const f4 = Metadata::GetOrAddFlag("ImFlexible");
+    REQUIRE(f3 == f4);
   }
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

In the `Initialization` of packages, I'm finding I want to add the same downstream, user metadata flag to variables across multiple packages. This simply adds a way to do this in a distributed way, rather than having to add the flag to metadata in a centralized location first.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
