### PR TITLE
Restructure buffer packing kernels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [[PR 890]](https://github.com/parthenon-hpc-lab/parthenon/pull/890) Fix bugs in sparse communication and prolongation
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 938]](https://github.com/parthenon-hpc-lab/parthenon/pull/938) Restructure buffer packing/unpacking kernel hierarchical parallelism
 - [[PR 904]](https://github.com/parthenon-hpc-lab/parthenon/pull/904) Move to prolongation/restriction in one for AMR and communicate non-cell centered fields
 - [[PR 918]](https://github.com/parthenon-hpc-lab/parthenon/pull/918) Refactor RegionSize 
 - [[PR 901]](https://github.com/parthenon-hpc-lab/parthenon/pull/901) Implement shared element ownership model

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -82,8 +82,6 @@ TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
   PARTHENON_DEBUG_REQUIRE(bnd_info.size() == nbound, "Need same size for boundary info");
   auto &sending_nonzero_flags = cache.sending_non_zero_flags;
   auto &sending_nonzero_flags_h = cache.sending_non_zero_flags_h;
-  for (int ibuf = 0; ibuf < cache.buf_vec.size(); ++ibuf)   
-    sending_nonzero_flags_h(ibuf) = true; 
   
   Kokkos::parallel_for(
       "SendBoundBufs",

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -248,7 +248,7 @@ TaskStatus SetBounds(std::shared_ptr<MeshData<Real>> &md) {
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange<>(team_member, idxer.size() / Ni),
                 [&](const int idx) {
-                  const auto [t, u, v, k, j, i] = idxer(idx);
+                  const auto [t, u, v, k, j, i] = idxer(idx * Ni);
                   Real *var = &bnd_info(b).var(iel, t, u, v, k, j, i);
                   Real *buf = &bnd_info(b).buf(idx * Ni + idx_offset);
                   // Have to do this because of some weird issue about structure bindings
@@ -267,7 +267,7 @@ TaskStatus SetBounds(std::shared_ptr<MeshData<Real>> &md) {
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange<>(team_member, idxer.size() / Ni),
                 [&](const int idx) {
-                  const auto [t, u, v, k, j, i] = idxer(idx);
+                  const auto [t, u, v, k, j, i] = idxer(idx * Ni);
                   Real *var = &bnd_info(b).var(iel, t, u, v, k, j, i);
                   const int kk = k;
                   const int jj = j;


### PR DESCRIPTION
## PR Summary

This PR adds a third level of hierarchical parallelism to the buffer packing/unpacking kernels in `SendBoundsBufs` and `SetBounds`. The new innermost level is a `ThreadVectorRange` that goes over the `i` index we are packing over, which is contiguous in memory. In the new inner most loop, we access the variable and buffer via a raw pointer which presumably enables vectorization, reduces the number of required index calculations, and (maybe?) helps with cacheing. 

This change gives a 30% speedup in 128^3 simulations in Riot with 32^3 blocks on CPU. There is a slight degradation in performance on GPUs though (5-6% for 32^3 and 64^3 blocks, based on @pdmullen's timings).   

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
