### PR TITLE
Only permit rank0 to mkdir when -d flag specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [[PR 885]](https://github.com/parthenon-hpc-lab/parthenon/pull/885) Expose PackDescriptor and use uids in SparsePacks
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 955]](https://github.com/parthenon-hpc-lab/parthenon/pull/955) Only permit rank0 to mkdir when -d flag specified
 - [[PR 952]](https://github.com/parthenon-hpc-lab/parthenon/pull/954) Fix format string in sparse advection example
 - [[PR 947]](https://github.com/parthenon-hpc-lab/parthenon/pull/947) Add missing ForceRemeshComm dependencies
 - [[PR 928]](https://github.com/parthenon-hpc-lab/parthenon/pull/928) Fix boundary comms during refinement next to refined blocks

--- a/src/utils/change_rundir.cpp
+++ b/src/utils/change_rundir.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -27,6 +27,8 @@
 #include <stdexcept>
 
 #include "defs.hpp"
+#include "globals.hpp"
+#include "parthenon_mpi.hpp"
 #include "utils/error_checking.hpp"
 
 namespace fs = FS_NAMESPACE;
@@ -42,18 +44,24 @@ void ChangeRunDir(const char *pdir) {
 
   if (pdir == nullptr || *pdir == '\0') return;
 
-  if (!fs::exists(pdir)) {
-    if (!fs::create_directories(pdir)) {
-      msg << "### FATAL ERROR in function [ChangeToRunDir]" << std::endl
-          << "Cannot create directory '" << pdir << "'";
-      PARTHENON_THROW(msg);
-    }
+  if (parthenon::Globals::my_rank == 0) {
+    if (!fs::exists(pdir)) {
+      if (!fs::create_directories(pdir)) {
+        msg << "### FATAL ERROR in function [ChangeToRunDir]" << std::endl
+            << "Cannot create directory '" << pdir << "'";
+        PARTHENON_THROW(msg);
+      }
 
-    // in POSIX, this is 0755 permission, rwxr-xr-x
-    auto perms = fs::perms::owner_all | fs::perms::group_read | fs::perms::group_exec |
-                 fs::perms::others_read | fs::perms::others_exec;
-    fs::permissions(pdir, perms);
+      // in POSIX, this is 0755 permission, rwxr-xr-x
+      auto perms = fs::perms::owner_all | fs::perms::group_read | fs::perms::group_exec |
+                   fs::perms::others_read | fs::perms::others_exec;
+      fs::permissions(pdir, perms);
+    }
   }
+
+#ifdef MPI_PARALLEL
+  MPI_Barrier(MPI_COMM_WORLD);
+#endif
 
   if (chdir(pdir)) {
     msg << "### FATAL ERROR in function [ChangeToRunDir]" << std::endl


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Evidently, @bprather and I are among the few who actually use the `-d` flag.  This flag enables users to send all output data to a specified directory, e.g., 

```
mpiexec -n 99999999999 ./my_exe -i my_input -d /my_scratch/my_run
```
I have found on several occasions that when firing up a multi-rank job, I get a crash with an accompanying error message indicating that there was an error in creating the directory.  

I think this issue is related to a race condition wherein multiple ranks were trying to create the same directory.  The changes in this MR permit only rank 0 to create the directory.  Then we call an `MPI_Barrier` in the unlikely chance that one rank tries to `chdir` into a directory not yet created.  

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
