### PR TITLE
Use `GNUInstallDirs` to fix installation problems on mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,10 @@ if (PARTHENON_ENABLE_ASCENT)
   find_package(Ascent REQUIRED NO_DEFAULT_PATH)
 endif()
 
+# Installation configuration
+include(GNUInstallDirs)
+set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/parthenon")
+
 add_subdirectory(src)
 add_subdirectory(example)
 add_subdirectory(benchmarks)

--- a/cmake/parthenonConfig.cmake.in
+++ b/cmake/parthenonConfig.cmake.in
@@ -11,6 +11,14 @@
 # the public, perform publicly and display publicly, and to permit others to do so.
 #=========================================================================================
 
+if(NOT PARTHENON_CMAKE)
+  cmake_path(SET PARTHENON_CMAKE_BASE_DIR NORMALIZE "${CMAKE_CURRENT_LIST_DIR}/..")
+  message(STATUS "Appending parthenon cmake module directory: " ${PARTHENON_CMAKE_BASE_DIR})
+  list(APPEND CMAKE_MODULE_PATH ${PARTHENON_CMAKE_BASE_DIR})
+  set(PARTHENON_CMAKE TRUE)
+endif()
+
+
 # Favor using the kokkos package that was built with parthenon, if one has not been specified
 if (@PARTHENON_IMPORT_KOKKOS@)
   find_package(Kokkos 3 REQUIRED PATHS @Kokkos_DIR@ NO_DEFAULT_PATH)
@@ -36,5 +44,7 @@ endif()
 if(@OpenMP_FOUND@)
   find_package(OpenMP REQUIRED COMPONENTS CXX)
 endif()
+
+find_package(Filesystem REQUIRED COMPONENTS Experimental Final)
 
 include("${CMAKE_CURRENT_LIST_DIR}/parthenonTargets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -325,23 +325,21 @@ lint_target(parthenon)
 target_include_directories(parthenon PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/generated>
-  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/parthenon>
+  $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
   )
 
-install(TARGETS parthenon EXPORT parthenonTargets
-  INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parthenon"
-  LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-  ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-)
+install(TARGETS parthenon EXPORT parthenonTargets)
 
 # Maintain directory structure in installed include files
-install(DIRECTORY . DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parthenon" FILES_MATCHING PATTERN "*.hpp")
+install(DIRECTORY ./ TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp")
 
 # Install generated config header file
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/generated/config.hpp
-  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/parthenon")
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 
 install(FILES ${PROJECT_BINARY_DIR}/cmake/parthenonConfig.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/parthenon")
+
+install(FILES ${PROJECT_SOURCE_DIR}/cmake/FindFilesystem.cmake DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake")
 
 install(EXPORT parthenonTargets
     FILE parthenonTargets.cmake


### PR DESCRIPTION
## PR Summary

A `make install` on my mac generated the following error:
```console
     479    -- Installing: /parthenon/.
  >> 480    CMake Error at src/cmake_install.cmake:57 (file):
     481      file INSTALL cannot make directory "/parthenon/.": No such file or
     482      directory.
     483    Call Stack (most recent call first):
     484      cmake_install.cmake:42 (include)
     485
     486
  >> 487    make: *** [Makefile:103: install] Error 1
```

This PR uses `GNUInstallDirs` to ensure things are defined.  The installed directory structure looks correct but I've never installed it before so...

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
