### PR TITLE
Convert numpy arrays to ASCII strings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ include(cmake/Lint.cmake)
 # regression test reference data
 set(REGRESSION_GOLD_STANDARD_VER 20 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+  "SHA512=e5e421f3c0be01e4708965542bb8b1b79b5c96de97091e46972e375c7616588d026a9a8e29226d9c7ef75346bc859fd9af72acdc7e95e0d783b5ef29aa4630b1"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,9 +62,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 19 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 20 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=e1d1a06b9cf9b761d42d0b6b241056ac75658db90138b6b867b1ca7ead4308af4f980285af092b40aee1dbbfb68b4e8cb15efcc9b83d7930c18bf992ae95c729"
+  "SHA512=e5e421f3c0be01e4708965542bb8b1b79b5c96de97091e46972e375c7616588d026a9a8e29226d9c7ef75346bc859fd9af72acdc7e95e0d783b5ef29aa4630b1"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ include(cmake/Lint.cmake)
 # regression test reference data
 set(REGRESSION_GOLD_STANDARD_VER 20 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=e5e421f3c0be01e4708965542bb8b1b79b5c96de97091e46972e375c7616588d026a9a8e29226d9c7ef75346bc859fd9af72acdc7e95e0d783b5ef29aa4630b1"
+  "SHA512=cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -180,14 +180,6 @@ class phdf:
         else:
             self.Params = None
 
-        # If strings are converted to numpy arrays of ASCII values, convert back to
-        # strings
-        for key in self.Params.keys():
-            val = self.Params[key]
-            if type(val) is type(np.zeros(0)):
-                val_str = "".join([chr(c) for c in val])
-                self.Params[key] = val_str
-
         # Read in coordinates
         def load_coord(coord_i):
             coord_name = ["x", "y", "z"][coord_i]

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -180,6 +180,14 @@ class phdf:
         else:
             self.Params = None
 
+        # If strings are converted to numpy arrays of ASCII values, convert back to
+        # strings
+        for key in self.Params.keys():
+            val = self.Params[key]
+            if type(val) is type(np.zeros(0)):
+                val_str = ''.join([chr(c) for c in val])
+                self.Params[key] = val_str
+
         # Read in coordinates
         def load_coord(coord_i):
             coord_name = ["x", "y", "z"][coord_i]

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -185,7 +185,7 @@ class phdf:
         for key in self.Params.keys():
             val = self.Params[key]
             if type(val) is type(np.zeros(0)):
-                val_str = ''.join([chr(c) for c in val])
+                val_str = "".join([chr(c) for c in val])
                 self.Params[key] = val_str
 
         # Read in coordinates

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -820,7 +820,8 @@ HDF5GetAttributeInfo(hid_t location, const std::string &name, H5A &attr) {
 // template specializations for std::string and bool
 void HDF5WriteAttribute(const std::string &name, const std::string &value,
                         hid_t location) {
-  HDF5WriteAttribute(name, value.size(), value.c_str(), location);
+  //HDF5WriteAttribute(name, value.size(), value.c_str(), location);
+  HDF5WriteAttribute(name, value.c_str(), location);
 }
 
 template <>

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -820,7 +820,6 @@ HDF5GetAttributeInfo(hid_t location, const std::string &name, H5A &attr) {
 // template specializations for std::string and bool
 void HDF5WriteAttribute(const std::string &name, const std::string &value,
                         hid_t location) {
-  //HDF5WriteAttribute(name, value.size(), value.c_str(), location);
   HDF5WriteAttribute(name, value.c_str(), location);
 }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Newer versions of `h5py` appear to convert string values in HDF5 attributes to numpy arrays of ASCII values (e.g. `[10 200 45 109 ...]`). This PR returns these values to strings.

Currently this PR acts on *all* numpy arrays that appear as values in the `Params` attribute; I think this is OK because `Params` doesn't support vector input but it is worth thinking about in case there is a better way to deal with this. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
