### PR TITLE
Add hook for UserWorkBeforeLoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 971]](https://github.com/parthenon-hpc-lab/parthenon/pull/971) Add UserWorkBeforeLoop
 - [[PR 907]](https://github.com/parthenon-hpc-lab/parthenon/pull/907) PEP1: Allow subclassing StateDescriptor
 - [[PR 932]](https://github.com/parthenon-hpc-lab/parthenon/pull/932) Add GetOrAddFlag to metadata
 - [[PR 931]](https://github.com/parthenon-hpc-lab/parthenon/pull/931) Allow SparsePacks with subsets of blocks

--- a/doc/sphinx/src/interface/state.rst
+++ b/doc/sphinx/src/interface/state.rst
@@ -112,6 +112,13 @@ several useful features and functions.
   deletgates to the ``std::function`` member ``PostStepDiagnosticsMesh``
   if set (defaults to ``nullptr`` an therefore a no-op) to print
   diagnostics after the time-integration advance
+- ``void UserWorkBeforeLoopMesh(Mesh *, ParameterInput *pin, SimTime
+  &tm)`` performs a per-package, mesh-wide calculation after the mesh
+  has been generated, and problem generators called, but before any
+  time evolution. This work is done both on first initialization and
+  on restart. If you would like to avoid doing the work upon restart,
+  you can check for the const ``is_restart`` member field of the ``Mesh``
+  object.
 
 The reasoning for providing ``FillDerived*`` and ``EstimateTimestep*``
 function pointers appropriate for usage with both ``MeshData`` and

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -217,6 +217,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   }
   pkg->CheckRefinementBlock = CheckRefinement;
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;
+  pkg->UserWorkBeforeLoopMesh = AdvectionGreetings;
 
   return pkg;
 }
@@ -224,7 +225,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 void AdvectionGreetings(Mesh *pmesh, ParameterInput *pin, parthenon::SimTime &tm) {
   if (parthenon::Globals::my_rank == 0) {
     std::cout << "Hello from the advection package in the advection example!\n"
-              << "This run is a restart: " << pmesh->is_restart << std::endl;
+              << "This run is a restart: " << pmesh->is_restart << "\n"
+              << std::endl;
   }
 }
 

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -13,12 +13,14 @@
 
 #include <algorithm>
 #include <cmath>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <string>
 #include <vector>
 
 #include <coordinates/coordinates.hpp>
+#include <globals.hpp>
 #include <parthenon/package.hpp>
 
 #include "advection_package.hpp"
@@ -217,6 +219,14 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   pkg->EstimateTimestepBlock = EstimateTimestepBlock;
 
   return pkg;
+}
+
+void AdvectionGreetings(Mesh *pmesh, ParameterInput *pin, SimTime &tm) {
+  if (GLobals::my_rank == 0) {
+    std::cout << "Hello from the advection package in the advection example!\n"
+	      << "This run is a restart: " << pmesh->is_restart
+	      << std::endl;
+  }
 }
 
 AmrTag CheckRefinement(MeshBlockData<Real> *rc) {

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -221,11 +221,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   return pkg;
 }
 
-void AdvectionGreetings(Mesh *pmesh, ParameterInput *pin, SimTime &tm) {
-  if (GLobals::my_rank == 0) {
+void AdvectionGreetings(Mesh *pmesh, ParameterInput *pin, parthenon::SimTime &tm) {
+  if (parthenon::Globals::my_rank == 0) {
     std::cout << "Hello from the advection package in the advection example!\n"
-	      << "This run is a restart: " << pmesh->is_restart
-	      << std::endl;
+              << "This run is a restart: " << pmesh->is_restart << std::endl;
   }
 }
 

--- a/example/advection/advection_package.hpp
+++ b/example/advection/advection_package.hpp
@@ -21,6 +21,7 @@ namespace advection_package {
 using namespace parthenon::package::prelude;
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
+  void AdvectionGreetings(Mesh *pmes, ParameterInput *pin, SimTime &tm);
 AmrTag CheckRefinement(MeshBlockData<Real> *rc);
 void PreFill(MeshBlockData<Real> *rc);
 void SquareIt(MeshBlockData<Real> *rc);

--- a/example/advection/advection_package.hpp
+++ b/example/advection/advection_package.hpp
@@ -21,7 +21,7 @@ namespace advection_package {
 using namespace parthenon::package::prelude;
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
-  void AdvectionGreetings(Mesh *pmes, ParameterInput *pin, SimTime &tm);
+void AdvectionGreetings(Mesh *pmes, ParameterInput *pin, parthenon::SimTime &tm);
 AmrTag CheckRefinement(MeshBlockData<Real> *rc);
 void PreFill(MeshBlockData<Real> *rc);
 void SquareIt(MeshBlockData<Real> *rc);

--- a/example/advection/advection_package.hpp
+++ b/example/advection/advection_package.hpp
@@ -21,7 +21,7 @@ namespace advection_package {
 using namespace parthenon::package::prelude;
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
-void AdvectionGreetings(Mesh *pmes, ParameterInput *pin, parthenon::SimTime &tm);
+void AdvectionGreetings(Mesh *pmesh, ParameterInput *pin, parthenon::SimTime &tm);
 AmrTag CheckRefinement(MeshBlockData<Real> *rc);
 void PreFill(MeshBlockData<Real> *rc);
 void SquareIt(MeshBlockData<Real> *rc);

--- a/example/advection/advection_package.hpp
+++ b/example/advection/advection_package.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -48,6 +48,7 @@ struct ApplicationInput {
       PostStepDiagnosticsInLoop = nullptr;
 
   std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkAfterLoop = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkBeforeLoop = nullptr;
   BValFunc boundary_conditions[BOUNDARY_NFACES] = {nullptr};
   SBValFunc swarm_boundary_conditions[BOUNDARY_NFACES] = {nullptr};
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -77,13 +77,16 @@ DriverStatus EvolutionDriver::Execute() {
 
   // Before loop do work
   // App input version
+  Kokkos::Profiling::pushRegion("Driver_UserWorkBeforeLoop");
   if (app_input->UserWorkBeforeLoop != nullptr) {
     app_input->UserWorkBeforeLoop(pmesh, pinput, tm);
   }
+
   // packages version
   for (auto &[name, pkg] : pmesh->packages.AllPackages()) {
     pkg->UserWorkBeforeLoop(pmesh, pinput, tm);
   }
+  Kokkos::Profiling::popRegion(); // Driver_UserWorkBeforeLoop
 
   Kokkos::Profiling::pushRegion("Driver_Main");
   while (tm.KeepGoing()) {

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -75,6 +75,16 @@ DriverStatus EvolutionDriver::Execute() {
   // Defaults must be set across all ranks
   DumpInputParameters();
 
+  // Before loop do work
+  // App input version
+  if (app_input->UserWorkBeforeLoop != nullptr) {
+    app_input->UserWorkBeforeLoop(pmesh, pinput, tm);
+  }
+  // packages version
+  for (auto &[name, pkg] : pmesh->packages.AllPackages()) {
+    pkg->UserWorkBeforeLoop(pmesh, pinput, tm);
+  }
+
   Kokkos::Profiling::pushRegion("Driver_Main");
   while (tm.KeepGoing()) {
     if (Globals::my_rank == 0) OutputCycleDiagnostics();

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -217,17 +217,18 @@ class StateDescriptor {
   // one can pass in a reference to a SparsePool or arguments that match one of the
   // SparsePool constructors
   template <typename... Args>
-  bool AddSparsePool(Args &&...args) {
+  bool AddSparsePool(Args &&... args) {
     return AddSparsePoolImpl(SparsePool(std::forward<Args>(args)...));
   }
   template <typename... Args>
-  bool AddSparsePool(const std::string &base_name, const Metadata &m_in, Args &&...args) {
+  bool AddSparsePool(const std::string &base_name, const Metadata &m_in,
+                     Args &&... args) {
     Metadata m = m_in; // so we can modify it
     if (!m.IsSet(GetMetadataFlag())) m.Set(GetMetadataFlag());
     return AddSparsePoolImpl(SparsePool(base_name, m, std::forward<Args>(args)...));
   }
   template <typename T, typename... Args>
-  bool AddSparsePool(const Metadata &m_in, Args &&...args) {
+  bool AddSparsePool(const Metadata &m_in, Args &&... args) {
     return AddSparsePool(T::name(), m_in, std::forward<Args>(args)...);
   }
 
@@ -406,6 +407,10 @@ class StateDescriptor {
     if (InitNewlyAllocatedVarsBlock != nullptr) return InitNewlyAllocatedVarsBlock(rc);
   }
 
+  void UserWorkBeforeLoop(Mesh *pmesh, ParameterInput *pin, SimTime &tm) const {
+    if (UserWorkBeforeLoopMesh != nullptr) return UserWorkBeforeLoopMesh(pmesh, pin, tm);
+  }
+
   std::vector<std::shared_ptr<AMRCriteria>> amr_criteria;
 
   std::function<void(MeshBlockData<Real> *rc)> PreCommFillDerivedBlock = nullptr;
@@ -416,6 +421,8 @@ class StateDescriptor {
   std::function<void(MeshData<Real> *rc)> PostFillDerivedMesh = nullptr;
   std::function<void(MeshBlockData<Real> *rc)> FillDerivedBlock = nullptr;
   std::function<void(MeshData<Real> *rc)> FillDerivedMesh = nullptr;
+  std::function<void(Mesh *, ParameterInput *, SimTime &)> UserWorkBeforeLoopMesh =
+      nullptr;
 
   std::function<void(SimTime const &simtime, MeshData<Real> *rc)> PreStepDiagnosticsMesh =
       nullptr;

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -217,18 +217,17 @@ class StateDescriptor {
   // one can pass in a reference to a SparsePool or arguments that match one of the
   // SparsePool constructors
   template <typename... Args>
-  bool AddSparsePool(Args &&... args) {
+  bool AddSparsePool(Args &&...args) {
     return AddSparsePoolImpl(SparsePool(std::forward<Args>(args)...));
   }
   template <typename... Args>
-  bool AddSparsePool(const std::string &base_name, const Metadata &m_in,
-                     Args &&... args) {
+  bool AddSparsePool(const std::string &base_name, const Metadata &m_in, Args &&...args) {
     Metadata m = m_in; // so we can modify it
     if (!m.IsSet(GetMetadataFlag())) m.Set(GetMetadataFlag());
     return AddSparsePoolImpl(SparsePool(base_name, m, std::forward<Args>(args)...));
   }
   template <typename T, typename... Args>
-  bool AddSparsePool(const Metadata &m_in, Args &&... args) {
+  bool AddSparsePool(const Metadata &m_in, Args &&...args) {
     return AddSparsePool(T::name(), m_in, std::forward<Args>(args)...);
   }
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -64,6 +64,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
            int mesh_test)
     : // public members:
       modified(true),
+      is_restart(false),
       // aggregate initialization of RegionSize struct:
       mesh_size({pin->GetReal("parthenon/mesh", "x1min"),
                  pin->GetReal("parthenon/mesh", "x2min"),
@@ -485,6 +486,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
       // aggregate initialization of RegionSize struct:
       // (will be overwritten by memcpy from restart file, in this case)
       modified(true),
+      is_restart(true),
       // aggregate initialization of RegionSize struct:
       mesh_size({pin->GetReal("parthenon/mesh", "x1min"),
                  pin->GetReal("parthenon/mesh", "x2min"),

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -63,8 +63,7 @@ namespace parthenon {
 Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
            int mesh_test)
     : // public members:
-      modified(true),
-      is_restart(false),
+      modified(true), is_restart(false),
       // aggregate initialization of RegionSize struct:
       mesh_size({pin->GetReal("parthenon/mesh", "x1min"),
                  pin->GetReal("parthenon/mesh", "x2min"),
@@ -485,8 +484,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
     : // public members:
       // aggregate initialization of RegionSize struct:
       // (will be overwritten by memcpy from restart file, in this case)
-      modified(true),
-      is_restart(true),
+      modified(true), is_restart(true),
       // aggregate initialization of RegionSize struct:
       mesh_size({pin->GetReal("parthenon/mesh", "x1min"),
                  pin->GetReal("parthenon/mesh", "x2min"),

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -94,6 +94,7 @@ class Mesh {
 
   // data
   bool modified;
+  const bool is_restart;
   RegionSize mesh_size;
   BoundaryFlag mesh_bcs[BOUNDARY_NFACES];
   const int ndim; // number of dimensions


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

What it says on the can... This kind of workflow has come up a number of times for us in downstream applications, so I decided to finally stick it into parthenon. The basic need here is that you want to modify some variables after the mesh has been generated and problem generator has been called, for example, because you want to compute some global reduction variable, you want to normalize some field, you want to apply atmospheres, etc.

Now this can be done within a problem generator in some cases, for example with mesh-level problem generators. But it may be desired to do this work for *every* problem (for example). I add a hook in `ApplicationInputs` and in `StateDescriptor`. As usual, you assign a function pointer, and then it gets called by `EvolutionDriver`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
