### PR TITLE
`IndexSplit` for hierarchical parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 981]](https://github.com/parthenon-hpc-lab/parthenon/pull/981) Add IndexSplit
 - [[PR 968]](https://github.com/parthenon-hpc-lab/parthenon/pull/968) Add per package registration of boundary conditions
 - [[PR 948]](https://github.com/parthenon-hpc-lab/parthenon/pull/948) Add solver interface and update Poisson geometric multi-grid example
 

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -121,7 +121,7 @@ get optimal performance. Here we list a few strategies/considerations.
   inner loop per SM (which is related to "occupancy") will depend
   positively on length of the inner loop and negatively on higher
   shared memory usage (scratch pad memory in Kokkos parlance and Local
-  Data Store or LDS on AMD GPUs) and higher register usage. Note that
+  Data Share or LDS on AMD GPUs) and higher register usage. Note that
   the number of SMs and the available shared memory and registers per
   SM will vary between GPU architectures and especially between GPU
   vendors.

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -133,7 +133,7 @@ where here ``md`` is a ``MeshData`` object on which you want to
 operate. ``domain`` specifies where in the ``MeshBlock`` you wish to
 operate, for example ``IndexDomain::Interior``. ``nkp`` and ``njp``
 are the number of points in ``X3`` and ``X2`` respectively that are in
-the outer loop. All remaining points are in the inner loop. Typically
+the outer loop. All remaining points are in the inner loop; each team will iterate over multiple `k` and/or `j` indices to cover the specified `k/j` range. Typically
 ``MeshBlock`` index in the pack is also assumed to be in the outer
 loop. ``nkp`` and ``njp`` also accept special flags
 ``IndexSplit::all_outer`` and ``IndexSplit::no_outer``, which specify

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -129,8 +129,8 @@ can be constructed as
 
   IndexSplit(MeshData<Real> md, IndexDomain domain, const int nkp, const int njp);
 
-where here ``md`` is ``MeshData`` object on which you want to
-operatore. ``domain`` specifies where in the ``MeshBlock`` you wish to
+where here ``md`` is a ``MeshData`` object on which you want to
+operate. ``domain`` specifies where in the ``MeshBlock`` you wish to
 operate, for example ``IndexDomain::Interior``. ``nkp`` and ``njp``
 are the number of points in ``X3`` and ``X2`` respectively that are in
 the outer loop. All remaining points are in the inner loop. Typically

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -110,10 +110,10 @@ get optimal performance. Here we list a few strategies/considerations.
   vector cells in the inner loop is to do a 1D ``SIMDFOR`` inner loop
   but combine the ``j`` and ``i`` indices by simply looping over the
   contiguous memory in a rasterized plane on a block.
-* On Cuda GPUs, the outer loop typically maps to blocks, while the
+* On GPUs, the outer loop typically maps to blocks, while the
   inner maps to threads. To see good performance, you must both
-  provide enough work in the inner loop to create enough threads to fill a streaming multiprocessor (SM) with multiple warps to take advantage of pipelining and enough work
-  in the outer loop to create enough blocks to fill all SMs on the GPU divided by the number of simultaneous streams. The number of warps in flight on the inner loop per SM (which is related to "occupancy") will depend positively on length of the inner loop and negatively on higher shared memory usage (or scratch pad memory in Kokkos parlance) and higher register usage.
+  provide enough work in the inner loop to create enough threads to fill in CUDA terms a streaming multiprocessor (SM, equivalent to a Compute Unit or CU on AMD GPUs) with multiple warps (or wavefronts for AMD) to take advantage of pipelining and enough work
+  in the outer loop to create enough blocks to fill all SMs on the GPU divided by the number of simultaneous streams. The number of warps in flight on the inner loop per SM (which is related to "occupancy") will depend positively on length of the inner loop and negatively on higher shared memory usage (scratch pad memory in Kokkos parlance and Local Data Store or LDS on AMD GPUs) and higher register usage. Note that the number of SMs and the available shared memory and registers per SM will vary between GPU architectures and especially between GPU vendors.
 
 IndexSplit
 -------------

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -136,11 +136,12 @@ available in ``<parthenon/package.hpp>`` in the
 ``parthenon::package::prelude`` namespace.
 
 In our experience ``IndexSplit`` is most beneficial when working with
-small meshblocks, especially in two dimensions. For small blocks, we
-want vectorized operations over contiguous memory for our innermost
-loop, but we want that loop to contain enough work for, e.g., vector
-ops to function. We have often found that the optimal split is to fuse
-j, and i into the inner loop and use k and blocks in the outer loop.
+small meshblocks on CPUs, especially in two dimensions. For small
+blocks, we want vectorized operations over contiguous memory for our
+innermost loop, but we want that loop to contain enough work for,
+e.g., vector ops to function. We have often found that the optimal
+split is to fuse j, and i into the inner loop and use k and blocks in
+the outer loop.
 
 The ``IndexSplit`` class can be constructed as
 

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -51,7 +51,7 @@ Data type for memory in scratch pad/cache memory. Use
 documentation <https://kokkos.github.io/kokkos-core-wiki/ProgrammingGuide/HierarchicalParallelism.html?highlight=hierarchical>`__
 for determining scratch pad memory needs before kernel launch.
 
-Important usage hints
+On Barriers
 ---------------------
 
 In order to ensure that individual threads of a team are synchronized
@@ -70,6 +70,7 @@ write to common variables, see this
 `code <https://github.com/parthenon-hpc-lab/parthenon/issues/659#issuecomment-1346871509>`__
 for an example.
 
+
 Cmake Options
 -------------
 
@@ -86,3 +87,117 @@ GPUs.
 ``#pragma omp simd`` to vectorize the loop, which typically gives better
 vectorization loops than ``PAR_LOOP_INNER_LAYOUT=TVR_INNER_LOOP`` on
 CPUs and so is the default on CPUs.
+
+
+Performance Considerations
+---------------------------
+
+Hierarchical parallelism can produce very performant code, but a
+deeper awareness of how hardware is mapped to threads is required to
+get optimal performance. Here we list a few strategies/considerations.
+
+* On CPU, with `SIMDFOR_INNER_LOOP` you may have trouble vectorizing
+  unless you help the compiler along. One way to do so is to work with
+  raw pointers to contiguous memory, rather than working with views
+  and strides. Even for stencil ops, if you can pull out pointers that
+  represent the different points on the stencil, this can help with
+  vectorization.
+* Similarly on CPUs, due to the cost of starting up a vector op,
+  vectorization will only be a performance win if there's enough work
+  in the inner loop. A minimum of 16 points is required for the op to
+  vectorize at all. Experience shows, however, that at least 64 is
+  really required to see big wins. One strategy for providing enough
+  vector cells in the inner loop is to do a 1D ``SIMDFOR`` inner loop
+  but combine the ``j`` and ``i`` indices by simply looping over the
+  contiguous memory in a rasterized plane on a block.
+* On Cuda GPUs, the outer loop typically maps to warps, while the
+  inner maps to threads. To see good performance, you must both
+  provide enough work in the inner loop to fill a warp and enough work
+  in the outer loop to fill all warps.
+
+IndexSplit
+-------------
+
+To balance the CPU vs GPU hardware considerations of hierarchical
+parallelism, ``Parthenon`` provides a utility, the ``IndexSplit``
+class, defined in the ``utils/index_split.hpp`` header file and
+available in ``<parthenon/package.hpp>`` in the
+``parthenon::package::prelude`` namespace. The ``IndexSplit`` class
+can be constructed as
+
+.. code:: cpp
+
+  IndexSplit(MeshData<Real> md, IndexDomain domain, const int nkp, const int njp);
+
+where here ``md`` is ``MeshData`` object on which you want to
+operatore. ``domain`` specifies where in the ``MeshBlock`` you wish to
+operate, for example ``IndexDomain::Interior``. ``nkp`` and ``njp``
+are the number of points in ``X3`` and ``X2`` respectively that are in
+the outer loop. All remaining points are in the inner loop. Typically
+``MeshBlock`` index in the pack is also assumed to be in the outer
+loop. ``nkp`` and ``njp`` also accept special flags
+``IndexSplit::all_outer`` and ``IndexSplit::no_outer``, which specify
+that all and none of the indices in that direction should be in the
+outer loop.
+
+A second constructor alternatively sets the range for ``X3``, ``X2``,
+and ``X1`` explicitly:
+
+.. code:: cpp
+
+  IndexSplit(MeshData<Real> *md, const IndexRange &kb, const IndexRange &jb,
+             const IndexRange &ib, const int nkp, const int njp);
+
+where here ``kb``, ``jb``, and ``ib`` specify the starting and ending
+indices for ``X3``, ``X2``, and ``X1`` respecively.
+
+An ``IndexSplit`` object is typically used as:
+
+.. code:: cpp
+
+  using namespace parthenon::package::prelude;
+  using parthenon::ScratchPad1D;
+  using parthenon::IndexSplit;
+  using parthenon::par_for_outer;
+  using parthenon::par_for_inner;
+  using parthenon::team_mbr_t;
+  // Initialize index split object
+  IndexSplit idx_sp(md, IndexDomain::interior, nkp, njp);
+  
+  // Request maximum size in i and j in the inner loop, for scratch
+  const int Ni = idx_sp.get_max_ni();
+  const int Nj = idx_sp = get_max_nj();
+  const in tNmax = Ni * Nj;
+  
+  // single scratch array for i,j
+  auto scratch_size = ScratchPad1D<Real>::shmem_size(Nmax);
+  constexpr int scratch_level = 0;
+  
+  // Par for
+  par_for_outer(
+	  DEFAULT_OUTER_LOOP_PATTERN, "KernalOuter", DevExecSpace(), scratch_size,
+	  scratch_level, 0, nblocks - 1, 0, idx_sp.outer_size() - 1,
+	  KOKKOS_LAMBDA(team_mbr_t member, const int b, const int outer_idx) {
+	    ScratchPad1D<Real> scratch(member.team_scratch(scratch_level), Nmax);
+	    // Get index ranges. Note they depend on where we are in the outer index!
+	    // These give us a sense for where we are in k,j space
+	    const auto krange = idx_sp.GetBoundsK(outer_idx);
+	    const auto jrange = idx_sp.GetBoundsJ(outer_idx);
+	    // This is the loop of contiguous inner memory. May contain i and j!
+	    const auto irange = idx_sp.GetInnerBounds(jrange);
+
+	    // Whatever part of k is not in the outer loop can be looped over
+	    // with a normal for loop here
+	    for (int k = krange.s; k <= krange.e; ++k) {
+
+	      // pull out a pointer some variable in some pack. Note
+	      // we pick the 0th index of i at k and jrange.s
+	      Real *var = &pack(b, ivar, k, jrange.s, 0);
+
+	      // Do something with the pointer in the inner loop.
+	      par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, irange.s, irange.e,
+	        [&](const int i) {
+		  foo(var[i]);
+		});
+	    }
+	  });

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -153,12 +153,13 @@ where here ``md`` is a ``MeshData`` object on which you want to
 operate. ``domain`` specifies where in the ``MeshBlock`` you wish to
 operate, for example ``IndexDomain::Interior``. ``nkp`` and ``njp``
 are the number of points in ``X3`` and ``X2`` respectively that are in
-the outer loop. All remaining points are in the inner loop; each team will iterate over multiple `k` and/or `j` indices to cover the specified `k/j` range. Typically
-``MeshBlock`` index in the pack is also assumed to be in the outer
-loop. ``nkp`` and ``njp`` also accept special flags
-``IndexSplit::all_outer`` and ``IndexSplit::no_outer``, which specify
-that all and none of the indices in that direction should be in the
-outer loop.
+the outer loop. All remaining points are in the inner loop; each team
+will iterate over multiple `k` and/or `j` indices to cover the
+specified `k/j` range. Typically ``MeshBlock`` index in the pack is
+also assumed to be in the outer loop. ``nkp`` and ``njp`` also accept
+special flags ``IndexSplit::all_outer`` and ``IndexSplit::no_outer``,
+which specify that all and none of the indices in that direction
+should be in the outer loop.
 
 A second constructor alternatively sets the range for ``X3``, ``X2``,
 and ``X1`` explicitly:
@@ -170,6 +171,14 @@ and ``X1`` explicitly:
 
 where here ``kb``, ``jb``, and ``ib`` specify the starting and ending
 indices for ``X3``, ``X2``, and ``X1`` respecively.
+
+.. warning::
+
+  Note that, at this time, ``IndexSplit`` doesn't know about
+  face-centered or edge-centered data. To use ``IndexSplit`` with,
+  e.g., face-centered data, set the input ``IndexRange`` quantities to
+  match the shape for the face-centered data (e.g., with the
+  appropriate offsets).
 
 An ``IndexSplit`` object is typically used as:
 

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -139,12 +139,8 @@ In our experience ``IndexSplit`` is most beneficial when working with
 small meshblocks, especially in two dimensions. For small blocks, we
 want vectorized operations over contiguous memory for our innermost
 loop, but we want that loop to contain enough work for, e.g., vector
-ops to function. 
-
-On CPUs, the optimal split is to fuse k, j, and i into the inner loop
-and use blocks in the outer loop. On Cuda GPUs, we have found a more
-optimal split is to fuse k and block index (in three dimensions) into
-the outer loop and i and j in the inner loop.
+ops to function. We have often found that the optimal split is to fuse
+j, and i into the inner loop and use k and blocks in the outer loop.
 
 The ``IndexSplit`` class can be constructed as
 

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -110,10 +110,10 @@ get optimal performance. Here we list a few strategies/considerations.
   vector cells in the inner loop is to do a 1D ``SIMDFOR`` inner loop
   but combine the ``j`` and ``i`` indices by simply looping over the
   contiguous memory in a rasterized plane on a block.
-* On Cuda GPUs, the outer loop typically maps to warps, while the
+* On Cuda GPUs, the outer loop typically maps to blocks, while the
   inner maps to threads. To see good performance, you must both
-  provide enough work in the inner loop to fill a warp and enough work
-  in the outer loop to fill all warps.
+  provide enough work in the inner loop to create enough threads to fill a streaming multiprocessor (SM) with multiple warps to take advantage of pipelining and enough work
+  in the outer loop to create enough blocks to fill all SMs on the GPU divided by the number of simultaneous streams. The number of warps in flight on the inner loop per SM (which is related to "occupancy") will depend positively on length of the inner loop and negatively on higher shared memory usage (or scratch pad memory in Kokkos parlance) and higher register usage.
 
 IndexSplit
 -------------

--- a/doc/sphinx/src/nested_par_for.rst
+++ b/doc/sphinx/src/nested_par_for.rst
@@ -221,7 +221,7 @@ An ``IndexSplit`` object is typically used as:
 
 	      // pull out a pointer some variable in some pack. Note
 	      // we pick the 0th index of i at k and jrange.s
-	      Real *var = &pack(b, ivar, k, jrange.s, 0);
+	      Real *var = &pack(b, ivar, k, jrange.s, irange.s);
 
 	      // Do something with the pointer in the inner loop.
 	      par_for_inner(DEFAULT_INNER_LOOP_PATTERN, member, irange.s, irange.e,

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -90,11 +90,11 @@ parthenon::DriverStatus PiDriver::Execute() {
   // retrieve "pi_val" and post execute.
   auto &pi_val = pmesh->packages.Get("calculate_pi")->Param<Real>("pi_val");
   pmesh->mbcnt = pmesh->nbtotal; // this is how many blocks were processed
-  PostExecute(pi_val);
+  PiPostExecute(pi_val);
   return DriverStatus::complete;
 }
 
-void PiDriver::PostExecute(Real pi_val) {
+void PiDriver::PiPostExecute(Real pi_val) {
   if (my_rank == 0) {
     std::cout << std::endl
               << std::endl

--- a/example/calculate_pi/pi_driver.hpp
+++ b/example/calculate_pi/pi_driver.hpp
@@ -42,7 +42,7 @@ class PiDriver : public Driver {
   DriverStatus Execute() override;
 
  protected:
-  void PostExecute(Real pi_val);
+  void PiPostExecute(Real pi_val);
 };
 
 } // namespace pi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,9 +233,11 @@ add_library(parthenon
   utils/communication_buffer.hpp
   utils/cleantypes.hpp
   utils/concepts_lite.hpp
-  utils/error_checking.hpp
   utils/error_checking.cpp
+  utils/error_checking.hpp
   utils/hash.hpp
+  utils/index_split.cpp
+  utils/index_split.hpp
   utils/indexer.hpp
   utils/loop_utils.hpp
   utils/morton_number.hpp

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -31,6 +31,26 @@ void MeshData<T>::Initialize(const MeshData<T> *src,
   }
 }
 
+template <typename T>
+void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh, int ndim) {
+  const int nblocks = blocks.size();
+  ndim_ = ndim;
+  block_data_.resize(nblocks);
+  SetMeshPointer(pmesh);
+  for (int i = 0; i < nblocks; i++) {
+    block_data_[i] = blocks[i]->meshblock_data.Get(stage_name_);
+  }
+}
+
+template <typename T>
+void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh) {
+  int ndim;
+  if (pmesh != nullptr) {
+    ndim = pmesh->ndim;
+  }
+  Set(blocks, pmesh, ndim);
+}
+
 template class MeshData<Real>;
 
 } // namespace parthenon

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -246,15 +246,8 @@ class MeshData {
     }
   }
 
-  void Set(BlockList_t blocks, Mesh *pmesh) {
-    const int nblocks = blocks.size();
-    block_data_.resize(nblocks);
-    SetMeshPointer(pmesh);
-    for (int i = 0; i < nblocks; i++) {
-      block_data_[i] = blocks[i]->meshblock_data.Get(stage_name_);
-    }
-  }
-
+  void Set(BlockList_t blocks, Mesh *pmesh, int ndim);
+  void Set(BlockList_t blocks, Mesh *pmesh);
   void Initialize(const MeshData<T> *src, const std::vector<std::string> &names,
                   const bool shallow);
 
@@ -419,6 +412,7 @@ class MeshData {
     bvars_cache_.clear();
   }
 
+  int GetNDim() const { return ndim_; }
   int NumBlocks() const { return block_data_.size(); }
 
   bool operator==(MeshData<T> &cmp) const {
@@ -442,6 +436,7 @@ class MeshData {
   SparsePackCache &GetSparsePackCache() { return sparse_pack_cache_; }
 
  private:
+  int ndim_;
   Mesh *pmy_mesh_;
   BlockDataList_t<T> block_data_;
   std::string stage_name_;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1163,13 +1163,12 @@ bool Mesh::SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size
 
 RegionSize Mesh::GetBlockSize(const LogicalLocation &loc) const {
   RegionSize block_size = GetBlockSize();
-  bool valid_region = true;
   for (auto &dir : {X1DIR, X2DIR, X3DIR}) {
     block_size.xrat(dir) = mesh_size.xrat(dir);
     block_size.symmetry(dir) = mesh_size.symmetry(dir);
     if (!block_size.symmetry(dir)) {
       std::int64_t nrbx_ll = nrbx[dir - 1] << (loc.level() - root_level);
-      if (loc.level() < root_level) {
+      if (loc.level() < root_level){ 
         std::int64_t fac = 1 << (root_level - loc.level());
         nrbx_ll = nrbx[dir - 1] / fac + (nrbx[dir - 1] % fac != 0);
       }
@@ -1182,8 +1181,6 @@ RegionSize Mesh::GetBlockSize(const LogicalLocation &loc) const {
         PARTHENON_REQUIRE(loc.level() < root_level, "Something is messed up.");
         std::int64_t loc_low = loc.l(dir - 1) << (root_level - loc.level());
         std::int64_t loc_hi = (loc.l(dir - 1) + 1) << (root_level - loc.level());
-        if (block_size.nx(dir) * (nrbx[dir - 1] - loc_low) % (loc_hi - loc_low) != 0)
-          valid_region = false;
         block_size.nx(dir) =
             block_size.nx(dir) * (nrbx[dir - 1] - loc_low) / (loc_hi - loc_low);
         block_size.xmax(dir) = mesh_size.xmax(dir);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1168,7 +1168,7 @@ RegionSize Mesh::GetBlockSize(const LogicalLocation &loc) const {
     block_size.symmetry(dir) = mesh_size.symmetry(dir);
     if (!block_size.symmetry(dir)) {
       std::int64_t nrbx_ll = nrbx[dir - 1] << (loc.level() - root_level);
-      if (loc.level() < root_level){ 
+      if (loc.level() < root_level) {
         std::int64_t fac = 1 << (root_level - loc.level());
         nrbx_ll = nrbx[dir - 1] / fac + (nrbx[dir - 1] % fac != 0);
       }

--- a/src/parthenon/package.hpp
+++ b/src/parthenon/package.hpp
@@ -31,6 +31,7 @@
 #include <mesh/meshblock_pack.hpp>
 #include <parameter_input.hpp>
 #include <parthenon_manager.hpp>
+#include <utils/index_split.hpp>
 #include <utils/partition_stl_containers.hpp>
 
 // Local Includes
@@ -46,6 +47,7 @@ using ::parthenon::ApplicationInput;
 using ::parthenon::BlockList_t;
 using ::parthenon::DevExecSpace;
 using ::parthenon::HostExecSpace;
+using ::parthenon::IndexSplit;
 using ::parthenon::Mesh;
 using ::parthenon::MeshBlock;
 using ::parthenon::MeshBlockPack;

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -101,7 +101,7 @@ void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
     // From Forrest Glines:
     // nkp_ * njp_ >= number of SMs / number of streams
     // => njp_ >= SMS / streams / NKP
-    njp_ = std::min(concurrency_ / (NSTREAMS * nkp_), total_j);
+    njp_ = std::min(concurrency_ / (NSTREAMS_ * nkp_), total_j);
 #else
     njp_ = 1;
 #endif

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -27,6 +27,12 @@
 
 namespace parthenon {
 
+struct DummyFunctor {
+  DummyFunctor() = default;
+  KOKKOS_INLINE_FUNCTION
+  void operator(team_mbr_t team_member) const {}
+};
+
 IndexSplit::IndexSplit(MeshData<Real> *md, const IndexRange &kb, const IndexRange &jb,
                        const IndexRange &ib, const int nkp, const int njp)
     : nghost_(Globals::nghost), nkp_(nkp), njp_(njp), kbs_(kb.s), jbs_(jb.s), ibs_(ib.s),
@@ -65,7 +71,7 @@ void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
   // dummy because we don't know what's available.
   // TODO(JMM): Should we expose the functor?
   policy.set_scratch_size(1, Kokkos::PerTeam(sizeof(Real) * total_i * total_j));
-  const int nteams = policy.team_size_recommended(KOKKOS_LAMBDA(team_mbr_t team_member){},
+  const int nteams = policy.team_size_recommended(DummyFunctor(),
                                                   Kokkos::ParallelForTag());
   concurrency_ = space.concurrency() / nteams;
 #else

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -94,7 +94,7 @@ void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
 #ifdef KOKKOS_ENABLE_CUDA
     // From Forrest Glines:
     // nkp_ * njp_ >= number of SMs / number of streams
-    njp_ = std::min(nkp_ * NSTREAMS_ / NSMS_, total_j);
+    njp_ = std::min(nkp_ * NSTREAMS_ / concurrency_, total_j);
 #else
     njp_ = 1;
 #endif

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -1,0 +1,96 @@
+//========================================================================================
+// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#include <algorithm>
+
+#include "utils/index_split.hpp"
+
+#include "basic_types.hpp"
+#include "defs.hpp"
+#include "globals.hpp"
+#include "interface/mesh_data.hpp"
+#include "mesh/domain.hpp"
+#include "mesh/mesh.hpp"
+
+namespace parthenon {
+
+IndexSplit::IndexSplit(MeshData<Real> *md, const IndexRange &kb, const IndexRange &jb,
+                       const IndexRange &ib, const int nkp, const int njp)
+    : nghost_(Globals::nghost), nkp_(nkp), njp_(njp), kbs_(kb.s), jbs_(jb.s), ibs_(ib.s),
+      ibe_(ib.e) {
+  Init(md, kb.e, jb.e);
+  ndim_ = md->GetNDim();
+}
+
+IndexSplit::IndexSplit(MeshData<Real> *md, IndexDomain domain, const int nkp,
+                       const int njp)
+    : nghost_(Globals::nghost), nkp_(nkp), njp_(njp) {
+  auto ib = md->GetBoundsI(domain);
+  auto jb = md->GetBoundsJ(domain);
+  auto kb = md->GetBoundsK(domain);
+  kbs_ = kb.s;
+  jbs_ = jb.s;
+  ibs_ = ib.s;
+  ibe_ = ib.e;
+  Init(md, kb.e, jb.e);
+  ndim_ = md->GetNDim();
+}
+
+void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
+  const int total_k = kbe - kbs_ + 1;
+  const int total_j = jbe - jbs_ + 1;
+
+  if (nkp_ == all_outer)
+    nkp_ = total_k;
+  else if (nkp_ == no_outer)
+    nkp_ = 1;
+  if (njp_ == all_outer)
+    njp_ = total_j;
+  else if (njp_ == no_outer)
+    njp_ = 1;
+
+  if (nkp_ == 0) {
+#ifdef KOKKOS_ENABLE_CUDA
+    nkp_ = total_k;
+#else
+    nkp_ = 1;
+#endif
+  } else if (nkp_ > total_k) {
+    nkp_ = total_k;
+  }
+  if (njp_ == 0) {
+#ifdef KOKKOS_ENABLE_CUDA
+    // TODO(@jdolence) why 4?  Do something better here for a default
+    njp_ = std::min(4, total_j);
+#else
+    njp_ = 1;
+#endif
+  } else if (njp_ > total_j) {
+    njp_ = total_j;
+  }
+
+  // add a tiny bit to avoid round-off issues when we ultimately convert to int
+  target_k_ = (1.0 * total_k) / nkp_ + 1.e-6;
+  target_j_ = (1.0 * total_j) / njp_ + 1.e-6;
+
+  // save the "entire" ranges
+  // don't bother save ".s" since it's always zero
+  auto ib = md->GetBoundsI(IndexDomain::entire);
+  auto jb = md->GetBoundsJ(IndexDomain::entire);
+  auto kb = md->GetBoundsK(IndexDomain::entire);
+  kbe_entire_ = kb.e;
+  jbe_entire_ = jb.e;
+  ibe_entire_ = ib.e;
+}
+
+} // namespace parthenon

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -30,7 +30,7 @@ namespace parthenon {
 struct DummyFunctor {
   DummyFunctor() = default;
   KOKKOS_INLINE_FUNCTION
-  void operator(team_mbr_t team_member) const {}
+  void operator()(team_mbr_t team_member) const {}
 };
 
 IndexSplit::IndexSplit(MeshData<Real> *md, const IndexRange &kb, const IndexRange &jb,
@@ -71,8 +71,8 @@ void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
   // dummy because we don't know what's available.
   // TODO(JMM): Should we expose the functor?
   policy.set_scratch_size(1, Kokkos::PerTeam(sizeof(Real) * total_i * total_j));
-  const int nteams = policy.team_size_recommended(DummyFunctor(),
-                                                  Kokkos::ParallelForTag());
+  const int nteams =
+      policy.team_size_recommended(DummyFunctor(), Kokkos::ParallelForTag());
   concurrency_ = space.concurrency() / nteams;
 #else
   concurrency_ = 1;

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -70,8 +70,9 @@ void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
   }
   if (njp_ == 0) {
 #ifdef KOKKOS_ENABLE_CUDA
-    // TODO(@jdolence) why 4?  Do something better here for a default
-    njp_ = std::min(4, total_j);
+    // From Forrest Glines:
+    // nkp_ * njp_ >= number of SMs / number of streams
+    njp_ = std::min(nkp_ * NSTREAMS_ / NSMS_, total_j);
 #else
     njp_ = 1;
 #endif

--- a/src/utils/index_split.cpp
+++ b/src/utils/index_split.cpp
@@ -80,8 +80,8 @@ void IndexSplit::Init(MeshData<Real> *md, const int kbe, const int jbe) {
   }
 
   // add a tiny bit to avoid round-off issues when we ultimately convert to int
-  target_k_ = (1.0 * total_k) / nkp_ + 1.e-6;
-  target_j_ = (1.0 * total_j) / njp_ + 1.e-6;
+  target_k_ = static_cast<int>((1.0 * total_k) / nkp_ + 1.e-6);
+  target_j_ = static_cast<int>((1.0 * total_j) / njp_ + 1.e-6);
 
   // save the "entire" ranges
   // don't bother save ".s" since it's always zero

--- a/src/utils/index_split.hpp
+++ b/src/utils/index_split.hpp
@@ -104,8 +104,8 @@ class IndexSplit {
 
  private:
   // TODO(JMM): Replace this with a macro or something when available
-  static constexpr int NSMS_ = 132; // For NVIDIA H100
   static constexpr int NSTREAMS_ = 1; // Change if we add streams back
+  int concurrency_;                   //  = NSMs = 132 for NVIDIA H100
   int nghost_, nkp_, njp_, kbs_, jbs_, ibs_, ibe_;
   int kbe_entire_, jbe_entire_, ibe_entire_, ndim_;
   float target_k_, target_j_;

--- a/src/utils/index_split.hpp
+++ b/src/utils/index_split.hpp
@@ -1,0 +1,115 @@
+//========================================================================================
+// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#ifndef UTILS_INDEX_SPLIT_HPP_
+#define UTILS_INDEX_SPLIT_HPP_
+
+#include "basic_types.hpp"
+#include "defs.hpp"
+#include "globals.hpp"
+#include "mesh/domain.hpp"
+
+namespace parthenon {
+
+// forward declarations
+template <typename T>
+class MeshData;
+
+class IndexSplit {
+ public:
+  static constexpr int all_outer = -100;
+  static constexpr int no_outer = -200;
+  IndexSplit(MeshData<Real> *md, const IndexRange &kb, const IndexRange &jb,
+             const IndexRange &ib, const int nkp, const int njp);
+  IndexSplit(MeshData<Real> *md, IndexDomain domain, const int nkp, const int njp);
+
+  int outer_size() const { return nkp_ * njp_; }
+  KOKKOS_INLINE_FUNCTION
+  IndexRange GetBoundsK(const int p) const {
+    const auto kf = p / njp_;
+    return {kbs_ + static_cast<int>(kf * target_k_),
+            kbs_ + static_cast<int>((kf + 1) * target_k_) - 1};
+  }
+  KOKKOS_INLINE_FUNCTION
+  IndexRange GetBoundsJ(const int p) const {
+    const auto jf = p % njp_;
+    return {jbs_ + static_cast<int>(jf * target_j_),
+            jbs_ + static_cast<int>((jf + 1) * target_j_) - 1};
+  }
+  KOKKOS_INLINE_FUNCTION
+  IndexRange GetBoundsI() const { return {ibs_, ibe_}; }
+  KOKKOS_INLINE_FUNCTION
+  IndexRange GetBoundsI(const int p) const { return GetBoundsI(); }
+  KOKKOS_INLINE_FUNCTION
+  auto GetBoundsKJI(const int p) const {
+    const auto kb = GetBoundsK(p);
+    const auto jb = GetBoundsJ(p);
+    const auto ib = GetBoundsI(p);
+    return std::make_tuple(kb, jb, ib);
+  }
+  KOKKOS_INLINE_FUNCTION
+  IndexRange GetInnerBounds(const IndexRange &jb) const {
+    return {ibs_, (ibe_entire_ + 1) * (jb.e - jb.s + 1) - (ibe_entire_ - ibe_) - 1};
+  }
+  KOKKOS_INLINE_FUNCTION
+  IndexRange GetInnerBounds(const IndexRange &jb, const IndexRange &ib) const {
+    return {ib.s, (ibe_entire_ + 1) * (jb.e - jb.s + 1) - (ibe_entire_ - ib.e) - 1};
+  }
+  KOKKOS_INLINE_FUNCTION
+  bool is_i_ghost(const int idx) const {
+    const int ni = ibe_entire_ + 1;
+    const int i = idx % ni;
+    const int i_inner_size = ni - 2 * nghost_;
+    return (i < nghost_ || i - nghost_ >= i_inner_size);
+  }
+  KOKKOS_INLINE_FUNCTION
+  bool is_j_ghost(const int outer_idx, const int idx) const {
+    const int ni = ibe_entire_ + 1;
+    const int j = GetBoundsJ(outer_idx).s + idx / ni;
+    const int j_inner_size = jbe_entire_ + 1 - 2 * nghost_;
+    return (ndim_ > 1 && (j < nghost_ || j - nghost_ >= j_inner_size));
+  }
+  KOKKOS_INLINE_FUNCTION
+  bool is_k_ghost(const int k) const {
+    const int k_inner_size = kbe_entire_ + 1 - 2 * nghost_;
+    return (ndim_ > 2 && (k < nghost_ || k - nghost_ >= k_inner_size));
+  }
+  KOKKOS_INLINE_FUNCTION
+  bool is_ghost(const int outer_idx, const int k, const int idx) const {
+    return is_k_ghost(k) || is_j_ghost(outer_idx, idx) || is_i_ghost(idx);
+  }
+  KOKKOS_INLINE_FUNCTION
+  int get_max_ni() const { return ibe_entire_ + 1; }
+  // TODO(@jdolence) these overestimate max size...should probably fix
+  int get_max_nj() const { return (jbe_entire_ + 1) / njp_ + 1; }
+  int get_max_nk() const { return (kbe_entire_ + 1) / nkp_ + 1; }
+  // inner_size could be used to find the bounds for a loop that is collapsed over
+  // 1, 2, or 3 dimensions by providing the right starting and stopping indices
+  template <typename V>
+  KOKKOS_INLINE_FUNCTION int inner_size(const V &v, const IndexRange &kb,
+                                        const IndexRange &jb,
+                                        const IndexRange &ib) const {
+    return &v(0, kb.e, jb.e, ib.e) - &v(0, kb.s, jb.s, ib.s);
+  }
+
+ private:
+  int nghost_, nkp_, njp_, kbs_, jbs_, ibs_, ibe_;
+  int kbe_entire_, jbe_entire_, ibe_entire_, ndim_;
+  float target_k_, target_j_;
+
+  void Init(MeshData<Real> *md, const int kbe, const int jbe);
+};
+
+} // namespace parthenon
+
+#endif // UTILS_INDEX_SPLIT_HPP_

--- a/src/utils/index_split.hpp
+++ b/src/utils/index_split.hpp
@@ -103,6 +103,9 @@ class IndexSplit {
   }
 
  private:
+  // TODO(JMM): Replace this with a macro or something when available
+  static constexpr int NSMS_ = 132; // For NVIDIA H100
+  static constexpr int NSTREAMS_ = 1; // Change if we add streams back
   int nghost_, nkp_, njp_, kbs_, jbs_, ibs_, ibe_;
   int kbe_entire_, jbe_entire_, ibe_entire_, ndim_;
   float target_k_, target_j_;

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -26,12 +26,13 @@ list(APPEND unit_tests_SOURCES
     test_unit_domain.cpp
     test_unit_sort.cpp
     kokkos_abstraction.cpp
+    test_index_split.cpp
     test_logical_location.cpp
     test_metadata.cpp
-    test_pararrays.cpp
     test_meshblock_data_iterator.cpp
     test_mesh_data.cpp
     test_nan_tags.cpp
+    test_pararrays.cpp
     test_sparse_pack.cpp
     test_swarm.cpp
     test_required_desired.cpp

--- a/tst/unit/test_index_split.cpp
+++ b/tst/unit/test_index_split.cpp
@@ -111,7 +111,7 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
         Kokkos::View<int *, atomic_view> nwrong("nwrong", 1);
         parthenon::par_for_outer(
             DEFAULT_OUTER_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, 0, 0,
-            sp.outer_size() - 1,
+            sp.outer_size() - 1, //N * N - 1
             KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int outer_idx) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);

--- a/tst/unit/test_index_split.cpp
+++ b/tst/unit/test_index_split.cpp
@@ -1,0 +1,145 @@
+//========================================================================================
+// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include "basic_types.hpp"
+#include "globals.hpp"
+#include "interface/data_collection.hpp"
+#include "interface/mesh_data.hpp"
+#include "interface/meshblock_data.hpp"
+#include "interface/metadata.hpp"
+#include "interface/sparse_pack.hpp"
+#include "kokkos_abstraction.hpp"
+#include "mesh/meshblock.hpp"
+#include "parthenon/package.hpp"
+#include "utils/index_split.hpp"
+
+// TODO(jcd): can't call the MeshBlock constructor without mesh_refinement.hpp???
+#include "mesh/mesh_refinement.hpp"
+
+using namespace parthenon::package::prelude;
+using parthenon::BlockList_t;
+using parthenon::DevExecSpace;
+using parthenon::IndexDomain;
+using parthenon::IndexSplit;
+using parthenon::MeshBlock;
+using parthenon::MeshBlockData;
+using parthenon::MeshData;
+using parthenon::Metadata;
+using parthenon::PackIndexMap;
+using parthenon::par_for;
+using parthenon::Real;
+using parthenon::StateDescriptor;
+
+namespace {
+BlockList_t MakeBlockList(const std::shared_ptr<StateDescriptor> pkg, const int NBLOCKS,
+                          const int NSIDE, const int NDIM) {
+  BlockList_t block_list;
+  block_list.reserve(NBLOCKS);
+  for (int i = 0; i < NBLOCKS; ++i) {
+    auto pmb = std::make_shared<MeshBlock>(NSIDE, NDIM);
+    auto &pmbd = pmb->meshblock_data.Get();
+    pmbd->Initialize(pkg, pmb);
+    block_list.push_back(pmb);
+  }
+  return block_list;
+}
+// JMM: Variables aren't really needed for this test but...
+struct v1 : public parthenon::variable_names::base_t<false> {
+  template <class... Ts>
+  KOKKOS_INLINE_FUNCTION v1(Ts &&...args)
+      : parthenon::variable_names::base_t<false>(std::forward<Ts>(args)...) {}
+  static std::string name() { return "v1"; }
+};
+struct v3 : public parthenon::variable_names::base_t<false, 3> {
+  template <class... Ts>
+  KOKKOS_INLINE_FUNCTION v3(Ts &&...args)
+      : parthenon::variable_names::base_t<false, 3>(std::forward<Ts>(args)...) {}
+  static std::string name() { return "v3"; }
+};
+struct v5 : public parthenon::variable_names::base_t<false> {
+  template <class... Ts>
+  KOKKOS_INLINE_FUNCTION v5(Ts &&...args)
+      : parthenon::variable_names::base_t<false>(std::forward<Ts>(args)...) {}
+  static std::string name() { return "v5"; }
+};
+} // namespace
+
+TEST_CASE("IndexSplit", "[IndexSplit]") {
+  GIVEN("A set of meshblocks and meshblock and mesh data") {
+    constexpr int N = 6;
+    constexpr int NDIM = 3;
+    constexpr int NBLOCKS = 9;
+    constexpr int NG = 0;
+    const std::vector<int> scalar_shape{N, N, N};
+    const std::vector<int> vector_shape{N, N, N, 3};
+
+    Metadata m({Metadata::Independent, Metadata::WithFluxes}, scalar_shape);
+    Metadata m_vector({Metadata::Independent, Metadata::WithFluxes, Metadata::Vector},
+                      vector_shape);
+    auto pkg = std::make_shared<StateDescriptor>("Test package");
+    pkg->AddField(v1::name(), m);
+    pkg->AddField(v3::name(), m_vector);
+    pkg->AddField(v5::name(), m);
+    BlockList_t block_list = MakeBlockList(pkg, NBLOCKS, N, NDIM);
+
+    MeshData<Real> mesh_data("base");
+    mesh_data.Set(block_list, nullptr, NDIM);
+
+    WHEN("We initialize an IndexSplit with all outer k and no outer j") {
+      IndexSplit sp(&mesh_data, IndexDomain::interior, IndexSplit::all_outer,
+                    IndexSplit::no_outer);
+      THEN("The outer range should be appropriate") { REQUIRE(sp.outer_size() == N); }
+      THEN("The inner ranges should be appropriate") {
+        parthenon::par_for_outer(
+            DEFAULT_OUTER_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, 0, 0,
+            sp.outer_size() - 1,
+            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int outer_idx) {
+              const auto krange = sp.GetBoundsK(outer_idx);
+              const auto jrange = sp.GetBoundsJ(outer_idx);
+              const auto irange = sp.GetInnerBounds(jrange);
+              // JMM: Note that these are little cleaner without ghosts
+              REQUIRE(krange.s == outer_idx);
+              REQUIRE(krange.e == outer_idx);
+              REQUIRE(jrange.s == 0);
+              REQUIRE(jrange.e == N - 1);
+              REQUIRE(irange.s == 0);
+              REQUIRE(irange.e == (N * N - 1));
+            });
+      }
+    }
+    WHEN("We initialize an IndexSplit with outer k and outer j") {
+      IndexSplit sp(&mesh_data, IndexDomain::interior, IndexSplit::all_outer,
+                    IndexSplit::all_outer);
+      THEN("the outer index range should be appropriate") {
+        REQUIRE(sp.outer_size() == (N * N));
+      }
+      THEN("The inner index ranges should be appropriate") {
+        parthenon::par_for_outer(
+            DEFAULT_OUTER_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, 0, 0,
+            sp.outer_size() - 1,
+            KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int outer_idx) {
+              const auto krange = sp.GetBoundsK(outer_idx);
+              const auto jrange = sp.GetBoundsJ(outer_idx);
+              const auto irange = sp.GetInnerBounds(jrange);
+              REQUIRE(irange.s == 0);
+              REQUIRE(irange.e == N - 1);
+            });
+      }
+    }
+  }
+}

--- a/tst/unit/test_index_split.cpp
+++ b/tst/unit/test_index_split.cpp
@@ -111,7 +111,7 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
         Kokkos::View<int *, atomic_view> nwrong("nwrong", 1);
         parthenon::par_for_outer(
             DEFAULT_OUTER_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, 0, 0,
-            sp.outer_size() - 1, //N * N - 1
+            sp.outer_size() - 1, // N * N - 1
             KOKKOS_LAMBDA(parthenon::team_mbr_t member, const int outer_idx) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);

--- a/tst/unit/test_index_split.cpp
+++ b/tst/unit/test_index_split.cpp
@@ -240,14 +240,16 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
         int total_work = 0;
         const int outer_size = sp.outer_size();
         parthenon::par_reduce(
-            DEFAULT_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0,  outer_size - 1,
+            DEFAULT_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, outer_size - 1,
             KOKKOS_LAMBDA(const int outer_idx, int &total_work) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);
               const auto irange = sp.GetInnerBounds(jrange);
-              const int local_work = (krange.e - krange.s + 1) * (irange.e - irange.s + 1);
+              const int local_work =
+                  (krange.e - krange.s + 1) * (irange.e - irange.s + 1);
               total_work += local_work;
-            }, Kokkos::Sum<int>(total_work));
+            },
+            Kokkos::Sum<int>(total_work));
         REQUIRE(total_work == N * N * N);
       }
     }
@@ -262,13 +264,15 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
       THEN("The inner index ranges should be appropriate") {
         int total_work = 0;
         parthenon::par_reduce(
-            DEFAULT_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, sp.outer_size() - 1,
+            DEFAULT_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0,
+            sp.outer_size() - 1,
             KOKKOS_LAMBDA(const int outer_idx, int &total_work) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);
               const auto irange = sp.GetInnerBounds(jrange);
               total_work += (krange.e - krange.s + 1) * (irange.e - irange.s + 1);
-            }, Kokkos::Sum<int>(total_work));
+            },
+            Kokkos::Sum<int>(total_work));
         REQUIRE(total_work == N * N * N);
       }
     }

--- a/tst/unit/test_index_split.cpp
+++ b/tst/unit/test_index_split.cpp
@@ -240,7 +240,8 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
         int total_work = 0;
         const int outer_size = sp.outer_size();
         parthenon::par_reduce(
-                              parthenon::loop_pattern_flatrange_tag, "Test IndexSplit", DevExecSpace(), 0,  outer_size - 1,
+            parthenon::loop_pattern_flatrange_tag, "Test IndexSplit", DevExecSpace(), 0,
+            outer_size - 1,
             KOKKOS_LAMBDA(const int outer_idx, int &total_work) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);
@@ -264,7 +265,8 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
       THEN("The inner index ranges should be appropriate") {
         int total_work = 0;
         parthenon::par_reduce(
-            parthenon::loop_pattern_flatrange_tag, "Test IndexSplit", DevExecSpace(), 0, sp.outer_size() - 1,
+            parthenon::loop_pattern_flatrange_tag, "Test IndexSplit", DevExecSpace(), 0,
+            sp.outer_size() - 1,
             KOKKOS_LAMBDA(const int outer_idx, int &total_work) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);

--- a/tst/unit/test_index_split.cpp
+++ b/tst/unit/test_index_split.cpp
@@ -240,7 +240,7 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
         int total_work = 0;
         const int outer_size = sp.outer_size();
         parthenon::par_reduce(
-            DEFAULT_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0,  outer_size - 1,
+                              parthenon::loop_pattern_flatrange_tag, "Test IndexSplit", DevExecSpace(), 0,  outer_size - 1,
             KOKKOS_LAMBDA(const int outer_idx, int &total_work) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);
@@ -262,7 +262,7 @@ TEST_CASE("IndexSplit", "[IndexSplit]") {
       THEN("The inner index ranges should be appropriate") {
         int total_work = 0;
         parthenon::par_reduce(
-            DEFAULT_LOOP_PATTERN, "Test IndexSplit", DevExecSpace(), 0, sp.outer_size() - 1,
+            parthenon::loop_pattern_flatrange_tag, "Test IndexSplit", DevExecSpace(), 0, sp.outer_size() - 1,
             KOKKOS_LAMBDA(const int outer_idx, int &total_work) {
               const auto krange = sp.GetBoundsK(outer_idx);
               const auto jrange = sp.GetBoundsJ(outer_idx);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Here I port in a tool written by @jdolence used for balancing the considerations of GPU vs CPU hardware constraints when using hierarchical parallelism. The `IndexSplit` class lets one automatically fuse different indices in two levels of hierarhical parallelism. For example, put k and j in an outer loop and i in an inner loop, or k in the outer loop and j and i in the inner loop. 

I also add some documentation describing best practices for hierarchical parallelism that we got from our experience in performance tuning downstream codes.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
