### PR TITLE
Allow leading whitespace in input parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 965]](https://github.com/parthenon-hpc-lab/parthenon/pull/965) Allow leading whitespace in input parameters
 - [[PR 926]](https://github.com/parthenon-hpc-lab/parthenon/pull/926) Internal refinement op registration
 - [[PR 897]](https://github.com/parthenon-hpc-lab/parthenon/pull/897) Deflate compression filter is not called any more if compression is soft disabled
 - [[PR 896]](https://github.com/parthenon-hpc-lab/parthenon/pull/896) Update Kokkos integration to support installed version. Use `serial` (flat MPI) host parallelization by default (instead of OpenMP)

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -295,7 +295,6 @@ bool ParameterInput::ParseLine(InputBlock *pib, std::string line, std::string &n
                                std::string &value, std::string &comment) {
   std::size_t first_char, last_char, equal_char, hash_char, cont_char, len;
   bool continuation = false;
-  printf("line: %s\n", line.c_str());
 
   hash_char = line.find_first_of("#"); // find "#" (optional)
   comment = "";
@@ -316,7 +315,7 @@ bool ParameterInput::ParseLine(InputBlock *pib, std::string line, std::string &n
     name.assign(line, first_char, len);
     last_char = name.find_last_not_of(" ");
     name.erase(last_char + 1, std::string::npos);
-    line.erase(0, equal_char+1);
+    line.erase(0, equal_char + 1);
   }
 
   cont_char = line.find_first_of("&"); // find "&" continuation character

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -295,6 +295,7 @@ bool ParameterInput::ParseLine(InputBlock *pib, std::string line, std::string &n
                                std::string &value, std::string &comment) {
   std::size_t first_char, last_char, equal_char, hash_char, cont_char, len;
   bool continuation = false;
+  printf("line: %s\n", line.c_str());
 
   hash_char = line.find_first_of("#"); // find "#" (optional)
   comment = "";
@@ -315,7 +316,7 @@ bool ParameterInput::ParseLine(InputBlock *pib, std::string line, std::string &n
     name.assign(line, first_char, len);
     last_char = name.find_last_not_of(" ");
     name.erase(last_char + 1, std::string::npos);
-    line.erase(0, len + 1);
+    line.erase(0, equal_char+1);
   }
 
   cont_char = line.find_first_of("&"); // find "&" continuation character

--- a/tst/regression/test_suites/advection_performance/parthinput.advection_performance
+++ b/tst/regression/test_suites/advection_performance/parthinput.advection_performance
@@ -49,8 +49,8 @@ nx2 = 64
 nx3 = 64
 
 <parthenon/time>
-tlim = 1.0
-nlim = 20
+ tlim = 1.0 # Test that leading whitespace is correctly sanitized
+	nlim = 20 # Test that leading tab is correctly sanitized
 integrator = rk2
 perf_cycle_offset = 2
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Currently, input parameters are read incorrectly. For example,

```
<block>
 var = 1.0
 ```

will read `var` as `= 1.0`, which when called with `GetReal` will cast to `0`. 

This PR fixes a bug where the length of the name was incorrectly calculated if leading whitespace was present in the input parameter file. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
