### PR TITLE
Allow for registering boundary conditions by package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 968]](https://github.com/parthenon-hpc-lab/parthenon/pull/968) Add per package registration of boundary conditions
 - [[PR 948]](https://github.com/parthenon-hpc-lab/parthenon/pull/948) Add solver interface and update Poisson geometric multi-grid example 
 - [[PR 911]](https://github.com/parthenon-hpc-lab/parthenon/pull/911) Add infrastructure for geometric multi-grid
 - [[PR 932]](https://github.com/parthenon-hpc-lab/parthenon/pull/932) Add GetOrAddFlag to metadata

--- a/example/poisson_gmg/main.cpp
+++ b/example/poisson_gmg/main.cpp
@@ -11,28 +11,9 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
-#include "bvals/boundary_conditions_generic.hpp"
 #include "parthenon_manager.hpp"
 
 #include "poisson_driver.hpp"
-
-using namespace parthenon;
-using namespace parthenon::BoundaryFunction;
-// We need to register FixedFace boundary conditions by hand since they can't
-// be chosen in the parameter input file. FixedFace boundary conditions assume
-// Dirichlet booundary conditions on the face of the domain and linearly extrapolate
-// into the ghosts to ensure the linear reconstruction on the block face obeys the
-// chosen boundary condition. Just setting the ghost zones of CC variables to a fixed
-// value results in poor MG convergence because the effective BC at the face
-// changes with MG level.
-template <CoordinateDirection DIR, BCSide SIDE>
-auto GetBoundaryCondition() {
-  return [](std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse) -> void {
-    using namespace parthenon;
-    using namespace parthenon::BoundaryFunction;
-    GenericBC<DIR, SIDE, BCType::FixedFace, variable_names::any>(rc, coarse, 0.0);
-  };
-}
 
 int main(int argc, char *argv[]) {
   using parthenon::ParthenonManager;
@@ -56,19 +37,6 @@ int main(int argc, char *argv[]) {
   // Now that ParthenonInit has been called and setup succeeded, the code can now
   // make use of MPI and Kokkos
 
-  // Set boundary conditions
-  pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] =
-      GetBoundaryCondition<X1DIR, BCSide::Inner>();
-  pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x2] =
-      GetBoundaryCondition<X2DIR, BCSide::Inner>();
-  pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x3] =
-      GetBoundaryCondition<X3DIR, BCSide::Inner>();
-  pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x1] =
-      GetBoundaryCondition<X1DIR, BCSide::Outer>();
-  pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x2] =
-      GetBoundaryCondition<X2DIR, BCSide::Outer>();
-  pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x3] =
-      GetBoundaryCondition<X3DIR, BCSide::Outer>();
   pman.ParthenonInitPackagesAndMesh();
 
   // This needs to be scoped so that the driver object is destructed before Finalize

--- a/src/bvals/boundary_conditions.cpp
+++ b/src/bvals/boundary_conditions.cpp
@@ -44,6 +44,9 @@ TaskStatus ApplyBoundaryConditionsOnCoarseOrFine(std::shared_ptr<MeshBlockData<R
       PARTHENON_DEBUG_REQUIRE(pmesh->MeshBndryFnctn[i] != nullptr,
                               "boundary function must not be null");
       pmesh->MeshBndryFnctn[i](rc, coarse);
+      for (auto &bnd_func : pmesh->UserBoundaryFunctions[i]) {
+        bnd_func(rc, coarse);
+      }
     }
   }
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -169,6 +169,11 @@ void EvolutionDriver::InitializeBlockTimeStepsAndBoundaries() {
     auto &mbase = pmesh->mesh_data.GetOrAdd("base", i);
     Update::EstimateTimestep(mbase.get());
     BuildBoundaryBuffers(mbase);
+    for (int gmg_level = 0; gmg_level < pmesh->gmg_mesh_data.size(); ++gmg_level) {
+      auto &mdg = pmesh->gmg_mesh_data[gmg_level].GetOrAdd(gmg_level, "base", i);
+      BuildBoundaryBuffers(mdg);
+      BuildGMGBoundaryBuffers(mdg);
+    }
   }
 }
 

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -425,6 +425,12 @@ StateDescriptor::CreateResolvedStateDescriptor(Packages_t &packages) {
     // sort
     field_tracker.CategorizeCollection(name, field_dict, &field_provider);
     swarm_tracker.CategorizeCollection(name, package->AllSwarms(), &swarm_provider);
+
+    // Add package registered boundary conditions
+    for (int i = 0; i < 6; ++i)
+      state->UserBoundaryFunctions[i].insert(state->UserBoundaryFunctions[i].end(),
+                                             package->UserBoundaryFunctions[i].begin(),
+                                             package->UserBoundaryFunctions[i].end());
   }
 
   // check that dependent variables are provided somewhere

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -431,7 +431,7 @@ class StateDescriptor {
 
   friend std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd);
 
-  std::array<std::vector<BValFunc>, 6> UserBoundaryFunctions;
+  std::array<std::vector<BValFunc>, BOUNDARY_NFACES> UserBoundaryFunctions;
 
  private:
   void InvertControllerMap();

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -44,6 +44,8 @@ class MeshBlockData;
 template <typename T>
 class MeshData;
 
+using BValFunc = std::function<void(std::shared_ptr<MeshBlockData<Real>> &, bool)>;
+
 /// A little container class owning refinement function properties
 /// needed for the state descriptor.
 /// Note using VarID here implies that custom prolongation/restriction
@@ -428,6 +430,8 @@ class StateDescriptor {
   std::function<void(MeshBlockData<Real> *rc)> InitNewlyAllocatedVarsBlock = nullptr;
 
   friend std::ostream &operator<<(std::ostream &os, const StateDescriptor &sd);
+
+  std::array<std::vector<BValFunc>, 6> UserBoundaryFunctions;
 
  private:
   void InvertControllerMap();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -406,6 +406,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
 
   resolved_packages = ResolvePackages(packages);
 
+  // Register user defined boundary conditions
+  UserBoundaryFunctions = resolved_packages->UserBoundaryFunctions;
+
   // Setup unique comms for each variable and swarm
   SetupMPIComms();
 
@@ -662,6 +665,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   mesh_data.SetMeshPointer(this);
 
   resolved_packages = ResolvePackages(packages);
+
+  // Register user defined boundary conditions
+  UserBoundaryFunctions = resolved_packages->UserBoundaryFunctions;
 
   // Setup unique comms for each variable and swarm
   SetupMPIComms();

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -152,9 +152,9 @@ class Mesh {
   void ApplyUserWorkBeforeOutput(ParameterInput *pin);
 
   // Boundary Functions
-  BValFunc MeshBndryFnctn[6];
-  SBValFunc SwarmBndryFnctn[6];
-  std::array<std::vector<BValFunc>, 6> UserBoundaryFunctions;
+  BValFunc MeshBndryFnctn[BOUNDARY_NFACES];
+  SBValFunc SwarmBndryFnctn[BOUNDARY_NFACES];
+  std::array<std::vector<BValFunc>, BOUNDARY_NFACES> UserBoundaryFunctions;
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   std::function<void(Mesh *, ParameterInput *, MeshData<Real> *)> ProblemGenerator =

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -154,6 +154,7 @@ class Mesh {
   // Boundary Functions
   BValFunc MeshBndryFnctn[6];
   SBValFunc SwarmBndryFnctn[6];
+  std::array<std::vector<BValFunc>, 6> UserBoundaryFunctions;
 
   // defined in either the prob file or default_pgen.cpp in ../pgen/
   std::function<void(Mesh *, ParameterInput *, MeshData<Real> *)> ProblemGenerator =

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -152,9 +152,6 @@ class MGSolver {
     IndexRange jb = md->GetBoundsJ(IndexDomain::interior, te);
     IndexRange kb = md->GetBoundsK(IndexDomain::interior, te);
 
-    auto pkg = md->GetMeshPointer()->packages.Get("poisson_package");
-    const auto alpha = pkg->Param<Real>("diagonal_alpha");
-
     int nblocks = md->NumBlocks();
     std::vector<bool> include_block(nblocks, true);
 

--- a/tst/regression/test_suites/poisson_gmg/parthinput.poisson
+++ b/tst/regression/test_suites/poisson_gmg/parthinput.poisson
@@ -21,14 +21,14 @@ multigrid = true
 nx1 = 64
 x1min = -1.0
 x1max = 1.0
-ix1_bc = user
-ox1_bc = user
+ix1_bc = outflow
+ox1_bc = outflow
 
 nx2 = 64
 x2min = -1.0
 x2max = 1.0
-ix2_bc = user
-ox2_bc = user
+ix2_bc = outflow
+ox2_bc = outflow
 
 nx3 = 1
 x3min = 0.0


### PR DESCRIPTION
## PR Summary

This PR contains a proposal for adding the ability to register boundary conditions on a per package basis. I am not wedded to this setup, but it was easy to implement and I think provides the functionality that I foresee needing myself. As written, boundary conditions will behave exactly as they used to unless boundary condition functions are registered within a package. 

Per package boundary condition registration is performed by adding to the `UserBoundaryFunctions` vectors:
```c++
template <CoordinateDirection DIR, BCSide SIDE>
auto GetMyBC() {
  return [](std::shared_ptr<MeshBlockData<Real>> &rc, bool coarse) -> void {
    // Implementation of BC here
  };
}

std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
  ...
  using BF = parthenon::BoundaryFace;
  pkg->UserBoundaryFunctions[BF::inner_x1].push_back(GetMyBC<X1DIR, BCSide::Inner>());
  pkg->UserBoundaryFunctions[BF::inner_x2].push_back(GetMyBC<X2DIR, BCSide::Inner>());
  ...
}
```
At package resolution, all of the boundary conditions functions from different packages are put into a vector of function pointers and when physical boundary conditions are called these functions are just sequentially called after calling `Mesh::MeshBndryFnctn`. One clear drawback of the current approach is that if multiple user registered boundary conditions update the same variable, its boundary values will be determined by the last boundary function operating on it that is called (i.e. there is no easy way to set the precedence of boundary functions).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
