### PR TITLE
Bugfix for sparse communication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR986]](https://github.com/parthenon-hpc-lab/parthenon/pull/986) Fix bug in sparse boundary communication BndInfo cacheing
 - [[PR978]](https://github.com/parthenon-hpc-lab/parthenon/pull/978) remove erroneous sparse check
 
 ### Infrastructure (changes irrelevant to downstream codes)

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -226,6 +226,7 @@ BndInfo BndInfo::GetSendBndInfo(MeshBlock *pmb, const NeighborBlock &nb,
   BndInfo out;
 
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
   if (!out.allocated) return out;
 
   out.buf = buf->buffer();
@@ -233,7 +234,6 @@ BndInfo BndInfo::GetSendBndInfo(MeshBlock *pmb, const NeighborBlock &nb,
   int Nv = v->GetDim(4);
   int Nu = v->GetDim(5);
   int Nt = v->GetDim(6);
-
   int mylevel = pmb->loc.level();
 
   auto elements = v->GetTopologicalElements();
@@ -267,6 +267,7 @@ BndInfo BndInfo::GetSetBndInfo(MeshBlock *pmb, const NeighborBlock &nb,
     PARTHENON_FAIL("Buffer should be in a received state.");
   }
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
 
   int Nv = v->GetDim(4);
   int Nu = v->GetDim(5);
@@ -297,6 +298,7 @@ ProResInfo ProResInfo::GetInteriorRestrict(MeshBlock *pmb, const NeighborBlock &
   ProResInfo out;
 
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
   if (!out.allocated) return out;
 
   int Nv = v->GetDim(4);
@@ -328,6 +330,7 @@ ProResInfo ProResInfo::GetInteriorProlongate(MeshBlock *pmb, const NeighborBlock
   ProResInfo out;
 
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
   if (!out.allocated) return out;
 
   int Nv = v->GetDim(4);
@@ -358,6 +361,7 @@ ProResInfo ProResInfo::GetSend(MeshBlock *pmb, const NeighborBlock &nb,
   ProResInfo out;
 
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
   if (!out.allocated) return out;
 
   int Nv = v->GetDim(4);
@@ -388,6 +392,7 @@ ProResInfo ProResInfo::GetSet(MeshBlock *pmb, const NeighborBlock &nb,
                               std::shared_ptr<Variable<Real>> v) {
   ProResInfo out;
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
   int Nv = v->GetDim(4);
   int Nu = v->GetDim(5);
   int Nt = v->GetDim(6);
@@ -448,6 +453,7 @@ BndInfo BndInfo::GetSendCCFluxCor(MeshBlock *pmb, const NeighborBlock &nb,
                                   CommBuffer<buf_pool_t<Real>::owner_t> *buf) {
   BndInfo out;
   out.allocated = v->IsAllocated();
+  out.alloc_status = v->GetAllocationStatus();
   if (!v->IsAllocated()) {
     // Not going to actually do anything with this buffer
     return out;
@@ -507,9 +513,11 @@ BndInfo BndInfo::GetSetCCFluxCor(MeshBlock *pmb, const NeighborBlock &nb,
 
   if (!v->IsAllocated() || buf->GetState() != BufferState::received) {
     out.allocated = false;
+    out.alloc_status = v->GetAllocationStatus();
     return out;
   }
   out.allocated = true;
+  out.alloc_status = v->GetAllocationStatus();
   out.buf = buf->buffer();
 
   IndexRange ib = pmb->cellbounds.GetBoundsI(IndexDomain::interior);

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -47,7 +47,7 @@ struct BndInfo {
   CoordinateDirection dir;
   bool allocated = true;
   bool buf_allocated = true;
-  int alloc_status; 
+  int alloc_status;
 
   buf_pool_t<Real>::weak_t buf;        // comm buffer from pool
   ParArrayND<Real, VariableState> var; // data variable used for comms

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -47,6 +47,7 @@ struct BndInfo {
   CoordinateDirection dir;
   bool allocated = true;
   bool buf_allocated = true;
+  int alloc_status; 
 
   buf_pool_t<Real>::weak_t buf;        // comm buffer from pool
   ParArrayND<Real, VariableState> var; // data variable used for comms
@@ -79,6 +80,7 @@ struct ProResInfo {
 
   CoordinateDirection dir;
   bool allocated = true;
+  int alloc_status;
   RefinementOp_t refinement_op = RefinementOp_t::None;
   Coordinates_t coords, coarse_coords; // coords
 

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -139,7 +139,7 @@ inline auto CheckSendBufferCacheForRebuild(std::shared_ptr<MeshData<Real>> md) {
     }
 
     if (ibuf < cache.bnd_info_h.size()) {
-      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true;
+      if (cache.bnd_info_h(ibuf).alloc_status != v->GetAllocationStatus()) rebuild = true;
       rebuild = rebuild || !UsingSameResource(cache.bnd_info_h(ibuf).buf, buf.buffer());
     } else {
       rebuild = true;
@@ -162,7 +162,7 @@ inline auto CheckReceiveBufferCacheForRebuild(std::shared_ptr<MeshData<Real>> md
     const std::size_t ibuf = cache.idx_vec[nbound];
     auto &buf = *cache.buf_vec[ibuf];
     if (ibuf < cache.bnd_info_h.size()) {
-      if (cache.bnd_info_h(ibuf).allocated != v->IsAllocated()) rebuild = true;
+      if (cache.bnd_info_h(ibuf).alloc_status != v->GetAllocationStatus()) rebuild = true;
       rebuild = rebuild || !UsingSameResource(cache.bnd_info_h(ibuf).buf, buf.buffer());
 
       if ((buf.GetState() == BufferState::received) &&


### PR DESCRIPTION
## PR Summary
If a variable was deallocated at the end of one step and reallocated during the next call to `ReceiveBoundBufs`, it would appear to `SetBounds` that the `BndInfo` cache was not stale (since the field was allocated on subsequent calls to `SetBounds`) even though the variable itself contained newly allocated memory. This is fixed by checking the value of `Variable::GetAllocationStatus()` in `CheckSendBufferCacheForRebuild` and`CheckReceiveBufferCacheForRebuild` against the value that is now store in `BndInfo`. `GetAllocationStatus()` returns zero if the variable is deallocated and the number of times the variable has been allocated over the simulation otherwise. 

This should not have any impact on codes that do not use sparse variables.
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] (@lanl.gov employees) Update copyright on changed files
