### PR TITLE
Add some diagnostics for Parthenon-VIBE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR978]](https://github.com/parthenon-hpc-lab/parthenon/pull/978) remove erroneous sparse check
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 982]](https://github.com/parthenon-hpc-lab/parthenon/pull/982) add some gut check testing for parthenon-VIBE
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/benchmarks/burgers/README.md
+++ b/benchmarks/burgers/README.md
@@ -78,6 +78,8 @@ where `Kokkos_ARCH` should be set appropriately for the machine (see [here](http
 
 Parthenon-VIBE prints to a history file (default name `burgers.hst`) a time series of the sum of squares of evolved variables integrated over volume for each octant of the domain, as well as the total number of meshblocks in the simulation at that time. To compare these quantities between runs, we provide the `burgers_diff.py` program in the benchmark folder. This will diff two history files and report when the relative difference is greater than some tolerance.
 
+Note that `burgers.hst` is **appended** to when the executable is re-run. So if you want to compare two different history files, rename the history file by changing either `problem_id` in the `parthenon/job` block in the input deck (this can be done on the command line. When you start the program, add `parthenon/job/problem_id=mynewname` to the command line argument), or copy the old file to back it up.
+
 ### Memory Usage
 
 The dominant memory usage in Parthenon-VIBE is for storage of the solution, for which two copies are required to support second order time stepping, for storing the update for a integrator stage (essentially the flux divergence), the intercell fluxes of each variable, for intermediate values of each solution variable on each side of every face, and for a derived quantity that we compute from the evolved solution.  From this we can construct a simple model for the memory usage $M$ as 

--- a/benchmarks/burgers/README.md
+++ b/benchmarks/burgers/README.md
@@ -74,6 +74,10 @@ To build for execution on a single GPU, it should be sufficient to add the follo
 ```
 where `Kokkos_ARCH` should be set appropriately for the machine (see [here](https://kokkos.github.io/kokkos-core-wiki/keywords.html)).
 
+### Diagnostics
+
+Parthenon-VIBE prints to a history file (default name `burgers.hst`) a time series of the sum of squares of evolved variables integrated over volume for each octant of the domain, as well as the total number of meshblocks in the simulation at that time. To compare these quantities between runs, we provide the `burgers_diff.py` program in the benchmark folder. This will diff two history files and report when the relative difference is greater than some tolerance.
+
 ### Memory Usage
 
 The dominant memory usage in Parthenon-VIBE is for storage of the solution, for which two copies are required to support second order time stepping, for storing the update for a integrator stage (essentially the flux divergence), the intercell fluxes of each variable, for intermediate values of each solution variable on each side of every face, and for a derived quantity that we compute from the evolved solution.  From this we can construct a simple model for the memory usage $M$ as 
@@ -109,5 +113,4 @@ On a two-socket Broadwell node with 36 cores, the benchmark takes approximately 
 For the GPU, we measure throughput on a single-level mesh ("parthenon/mesh/numlevel = 1") and vary the base mesh size and the block size.  Results on a 40 GB A100 are shown in Figure 3.
 
 <p style="text-align:center;"><img src="data/pvibe_gpu_throughput.png" alt="Plot showing throughput on an A100 at different mesh and block sizes" style=width:50%><br />Figure 3: Throughput for different mesh and block sizes on a single 40 GB A100 GPU.</p>
-
 

--- a/benchmarks/burgers/burgers.pin
+++ b/benchmarks/burgers/burgers.pin
@@ -67,6 +67,11 @@ file_type = hdf5
 dt = -0.4
 variables = U, derived
 
+<parthenon/output1>
+file_type = hst
+data_format = %.14e
+dt = 0.01
+
 <burgers>
 cfl = 0.8
 recon = weno5

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -25,16 +25,6 @@ parser.add_argument(
     "-t", "--tolerance", type=float, default=1e-8, help="Relative tolerance for diff"
 )
 
-
-def matprint(mat, fmt="14g"):
-    "Print a numpy arraay prettily"
-    col_maxes = [max([len(("{:" + fmt + "}").format(x)) for x in col]) for col in mat.T]
-    for x in mat:
-        for i, y in enumerate(x):
-            print(("{:" + str(col_maxes[i]) + fmt + "}").format(y), end="  ")
-        print("")
-
-
 def get_rel_diff(d1, d2):
     "Get relative difference between two numpy arrays"
     return 2 * np.abs(d1 - d2) / (d1 + d2 + 1e-20)

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -1,3 +1,16 @@
+#========================================================================================
+# (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+#========================================================================================
+
 #!/usr/bin/env python
 import numpy as np
 from argparse import ArgumentParser

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -25,21 +25,32 @@ parser.add_argument(
     "-t", "--tolerance", type=float, default=1e-8, help="Relative tolerance for diff"
 )
 
+
 def get_rel_diff(d1, d2):
     "Get relative difference between two numpy arrays"
     return 2 * np.abs(d1 - d2) / (d1 + d2 + 1e-20)
 
 
+def compare_files(file1, file2, tolerance, print_results=True):
+    "Compare file1 and file2 to tolerance. Optionally print results."
+    d1 = np.loadtxt(file1)
+    d2 = np.loadtxt(file2)
+    diffs = get_rel_diff(d1, d2)
+    mask = diffs > tolerance
+    errcode = 0
+    if np.any(mask):
+        errcode = 1
+        if print_results:
+            print("Diffs found!")
+            indices = np.transpose(np.nonzero(mask))
+            print("Diff locations (row, column) =", indices)
+            print("Diffs =", diffs[mask])
+    else:
+        if print_results:
+            print("No diffs found!")
+    return errcode
+
+
 if __name__ == "__main__":
     args = parser.parse_args()
-    d1 = np.loadtxt(args.file1)
-    d2 = np.loadtxt(args.file2)
-    diffs = get_rel_diff(d1, d2)
-    mask = diffs > args.tolerance
-    if np.any(mask):
-        print("Diffs found!")
-        indices = np.transpose(np.nonzero(mask))
-        print("Diff locations (row, column) =", indices)
-        print("Diffs =", diffs[mask])
-    else:
-        print("No diffs found!")
+    compare_files(args.file1, args.file1, args.tolerance, True)

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+import numpy as np
+from argparse import ArgumentParser
+
+parser = ArgumentParser(
+    prog="burgers_diff.py",
+    description="Compute difference between two history solvers parthenon VIBE",
+)
+parser.add_argument("file1", type=str, help="First file in diff")
+parser.add_argument("file2", type=str, help="Second fiel in diff")
+parser.add_argument(
+    "-t", "--tolerance", type=float, default=1e-8, help="Relative tolerance for diff"
+)
+
+
+def matprint(mat, fmt="14g"):
+    "Print a numpy arraay prettily"
+    col_maxes = [max([len(("{:" + fmt + "}").format(x)) for x in col]) for col in mat.T]
+    for x in mat:
+        for i, y in enumerate(x):
+            print(("{:" + str(col_maxes[i]) + fmt + "}").format(y), end="  ")
+        print("")
+
+
+def get_rel_diff(d1, d2):
+    "Get relative difference between two numpy arrays"
+    return 2 * np.abs(d1 - d2) / (d1 + d2 + 1e-20)
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    d1 = np.loadtxt(args.file1)
+    d2 = np.loadtxt(args.file2)
+    diffs = get_rel_diff(d1, d2)
+    mask = diffs > args.tolerance
+    if np.any(mask):
+        print("Diffs found!")
+        indices = np.transpose(np.nonzero(mask))
+        print("Diff locations (row, column) =", indices)
+        print("Diffs =", diffs[mask])
+    else:
+        print("No diffs found!")

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # ========================================================================================
 # (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
 #
@@ -11,7 +12,6 @@
 # the public, perform publicly and display publicly, and to permit others to do so.
 # ========================================================================================
 
-#!/usr/bin/env python
 import numpy as np
 from argparse import ArgumentParser
 

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -1,4 +1,4 @@
-#========================================================================================
+# ========================================================================================
 # (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
@@ -9,7 +9,7 @@
 # itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
 # license in this material to reproduce, prepare derivative works, distribute copies to
 # the public, perform publicly and display publicly, and to permit others to do so.
-#========================================================================================
+# ========================================================================================
 
 #!/usr/bin/env python
 import numpy as np

--- a/benchmarks/burgers/burgers_package.cpp
+++ b/benchmarks/burgers/burgers_package.cpp
@@ -126,8 +126,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       return MassHistory(md, octant.xmin[0], octant.xmax[0], octant.xmin[1],
                          octant.xmax[1], octant.xmin[2], octant.xmax[2]);
     };
-    hst_vars.emplace_back(HstSum, ReduceMass,
-                          "MS Mass " + std::to_string(i_octant));
+    hst_vars.emplace_back(HstSum, ReduceMass, "MS Mass " + std::to_string(i_octant));
     i_octant++;
   }
   hst_vars.emplace_back(HstSum, MeshCountHistory, "Meshblock count");

--- a/benchmarks/burgers/burgers_package.cpp
+++ b/benchmarks/burgers/burgers_package.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   for (int d = 1; d <= 3; ++d) {
     mesh_mins.push_back(pin->GetReal("parthenon/mesh", "x" + std::to_string(d) + "min"));
     mesh_maxs.push_back(pin->GetReal("parthenon/mesh", "x" + std::to_string(d) + "max"));
-    vol *= (mesh_maxs.back() - mesh_mins.back());
+    mesh_vol *= (mesh_maxs.back() - mesh_mins.back());
     mesh_mids.push_back(0.5 * (mesh_mins.back() + mesh_maxs.back()));
   }
   pkg->AddParam("mesh_volume", mesh_vol);
@@ -170,7 +170,7 @@ void CalculateDerived(MeshData<Real> *md) {
 // provide the routine that estimates a stable timestep for this package
 Real EstimateTimestepMesh(MeshData<Real> *md) {
   Kokkos::Profiling::pushRegion("Task_burgers_EstimateTimestepMesh");
-  auto pm = md->GetParentPointer();
+  Mesh *pm = md->GetMeshPointer();
   IndexRange ib = md->GetBoundsI(IndexDomain::interior);
   IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
@@ -412,6 +412,7 @@ Real MassHistory(MeshData<Real> *md, const Real x1min, const Real x1max, const R
   const auto jb = md->GetBoundsJ(IndexDomain::interior);
   const auto kb = md->GetBoundsK(IndexDomain::interior);
 
+  Mesh *pm = md->GetMeshPointer();
   auto &params = pm->packages.Get("burgers_package")->AllParams();
   const auto &mesh_vol = params.Get<Real>("mesh_volume");
 

--- a/benchmarks/burgers/burgers_package.hpp
+++ b/benchmarks/burgers/burgers_package.hpp
@@ -43,6 +43,9 @@ void lr_to_flux(const Real uxl, const Real uxr, const Real uyl, const Real uyr,
   fuz = 0.5 * (sr * uzl * upl - sl * uzr * upr + sl * sr * (uzr - uzl)) * islsr;
 }
 
+// JMM: I could have instead used the parthenon::RegionSize
+// class. However, this little Region struct is lighter weight and
+// easier to work with in this context.
 struct Region {
   std::array<Real, 3> xmin, xmax;
 };

--- a/benchmarks/burgers/burgers_package.hpp
+++ b/benchmarks/burgers/burgers_package.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/benchmarks/burgers/burgers_package.hpp
+++ b/benchmarks/burgers/burgers_package.hpp
@@ -25,6 +25,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 void CalculateDerived(MeshData<Real> *md);
 Real EstimateTimestepMesh(MeshData<Real> *md);
 TaskStatus CalculateFluxes(MeshData<Real> *md);
+Real MassHistory(MeshData<Real> *md, const Real x1min, const Real x1max, const Real x2min,
+                 const Real x2max, const Real x3min, const Real x3max);
+Real MeshCountHistory(MeshData<Real> *md);
 
 // compute the hll flux for Burgers' equation
 KOKKOS_INLINE_FUNCTION
@@ -39,6 +42,10 @@ void lr_to_flux(const Real uxl, const Real uxr, const Real uyl, const Real uyr,
   fuy = 0.5 * (sr * uyl * upl - sl * uyr * upr + sl * sr * (uyr - uyl)) * islsr;
   fuz = 0.5 * (sr * uzl * upl - sl * uzr * upr + sl * sr * (uzr - uzl)) * islsr;
 }
+
+struct Region {
+  std::array<Real, 3> xmin, xmax;
+};
 
 } // namespace burgers_package
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As a way to quickly gut check some measure of correctness, and to highlight the history features of parthenon, I add some tooling to output the total "mean-square mass" of the Burger's variables in Parthenon-VIBE into the history file. I also output the total number of meshblocks at the time of history dump.

This can be compared, up to some tolerance, for various configurations or pieces of hardware by diffing using the `burgers_diff.py` script that I also add.

In principle, this could be hooked into a gold file for regression testing, but I think for now this is good enough. It provides some useful machinery for us to use for, e.g., machine acceptance criteria.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
