### PR TITLE
Forceinline par_for_inner: add meshblock version

### DIFF
--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -57,7 +57,7 @@ class StateDescriptor;
 // - Not defined in kokkos_abstraction.hpp because it requires the compile time option
 //   DEFAULT_INNER_LOOP_PATTERN to be set.
 template <typename Function>
-KOKKOS_INLINE_FUNCTION void par_for_inner(const team_mbr_t &team_member, const int &il,
+KOKKOS_FORCEINLINE_FUNCTION void par_for_inner(const team_mbr_t &team_member, const int &il,
                                           const int &iu, const Function &function) {
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, team_member, il, iu, function);
 }

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -57,8 +57,9 @@ class StateDescriptor;
 // - Not defined in kokkos_abstraction.hpp because it requires the compile time option
 //   DEFAULT_INNER_LOOP_PATTERN to be set.
 template <typename Function>
-KOKKOS_FORCEINLINE_FUNCTION void par_for_inner(const team_mbr_t &team_member, const int &il,
-                                          const int &iu, const Function &function) {
+KOKKOS_FORCEINLINE_FUNCTION void par_for_inner(const team_mbr_t &team_member,
+                                               const int &il, const int &iu,
+                                               const Function &function) {
   parthenon::par_for_inner(DEFAULT_INNER_LOOP_PATTERN, team_member, il, iu, function);
 }
 


### PR DESCRIPTION
This is an amendment to #967 that adds the implementation of `par_for_inner` in `meshblock.hpp` to the functions forced to be inline.  It gets rid of some more warnings about non-vectorized code for me (though I haven't directly measured performance), and since it's just a call through there should be no other impact.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
