### PR TITLE
WIP: Attempt to fix hanging at first output

### DIFF
--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -414,6 +414,7 @@ void OutputType::ClearOutputData() {
 void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
                           const SignalHandler::OutputSignal signal) {
   Kokkos::Profiling::pushRegion("MakeOutputs");
+  MPI_Barrier(MPI_COMM_WORLD);
   bool first = true;
   OutputType *ptype = pfirst_type_;
   while (ptype != nullptr) {
@@ -429,6 +430,7 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
     }
     ptype = ptype->pnext_type; // move to next OutputType node in singly linked list
   }
+  MPI_Barrier(MPI_COMM_WORLD);
   Kokkos::Profiling::popRegion(); // MakeOutputs
 }
 


### PR DESCRIPTION
## PR Summary

This is a ham-fisted attempt at fixing an MPI hang in KHARMA on slow filesystems when both SMR and HDF5 outputs are enabled.  It appears not to happen for AMR (at least, early on) or single-mesh runs.

The patch as-is doesn't seem to fully fix the issue for me, but it does decrease the frequency a little.  If I get a solid fix working I'll post it here and remove WIP.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
