### PR TITLE
[trivial] move userworkbeforeloop before outputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [[PR 868]](https://github.com/parthenon-hpc-lab/parthenon/pull/868) Add block-local face, edge, and nodal fields and allow for packing
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 976]](https://github.com/parthenon-hpc-lab/parthenon/pull/976) Move UserWorkBeforeLoop to be after first output
 - [[PR 965]](https://github.com/parthenon-hpc-lab/parthenon/pull/965) Allow leading whitespace in input parameters
 - [[PR 926]](https://github.com/parthenon-hpc-lab/parthenon/pull/926) Internal refinement op registration
 - [[PR 897]](https://github.com/parthenon-hpc-lab/parthenon/pull/897) Deflate compression filter is not called any more if compression is soft disabled

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -65,6 +65,19 @@ DriverStatus EvolutionDriver::Execute() {
   PreExecute();
   InitializeBlockTimeStepsAndBoundaries();
   SetGlobalTimeStep();
+
+  // Before loop do work
+  // App input version
+  Kokkos::Profiling::pushRegion("Driver_UserWorkBeforeLoop");
+  if (app_input->UserWorkBeforeLoop != nullptr) {
+    app_input->UserWorkBeforeLoop(pmesh, pinput, tm);
+  }
+  // packages version
+  for (auto &[name, pkg] : pmesh->packages.AllPackages()) {
+    pkg->UserWorkBeforeLoop(pmesh, pinput, tm);
+  }
+  Kokkos::Profiling::popRegion(); // Driver_UserWorkBeforeLoop
+
   OutputSignal signal = OutputSignal::none;
   pouts->MakeOutputs(pmesh, pinput, &tm, signal);
   pmesh->mbcnt = 0;
@@ -74,19 +87,6 @@ DriverStatus EvolutionDriver::Execute() {
   // Output a text file of all parameters at this point
   // Defaults must be set across all ranks
   DumpInputParameters();
-
-  // Before loop do work
-  // App input version
-  Kokkos::Profiling::pushRegion("Driver_UserWorkBeforeLoop");
-  if (app_input->UserWorkBeforeLoop != nullptr) {
-    app_input->UserWorkBeforeLoop(pmesh, pinput, tm);
-  }
-
-  // packages version
-  for (auto &[name, pkg] : pmesh->packages.AllPackages()) {
-    pkg->UserWorkBeforeLoop(pmesh, pinput, tm);
-  }
-  Kokkos::Profiling::popRegion(); // Driver_UserWorkBeforeLoop
 
   Kokkos::Profiling::pushRegion("Driver_Main");
   while (tm.KeepGoing()) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This is a trivial change to a feature I think almost no one is using yet. One reason to use `UserWorkBeforeLoop` is to modify, e.g., initial conditions. If you want to see that reflected in your initial data, it needs to be before the first output. This moves it to be above the first output.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
