### PR TITLE
Multigrid MPI Bug Fix

### DIFF
--- a/example/poisson_gmg/main.cpp
+++ b/example/poisson_gmg/main.cpp
@@ -86,7 +86,7 @@ int main(int argc, char *argv[]) {
   }
   // call MPI_Finalize and Kokkos::finalize if necessary
   pman.ParthenonFinalize();
-  printf("success: %i\n", success);
+  if (Globals::my_rank == 0) printf("success: %i\n", success);
 
   // MPI and Kokkos can no longer be used
   return static_cast<int>(!success);

--- a/example/poisson_gmg/poisson_driver.cpp
+++ b/example/poisson_gmg/poisson_driver.cpp
@@ -79,7 +79,8 @@ TaskID AddSRJIteration(TaskList &tl, TaskID depends_on, int stages, bool multile
       {{0.8723, 0.5395, 0.0000}, {1.3895, 0.5617, 0.0000}, {1.7319, 0.5695, 0.0000}}};
   std::array<std::array<Real, 3>, 3> omega_M3{
       {{0.9372, 0.6667, 0.5173}, {1.6653, 0.8000, 0.5264}, {2.2473, 0.8571, 0.5296}}};
-
+  
+  if (stages == 0) return depends_on;
   auto omega = omega_M1;
   if (stages == 2) omega = omega_M2;
   if (stages == 3) omega = omega_M3;
@@ -148,12 +149,13 @@ TaskID DotProduct(TaskID dependency_in, TaskRegion &region, TaskList &tl, int pa
   return finish_global_adotb;
 }
 
-void PoissonDriver::AddMultiGridTasksLevel(TaskRegion &region, int level, int min_level,
+TaskID PoissonDriver::AddMultiGridTasksLevel(TaskList &tl, TaskID dependency, int partition, 
+                                           int level, int min_level,
                                            int max_level, bool final) {
   using namespace parthenon;
   using namespace poisson_package;
   TaskID none(0);
-  const int num_partitions = pmesh->DefaultNumPartitions();
+  //const int num_partitions = pmesh->DefaultNumPartitions();
 
   auto pkg = pmesh->packages.Get("poisson_package");
   auto damping = pkg->Param<Real>("jacobi_damping");
@@ -161,7 +163,10 @@ void PoissonDriver::AddMultiGridTasksLevel(TaskRegion &region, int level, int mi
   int pre_stages = pkg->Param<int>("pre_smooth_iterations");
   int post_stages = pkg->Param<int>("post_smooth_iterations");
   bool do_FAS = pkg->Param<bool>("do_FAS");
-  if (smoother == "SRJ1") {
+  if (smoother == "none") {
+    pre_stages = 0;
+    post_stages = 0;
+  } else if (smoother == "SRJ1") {
     pre_stages = 1;
     post_stages = 1;
   } else if (smoother == "SRJ2") {
@@ -176,94 +181,97 @@ void PoissonDriver::AddMultiGridTasksLevel(TaskRegion &region, int level, int mi
 
   int ndim = pmesh->ndim;
   bool multilevel = (level != min_level);
-  for (int i = 0; i < num_partitions; ++i) {
-    TaskList &tl = region[i + (max_level - level) * num_partitions];
 
-    auto &md = pmesh->gmg_mesh_data[level].GetOrAdd(level, "base", i);
-    // 0. Receive residual from coarser level if there is one
-    auto set_from_finer = none;
-    if (level < max_level) {
-      // Fill fields with restricted values
-      auto recv_from_finer =
-          tl.AddTask(none, ReceiveBoundBufs<BoundaryType::gmg_restrict_recv>, md);
+  auto &md = pmesh->gmg_mesh_data[level].GetOrAdd(level, "base", partition);
+  // 0. Receive residual from coarser level if there is one
+  auto set_from_finer = dependency;
+  if (level < max_level) {
+    // Fill fields with restricted values
+    auto recv_from_finer =
+        tl.AddTask(set_from_finer, ReceiveBoundBufs<BoundaryType::gmg_restrict_recv>, md);
+    set_from_finer =
+        tl.AddTask(recv_from_finer, SetBounds<BoundaryType::gmg_restrict_recv>, md);
+    // 1. Copy residual from dual purpose communication field to the rhs, should be
+    // actual RHS for finest level
+    auto copy_u = tl.AddTask(set_from_finer, CopyData<u, u0, true>, md);
+    if (!do_FAS) {
+      auto zero_u = tl.AddTask(copy_u, SetToZero<u, true>, md);
+      auto copy_rhs = tl.AddTask(set_from_finer, CopyData<res_err, rhs, true>, md);
+      set_from_finer = zero_u | copy_u | copy_rhs;
+    } else {
+      set_from_finer = AddBoundaryExchangeTasks<BoundaryType::gmg_same>(
+          set_from_finer, tl, md, multilevel);
+      // This should set the rhs only in blocks that correspond to interior nodes, the
+      // RHS of leaf blocks that are on this GMG level should have already been set on
+      // entry into multigrid
       set_from_finer =
-          tl.AddTask(recv_from_finer, SetBounds<BoundaryType::gmg_restrict_recv>, md);
-      // 1. Copy residual from dual purpose communication field to the rhs, should be
-      // actual RHS for finest level
-      auto copy_u = tl.AddTask(set_from_finer, CopyData<u, u0, true>, md);
-      if (!do_FAS) {
-        auto zero_u = tl.AddTask(copy_u, SetToZero<u, true>, md);
-        auto copy_rhs = tl.AddTask(set_from_finer, CopyData<res_err, rhs, true>, md);
-        set_from_finer = zero_u | copy_u | copy_rhs;
-      } else {
-        set_from_finer = AddBoundaryExchangeTasks<BoundaryType::gmg_same>(
-            set_from_finer, tl, md, multilevel);
-        // This should set the rhs only in blocks that correspond to interior nodes, the
-        // RHS of leaf blocks that are on this GMG level should have already been set on
-        // entry into multigrid
-        set_from_finer =
-            Axpy<u, res_err, rhs, true>(tl, set_from_finer, md, 1.0, 1.0, true);
-        set_from_finer = set_from_finer | copy_u;
-      }
-    } else {
-      set_from_finer = tl.AddTask(set_from_finer, CopyData<u, u0, true>, md);
+          Axpy<u, res_err, rhs, true>(tl, set_from_finer, md, 1.0, 1.0, true);
+      set_from_finer = set_from_finer | copy_u;
     }
-
-    // 2. Do pre-smooth and fill solution on this level
-    auto pre_smooth = AddSRJIteration<BoundaryType::gmg_same>(tl, set_from_finer,
-                                                              pre_stages, multilevel, md);
-    // If we are finer than the coarsest level:
-    auto post_smooth = none;
-    if (level > min_level) {
-      // 3. Communicate same level boundaries so that u is up to date everywhere
-      auto comm_u = AddBoundaryExchangeTasks<BoundaryType::gmg_same>(pre_smooth, tl, md,
-                                                                     multilevel);
-
-      // 4. Caclulate residual and store in communication field
-      auto residual = Axpy<u, rhs, res_err, true>(tl, comm_u, md, -1.0, 1.0, false);
-
-      // 5. Restrict communication field and send to next level
-      auto communicate_to_coarse =
-          tl.AddTask(residual, SendBoundBufs<BoundaryType::gmg_restrict_send>, md);
-
-      // 6. Receive error field into communication field and prolongate
-      auto recv_from_coarser = tl.AddTask(
-          communicate_to_coarse, ReceiveBoundBufs<BoundaryType::gmg_prolongate_recv>, md);
-      auto set_from_coarser =
-          tl.AddTask(recv_from_coarser, SetBounds<BoundaryType::gmg_prolongate_recv>, md);
-      auto prolongate = tl.AddTask(
-          set_from_coarser, ProlongateBounds<BoundaryType::gmg_prolongate_recv>, md);
-
-      // 7. Correct solution on this level with res_err field and store in
-      //    communication field
-      auto update_sol =
-          tl.AddTask(prolongate, AddFieldsAndStore<u, res_err, u, true>, md, 1.0, 1.0);
-
-      // 8. Post smooth using communication field and stored RHS
-      post_smooth = AddSRJIteration<BoundaryType::gmg_same>(tl, update_sol, post_stages,
-                                                            multilevel, md);
-    } else {
-      post_smooth = tl.AddTask(pre_smooth, CopyData<u, res_err, true>, md);
-    }
-
-    // 9. Send communication field to next finer level (should be error field for that
-    // level)
-    if (level < max_level) {
-      auto copy_over = post_smooth;
-      if (!do_FAS) {
-        copy_over = tl.AddTask(post_smooth, CopyData<u, res_err, true>, md);
-      } else {
-        auto calc_err = tl.AddTask(post_smooth, AddFieldsAndStore<u, u0, res_err, true>,
-                                   md, 1.0, -1.0);
-        copy_over = calc_err;
-      }
-      auto boundary =
-          AddBoundaryExchangeTasks<BoundaryType::gmg_same>(copy_over, tl, md, multilevel);
-      tl.AddTask(boundary, SendBoundBufs<BoundaryType::gmg_prolongate_send>, md);
-    } else {
-      AddBoundaryExchangeTasks<BoundaryType::gmg_same>(post_smooth, tl, md, multilevel);
-    }
+  } else {
+    set_from_finer = tl.AddTask(set_from_finer, CopyData<u, u0, true>, md);
   }
+
+  // 2. Do pre-smooth and fill solution on this level
+  auto pre_smooth = AddSRJIteration<BoundaryType::gmg_same>(tl, set_from_finer,
+                                                            pre_stages, multilevel, md);
+  // If we are finer than the coarsest level:
+  auto post_smooth = none;
+  if (level > min_level) {
+    // 3. Communicate same level boundaries so that u is up to date everywhere
+    auto comm_u = AddBoundaryExchangeTasks<BoundaryType::gmg_same>(pre_smooth, tl, md,
+                                                                   multilevel);
+
+    // 4. Caclulate residual and store in communication field
+    auto residual = Axpy<u, rhs, res_err, true>(tl, comm_u, md, -1.0, 1.0, false);
+
+    // 5. Restrict communication field and send to next level
+    auto communicate_to_coarse =
+        tl.AddTask(residual, SendBoundBufs<BoundaryType::gmg_restrict_send>, md);
+    
+    auto coarser = AddMultiGridTasksLevel(tl, communicate_to_coarse, partition, 
+                                          level - 1, min_level, max_level,
+                                          level - 1 == min_level);
+
+    // 6. Receive error field into communication field and prolongate
+    auto recv_from_coarser = tl.AddTask(
+        coarser, ReceiveBoundBufs<BoundaryType::gmg_prolongate_recv>, md);
+    auto set_from_coarser =
+        tl.AddTask(recv_from_coarser, SetBounds<BoundaryType::gmg_prolongate_recv>, md);
+    auto prolongate = tl.AddTask(
+        set_from_coarser, ProlongateBounds<BoundaryType::gmg_prolongate_recv>, md);
+
+    // 7. Correct solution on this level with res_err field and store in
+    //    communication field
+    auto update_sol =
+        tl.AddTask(prolongate, AddFieldsAndStore<u, res_err, u, true>, md, 1.0, 1.0);
+
+    // 8. Post smooth using communication field and stored RHS
+    post_smooth = AddSRJIteration<BoundaryType::gmg_same>(tl, update_sol, post_stages,
+                                                          multilevel, md);
+  } else {
+    post_smooth = tl.AddTask(pre_smooth, CopyData<u, res_err, true>, md);
+  }
+
+  // 9. Send communication field to next finer level (should be error field for that
+  // level)
+  auto final_task = post_smooth;
+  if (level < max_level) {
+    auto copy_over = post_smooth;
+    if (!do_FAS) {
+      copy_over = tl.AddTask(post_smooth, CopyData<u, res_err, true>, md);
+    } else {
+      auto calc_err = tl.AddTask(post_smooth, AddFieldsAndStore<u, u0, res_err, true>,
+                                 md, 1.0, -1.0);
+      copy_over = calc_err;
+    }
+    auto boundary =
+        AddBoundaryExchangeTasks<BoundaryType::gmg_same>(copy_over, tl, md, multilevel);
+    final_task = tl.AddTask(boundary, SendBoundBufs<BoundaryType::gmg_prolongate_send>, md);
+  } else {
+    final_task = AddBoundaryExchangeTasks<BoundaryType::gmg_same>(post_smooth, tl, md, multilevel);
+  }
+  return final_task;
 }
 
 TaskCollection PoissonDriver::MakeTaskCollectionMG(BlockList_t &blocks) {
@@ -292,9 +300,10 @@ TaskCollection PoissonDriver::MakeTaskCollectionMG(BlockList_t &blocks) {
   }
 
   for (int ivcycle = 0; ivcycle < max_iterations; ++ivcycle) {
-    TaskRegion &region = tc.AddRegion(num_partitions * (max_level + 1));
-    for (int level = max_level; level >= min_level; --level) {
-      AddMultiGridTasksLevel(region, level, min_level, max_level, level == min_level);
+    TaskRegion &region = tc.AddRegion(num_partitions);
+    for (int i = 0; i < num_partitions; ++i) { 
+      TaskList &tl = region[i];
+      AddMultiGridTasksLevel(tl, none, i, max_level, min_level, max_level, false);
     }
 
     int reg_dep_id = 0;
@@ -349,9 +358,10 @@ TaskCollection PoissonDriver::MakeTaskCollectionMGBiCGSTAB(BlockList_t &blocks) 
 
   auto AddGMGRegion = [&]() {
     if (precondition) {
-      TaskRegion &region = tc.AddRegion(num_partitions * (max_level + 1));
-      for (int level = max_level; level >= min_level; --level) {
-        AddMultiGridTasksLevel(region, level, min_level, max_level, level == min_level);
+      TaskRegion &region = tc.AddRegion(num_partitions);
+      for (int i = 0; i < num_partitions; ++i) { 
+        TaskList &tl = region[i];
+        AddMultiGridTasksLevel(tl, none, i, max_level, min_level, max_level, false);
       }
     } else {
       TaskRegion &region = tc.AddRegion(num_partitions);

--- a/example/poisson_gmg/poisson_driver.cpp
+++ b/example/poisson_gmg/poisson_driver.cpp
@@ -217,7 +217,7 @@ TaskID PoissonDriver::AddMultiGridTasksLevel(TaskRegion &region, TaskList &tl,
   auto pre_smooth = AddSRJIteration<BoundaryType::gmg_same>(tl, set_from_finer,
                                                             pre_stages, multilevel, md);
   // If we are finer than the coarsest level:
-  auto post_smooth = none;
+  auto post_smooth = pre_smooth;
   if (level > min_level) {
     // 3. Communicate same level boundaries so that u is up to date everywhere
     auto comm_u =

--- a/example/poisson_gmg/poisson_driver.cpp
+++ b/example/poisson_gmg/poisson_driver.cpp
@@ -155,8 +155,6 @@ TaskID PoissonDriver::AddMultiGridTasksLevel(TaskRegion &region, TaskList &tl,
                                              int max_level) {
   using namespace parthenon;
   using namespace poisson_package;
-  TaskID none(0);
-  // const int num_partitions = pmesh->DefaultNumPartitions();
 
   auto pkg = pmesh->packages.Get("poisson_package");
   auto damping = pkg->Param<Real>("jacobi_damping");

--- a/example/poisson_gmg/poisson_driver.cpp
+++ b/example/poisson_gmg/poisson_driver.cpp
@@ -182,7 +182,7 @@ TaskID PoissonDriver::AddMultiGridTasksLevel(TaskRegion &region, TaskList &tl,
   bool multilevel = (level != min_level);
 
   auto &md = pmesh->gmg_mesh_data[level].GetOrAdd(level, "base", partition);
-  // 0. Receive residual from coarser level if there is one
+  // 0. Receive residual from finer level if there is one
   auto set_from_finer = dependency;
   if (level < max_level) {
     // Fill fields with restricted values

--- a/example/poisson_gmg/poisson_driver.hpp
+++ b/example/poisson_gmg/poisson_driver.hpp
@@ -39,8 +39,9 @@ class PoissonDriver : public Driver {
 
   DriverStatus Execute() override;
 
-  TaskID AddMultiGridTasksLevel(TaskList &tl, TaskID dependency, int partition, int level, int min_level, int max_level,
-                              bool final);
+  TaskID AddMultiGridTasksLevel(TaskRegion &region, TaskList &tl, TaskID dependency,
+                                int partition, int &reg_dep_id, int level, int min_level,
+                                int max_level);
   void AddRestrictionProlongationLevel(TaskRegion &region, int level, int min_level,
                                        int max_level);
 

--- a/example/poisson_gmg/poisson_driver.hpp
+++ b/example/poisson_gmg/poisson_driver.hpp
@@ -39,7 +39,7 @@ class PoissonDriver : public Driver {
 
   DriverStatus Execute() override;
 
-  void AddMultiGridTasksLevel(TaskRegion &region, int level, int min_level, int max_level,
+  TaskID AddMultiGridTasksLevel(TaskList &tl, TaskID dependency, int partition, int level, int min_level, int max_level,
                               bool final);
   void AddRestrictionProlongationLevel(TaskRegion &region, int level, int min_level,
                                        int max_level);

--- a/example/poisson_gmg/poisson_package.hpp
+++ b/example/poisson_gmg/poisson_package.hpp
@@ -62,10 +62,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 template <class in, class out, bool only_md_level = false>
 TaskStatus CopyData(std::shared_ptr<MeshData<Real>> &md) {
   using TE = parthenon::TopologicalElement;
-  auto pmb = md->GetBlockData(0)->GetBlockPointer();
-  IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire, te);
-  IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire, te);
-  IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire, te);
+  IndexRange ib = md->GetBoundsI(IndexDomain::entire, te);
+  IndexRange jb = md->GetBoundsJ(IndexDomain::entire, te);
+  IndexRange kb = md->GetBoundsK(IndexDomain::entire, te);
 
   int nblocks = md->NumBlocks();
   std::vector<bool> include_block(nblocks, true);
@@ -91,10 +90,9 @@ TaskStatus AddFieldsAndStoreInteriorSelect(std::shared_ptr<MeshData<Real>> &md,
                                            Real wa = 1.0, Real wb = 1.0,
                                            bool only_interior = false) {
   using TE = parthenon::TopologicalElement;
-  auto pmb = md->GetBlockData(0)->GetBlockPointer();
-  IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::entire, te);
-  IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::entire, te);
-  IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::entire, te);
+  IndexRange ib = md->GetBoundsI(IndexDomain::entire, te);
+  IndexRange jb = md->GetBoundsJ(IndexDomain::entire, te);
+  IndexRange kb = md->GetBoundsK(IndexDomain::entire, te);
 
   int nblocks = md->NumBlocks();
   std::vector<bool> include_block(nblocks, true);
@@ -162,10 +160,9 @@ TaskStatus SetToZero(std::shared_ptr<MeshData<Real>> &md) {
 template <class a_t, class b_t>
 TaskStatus DotProductLocal(std::shared_ptr<MeshData<Real>> &md, Real *reduce_sum) {
   using TE = parthenon::TopologicalElement;
-  auto pmb = md->GetBlockData(0)->GetBlockPointer();
-  IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior, te);
-  IndexRange jb = pmb->cellbounds.GetBoundsJ(IndexDomain::interior, te);
-  IndexRange kb = pmb->cellbounds.GetBoundsK(IndexDomain::interior, te);
+  IndexRange ib = md->GetBoundsI(IndexDomain::interior, te);
+  IndexRange jb = md->GetBoundsJ(IndexDomain::interior, te);
+  IndexRange kb = md->GetBoundsK(IndexDomain::interior, te);
 
   auto desc = parthenon::MakePackDescriptor<a_t, b_t>(md.get());
   auto pack = desc.GetPack(md.get());
@@ -362,7 +359,6 @@ template <class... vars>
 TaskStatus PrintChosenValues(std::shared_ptr<MeshData<Real>> &md,
                              const std::string &label) {
   using TE = parthenon::TopologicalElement;
-  auto pmb = md->GetBlockData(0)->GetBlockPointer();
 
   auto desc = parthenon::MakePackDescriptor<vars...>(md.get());
   auto pack = desc.GetPack(md.get());

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -66,11 +66,13 @@ GetOrAdd_impl(Mesh *pmy_mesh_,
     // TODO(someone) add caching of partitions to Mesh at some point
     const int pack_size = pmy_mesh_->DefaultPackSize();
     auto partitions = partition::ToSizeN(block_list, pack_size);
+    // Account for possibly empty block_list
+    if (partitions.size() == 0) partitions = std::vector<BlockList_t>(1);
     for (auto i = 0; i < partitions.size(); i++) {
       std::string md_label = mbd_label + "_part-" + std::to_string(i);
       if (gmg_level >= 0) md_label = md_label + "_gmg-" + std::to_string(gmg_level);
       containers_[md_label] = std::make_shared<MeshData<Real>>(mbd_label);
-      containers_[md_label]->Set(partitions[i]);
+      containers_[md_label]->Set(partitions[i], pmy_mesh_);
       if (gmg_level >= 0) {
         int min_gmg_logical_level = pmy_mesh_->GetGMGMinLogicalLevel();
         containers_[md_label]->grid = GridIdentifier{GridType::two_level_composite,

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -220,15 +220,23 @@ class MeshData {
 
   template <class... Ts>
   IndexRange GetBoundsI(Ts &&...args) const {
-    return block_data_[0]->GetBoundsI(std::forward<Ts>(args)...);
+    if (block_data_.size() > 0)
+      return block_data_[0]->GetBoundsI(std::forward<Ts>(args)...);
+    return IndexRange{-1, -2};
   }
+
   template <class... Ts>
   IndexRange GetBoundsJ(Ts &&...args) const {
-    return block_data_[0]->GetBoundsJ(std::forward<Ts>(args)...);
+    if (block_data_.size() > 0)
+      return block_data_[0]->GetBoundsJ(std::forward<Ts>(args)...);
+    return IndexRange{-1, -2};
   }
+  
   template <class... Ts>
   IndexRange GetBoundsK(Ts &&...args) const {
-    return block_data_[0]->GetBoundsK(std::forward<Ts>(args)...);
+    if (block_data_.size() > 0)
+      return block_data_[0]->GetBoundsK(std::forward<Ts>(args)...);
+    return IndexRange{-1, -2};
   }
 
   template <class... Args>
@@ -238,10 +246,10 @@ class MeshData {
     }
   }
 
-  void Set(BlockList_t blocks) {
+  void Set(BlockList_t blocks, Mesh *pmesh) {
     const int nblocks = blocks.size();
     block_data_.resize(nblocks);
-    SetMeshPointer(blocks[0]->pmy_mesh);
+    SetMeshPointer(pmesh);
     for (int i = 0; i < nblocks; i++) {
       block_data_[i] = blocks[i]->meshblock_data.Get(stage_name_);
     }

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -231,7 +231,7 @@ class MeshData {
       return block_data_[0]->GetBoundsJ(std::forward<Ts>(args)...);
     return IndexRange{-1, -2};
   }
-  
+
   template <class... Ts>
   IndexRange GetBoundsK(Ts &&...args) const {
     if (block_data_.size() > 0)

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1105,7 +1105,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
   } while (!init_done);
 
   // Initialize the "base" MeshData object
-  mesh_data.Get()->Set(block_list);
+  mesh_data.Get()->Set(block_list, this);
 
   Kokkos::Profiling::popRegion(); // Mesh::Initialize
 }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1232,9 +1232,8 @@ void Mesh::SetupMPIComms() {
     auto &metadata = pair.second;
     // Create both boundary and flux communicators for everything with either FillGhost
     // or WithFluxes just to be safe
-    if (metadata.IsSet(Metadata::FillGhost) || 
-        metadata.IsSet(Metadata::WithFluxes) ||
-        metadata.IsSet(Metadata::ForceRemeshComm) || 
+    if (metadata.IsSet(Metadata::FillGhost) || metadata.IsSet(Metadata::WithFluxes) ||
+        metadata.IsSet(Metadata::ForceRemeshComm) ||
         metadata.IsSet(Metadata::GMGProlongate) ||
         metadata.IsSet(Metadata::GMGRestrict)) {
       MPI_Comm mpi_comm;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1232,8 +1232,11 @@ void Mesh::SetupMPIComms() {
     auto &metadata = pair.second;
     // Create both boundary and flux communicators for everything with either FillGhost
     // or WithFluxes just to be safe
-    if (metadata.IsSet(Metadata::FillGhost) || metadata.IsSet(Metadata::WithFluxes) ||
-        metadata.IsSet(Metadata::ForceRemeshComm)) {
+    if (metadata.IsSet(Metadata::FillGhost) || 
+        metadata.IsSet(Metadata::WithFluxes) ||
+        metadata.IsSet(Metadata::ForceRemeshComm) || 
+        metadata.IsSet(Metadata::GMGProlongate) ||
+        metadata.IsSet(Metadata::GMGRestrict)) {
       MPI_Comm mpi_comm;
       PARTHENON_MPI_CHECK(MPI_Comm_dup(MPI_COMM_WORLD, &mpi_comm));
       const auto ret = mpi_comm_map_.insert({pair.first.label(), mpi_comm});

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -67,13 +67,13 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       auto &md_base = pm->mesh_data.Get();
       // Populated with all blocks
       if (md_base->NumBlocks() == 0) {
-        md_base->Set(pm->block_list);
+        md_base->Set(pm->block_list, pm);
       } else if (md_base->NumBlocks() != pm->block_list.size()) {
         PARTHENON_WARN(
             "Resetting \"base\" MeshData to contain all blocks. This indicates that "
             "the \"base\" MeshData container has been modified elsewhere. Double check "
             "that the modification was intentional and is compatible with this reset.")
-        md_base->Set(pm->block_list);
+        md_base->Set(pm->block_list, pm);
       }
       auto result = hist_var.hst_fun(md_base.get());
 #ifdef MPI_PARALLEL

--- a/tst/unit/test_mesh_data.cpp
+++ b/tst/unit/test_mesh_data.cpp
@@ -78,7 +78,7 @@ TEST_CASE("MeshData works as expected for simple packs", "[MeshData]") {
     BlockList_t block_list = MakeBlockList(pkg, NBLOCKS, N, NDIM);
 
     MeshData<Real> mesh_data("base");
-    mesh_data.Set(block_list);
+    mesh_data.Set(block_list, nullptr);
 
     THEN("The number of blocks is correct") { REQUIRE(mesh_data.NumBlocks() == NBLOCKS); }
 

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -97,7 +97,7 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
     BlockList_t block_list = MakeBlockList(pkg, NBLOCKS, N, NDIM);
 
     MeshData<Real> mesh_data("base");
-    mesh_data.Set(block_list);
+    mesh_data.Set(block_list, nullptr);
 
     WHEN("We initialize the independent variables by hand and deallocate one") {
       auto ib = block_list[0]->cellbounds.GetBoundsI(IndexDomain::entire);


### PR DESCRIPTION
## PR Summary

It turns out I never bothered to actually test MG with MPI. This PR makes changes to the MG PR for MG to work correctly with MPI. First, it makes some small changes so that empty `MeshData` objects don't cause errors and adds MPI communicators for GMG fields that are involved in restriction. Second, and more importantly, it corrects a bug in the task list that allowed certain parts of composite GMG levels to run ahead of coarser levels in the hierarchy. This resulted in boundary data not being up to date at coarse-fine boundaries when any rank only owned coarse blocks on a composite grid. The multi-grid task list now includes task list dependencies and regional dependencies to ensure that the coarser levels of the hierarchy have finished before the post prolongation steps take place on finer two-level composite grids. To ensure the correct ordering within task lists, `AddMultiGridTasksLevel` is now called recursively. I did *not* need to add extra buffers, which I had mentioned as a possible solution in the Parthenon sync last Thursday.

Once this is reviewed, I will merge it into the main multi-grid PR and then merge that PR into develop.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
