### PR TITLE
Add Contains to Sparse Pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR 983]](https://github.com/parthenon-hpc-lab/parthenon/pull/983) Add Exists to SparsePack
+- [[PR 983]](https://github.com/parthenon-hpc-lab/parthenon/pull/983) Add Contains to SparsePack
 - [[PR 968]](https://github.com/parthenon-hpc-lab/parthenon/pull/968) Add per package registration of boundary conditions
 - [[PR 948]](https://github.com/parthenon-hpc-lab/parthenon/pull/948) Add solver interface and update Poisson geometric multi-grid example
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 983]](https://github.com/parthenon-hpc-lab/parthenon/pull/983) Add Exists to SparsePack
 - [[PR 968]](https://github.com/parthenon-hpc-lab/parthenon/pull/968) Add per package registration of boundary conditions
 - [[PR 948]](https://github.com/parthenon-hpc-lab/parthenon/pull/948) Add solver interface and update Poisson geometric multi-grid example
 

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -249,13 +249,11 @@ class SparsePack : public SparsePackBase {
 
   template <class... Args>
   KOKKOS_INLINE_FUNCTION bool Contains(const int b, Args... args) const {
-    static_assert(sizeof...(Args) > 0, "Must pass in a variable to check existence");
     return GetUpperBound(b, std::forward<Args>(args)...) >= 0;
   }
 
   template <class... Args>
   KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b, Args... args) const {
-    static_assert(sizeof...(Args) > 0, "Must pass in a variable to check existence");
     return GetUpperBoundHost(b, std::forward<Args>(args)...) >= 0;
   }
 

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -247,6 +247,18 @@ class SparsePack : public SparsePackBase {
     return bounds_h_(1, b, vidx);
   }
 
+  template <class... Args>
+  KOKKOS_INLINE_FUNCTION bool Exists(const int b, Args... args) const {
+    static_assert(sizeof...(Args) > 0, "Must pass in a variable to check existence");
+    return GetUpperBound(b, std::forward<Args>(args)...) >= 0;
+  }
+
+  template <class... Args>
+  KOKKOS_INLINE_FUNCTION bool ExistsHost(const int b, Args... args) const {
+    static_assert(sizeof...(Args) > 0, "Must pass in a variable to check existence");
+    return GetUpperBoundHost(b, std::forward<Args>(args)...) >= 0;
+  }
+
   // operator() overloads
   using TE = TopologicalElement;
   KOKKOS_INLINE_FUNCTION auto &operator()(const int b, const TE el, const int idx) const {

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -248,13 +248,13 @@ class SparsePack : public SparsePackBase {
   }
 
   template <class... Args>
-  KOKKOS_INLINE_FUNCTION bool Exists(const int b, Args... args) const {
+  KOKKOS_INLINE_FUNCTION bool Contains(const int b, Args... args) const {
     static_assert(sizeof...(Args) > 0, "Must pass in a variable to check existence");
     return GetUpperBound(b, std::forward<Args>(args)...) >= 0;
   }
 
   template <class... Args>
-  KOKKOS_INLINE_FUNCTION bool ExistsHost(const int b, Args... args) const {
+  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b, Args... args) const {
     static_assert(sizeof...(Args) > 0, "Must pass in a variable to check existence");
     return GetUpperBoundHost(b, std::forward<Args>(args)...) >= 0;
   }

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -247,14 +247,43 @@ class SparsePack : public SparsePackBase {
     return bounds_h_(1, b, vidx);
   }
 
-  template <class... Args>
-  KOKKOS_INLINE_FUNCTION bool Contains(const int b, Args... args) const {
-    return GetUpperBound(b, std::forward<Args>(args)...) >= 0;
+  /* Usage:
+   * Contains(b, v1(), v2(), v3())
+   *
+   * returns true if all listed vars are present on block b, false
+   * otherwise.
+   */
+  KOKKOS_INLINE_FUNCTION bool Contains(const int b) const {
+    return GetUpperBound(b) >= 0;
   }
-
-  template <class... Args>
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION bool Contains(const int b, const T t) const {
+    return GetUpperBound(b, t) >= 0;
+  }
+  template <typename... Args>
+  KOKKOS_INLINE_FUNCTION bool Contains(const int b, Args... args) const {
+    return (... && Contains(b, args));
+  }
+  // Version that takes templates but no arguments passed
+  template <typename... Args, REQUIRES(sizeof...(Args) > 0)>
+  KOKKOS_INLINE_FUNCTION bool Contains(const int b) const {
+    return (... && Contains(b, Args()));
+  }
+  // Host versions
+  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b) const {
+    return GetUpperBoundHost(b) >= 0;
+  }
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b, const T t) const {
+    return GetUpperBoundHost(b, t) >= 0;
+  }
+  template <typename... Args>
   KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b, Args... args) const {
-    return GetUpperBoundHost(b, std::forward<Args>(args)...) >= 0;
+    return (... && ContainsHost(b, args));
+  }
+  template <typename... Args, REQUIRES(sizeof...(Args) > 0)>
+  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b) const {
+    return (... && ContainsHost(b, Args()));
   }
 
   // operator() overloads

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -143,6 +143,8 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         REQUIRE(pack.ContainsHost(2, v1()));
         REQUIRE(!pack.ContainsHost(2, v3()));
         REQUIRE(pack.ContainsHost(2, v5()));
+        REQUIRE(!pack.ContainsHost(2, v1(), v3(), v5()));
+        REQUIRE(pack.ContainsHost<v1, v5>(2));
       }
 
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -140,9 +140,9 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
            "nonexistence for variables on different blocks.") {
         auto desc = parthenon::MakePackDescriptor<v1, v3, v5>(pkg.get());
         auto pack = desc.GetPack(&mesh_data);
-        REQUIRE(pack.ExistsHost(2, v1()));
-        REQUIRE(!pack.ExistsHost(2, v3()));
-        REQUIRE(pack.ExistsHost(2, v5()));
+        REQUIRE(pack.ContainsHost(2, v1()));
+        REQUIRE(!pack.ContainsHost(2, v3()));
+        REQUIRE(pack.ContainsHost(2, v5()));
       }
 
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -136,6 +136,15 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         REQUIRE(hi == 0); // hi is scalar. Only one value.
       }
 
+      THEN("A sparse pack correctly loads this data and can report existence and "
+           "nonexistence for variables on different blocks.") {
+        auto desc = parthenon::MakePackDescriptor<v1, v3, v5>(pkg.get());
+        auto pack = desc.GetPack(&mesh_data);
+        REQUIRE(pack.ExistsHost(2, v1()));
+        REQUIRE(!pack.ExistsHost(2, v3()));
+        REQUIRE(pack.ExistsHost(2, v5()));
+      }
+
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "
            "blocks") {
         // Create a pack use type variables


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Syntactic sugar for

```C++
bool var_v_is_in_pack = (pack.GetUpperBoundHost(0, v()) >= 0);
```

This was suggested by @brryan in a downstream PR in Phoebus. I think it helps clarify the cases when we pack on many variables, of which only some are present.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
