### PR TITLE
WIP: Fix MPI Communicator destruction (again)

### DIFF
--- a/src/utils/reductions.hpp
+++ b/src/utils/reductions.hpp
@@ -68,7 +68,7 @@ struct ReductionBase {
     // Store the communicator in a shared_ptr, so that
     // MPI_Comm_free is called, but only when the last
     // copy of this ReductionBase is destroyed.
-    pcomm = std::shared_ptr<MPI_Comm>(new MPI_Comm, MPI_Comm_disconnect);
+    pcomm = std::shared_ptr<MPI_Comm>(new MPI_Comm, MPI_Comm_free);
     PARTHENON_MPI_CHECK(MPI_Comm_dup(MPI_COMM_WORLD, pcomm.get()));
 #endif
   }


### PR DESCRIPTION
Remember #841?  It's back!

A refresher: in CI tests, there was a semi-common (30-50%?) race condition between Parthenon's use of MPI and HDF5's use of MPI when making the last outputs and cleaning up.  Parthenon would `MPI_Comm_free` a communicator, and HDF5 would then attempt to `MPI_Comm_dup` at the same time, which is apparently an issue for implementations.

I found (without explanation nor extensive testing) that I could make that race condition less frequent if I switched the destructor of `Reduction` objects to use `MPI_Comm_disconnect` instead of `MPI_Comm_free`.  The difference is, `MPI_Comm_free` is asynchronous, and sets the current reference to `null` without actually destroying the communicator until every process has done so.  It "disconnects" from the communicator, if you will.  Whereas `MPI_Comm_disconnect` waits until it can confirm that the communicator has been destroyed.  That is, it "frees" it (the MPI standard is so straightforward!).

In any case, after reorganizing communicators in KHARMA, I've found that when freeing a lot of communicators together, `MPI_Comm_disconnect` is very likely to just... hang forever.  This condition happens in, for example, the destructor of `Mesh`, which calls the destructor of `Packages_t` which calls every package's destructor, which should in codes which follow our best practices free *every communicator at once*.  So, I imagine it will become a problem for other folks as well, manifesting as a run which finishes, prints statistics, and then just... doesn't return.  This will be a problem in batch jobs, where a job that would otherwise return will continue spending core-hours without printing anything suspicious.

This PR just reverts to using `MPI_Comm_free` as the destructor, which fixes the issue in KHARMA, and allows all tests to pass on my machine, both without any warnings/double-free/etc.  If it fails CI, we can talk about other sorts of hacks for keeping HDF5 out of our way while we destroy the `Mesh`.

Teaching sand to think might have been a mistake, but letting it talk to itself was a catastrophe.