### PR TITLE
[Breaking Change][WIP] Make Mesh-Level Boundary Conditions Usable without "User" flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### Removed (removing behavior/API/varaibles/...)
 
 ### Incompatibilities (i.e. breaking changes)
+- [[PR 989]](https://github.com/parthenon-hpc-lab/parthenon/pull/989) Update how mesh-level boundary conditions are registered and eliminate the need for the user flag
 - [[PR 974]](https://github.com/parthenon-hpc-lab/parthenon/pull/974) Change GetParentPointer to always return T*
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 - [[PR 948]](https://github.com/parthenon-hpc-lab/parthenon/pull/948) Add solver interface and update Poisson geometric multi-grid example
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 989]](https://github.com/parthenon-hpc-lab/parthenon/pull/989) Update how mesh-level boundary conditions are registered and eliminate the need for the user flag
+- [[PR 974]](https://github.com/parthenon-hpc-lab/parthenon/pull/974) Change GetParentPointer to always return T*
 
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR978]](https://github.com/parthenon-hpc-lab/parthenon/pull/978) remove erroneous sparse check

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Parthenon -- a performance portable block-structured adaptive mesh refinement framework
 
+[[Code Paper]](https://doi.org/10.1177/10943420221143775))
+
 # Key features
 
 * High performance by

--- a/doc/sphinx/src/boundary_conditions.rst
+++ b/doc/sphinx/src/boundary_conditions.rst
@@ -40,7 +40,9 @@ for your ``parthenon_manager``. e.g.,
 
 .. code:: c++
 
-   pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] = MyBoundaryInnerX1;
+   pman.app_input->RegisterBoundaryCondition(
+	  parthenon::BoundaryFace::inner_x1,
+	  "my_bc_name", MyBoundaryInnerX1);
 
 where ``BoundaryFace`` is an enum defined in ``defs.hpp`` as
 
@@ -58,13 +60,13 @@ where ``BoundaryFace`` is an enum defined in ``defs.hpp`` as
      outer_x3 = 5
    };
 
-You can then set this boundary condition via the ``user`` flag in the
-input file:
+You can then set this boundary condition by using the name you
+registered in the input file:
 
 ::
 
    <parthenon/mesh>
-   ix1_bc = user
+   ix1_bc = my_bc_name
 
 Boundary conditions so defined should look roughly like
 

--- a/doc/sphinx/src/particles.rst
+++ b/doc/sphinx/src/particles.rst
@@ -154,13 +154,17 @@ Particle boundary conditions are not applied in separate kernel calls;
 instead, inherited classes containing boundary condition functions for
 updating particles or removing them when they are in boundary regions
 are allocated depending on the boundary flags specified in the input
-file. Currently, outflow and periodic boundaries are supported natively.
-User-specified boundary conditions must be set by specifying the “user”
-flag in the input parameter file and then updating the appropriate
-Swarm::bounds array entries to factory functions that allocate
-device-side boundary condition objects. An example is given in the
-``particles`` example when ix1 and ox1 are set to ``user`` in the input
-parameter file.
+file. Swarm boundary conditions are set via the ``swarm_*_bc``
+variable in the ``parthenon/mesh`` input block in the input file,
+where ``*`` is ``ix1``, ``ox2``, etc.
+
+Currently, outflow and periodic boundaries are supported natively.
+You can register a new boundary condition by calling
+``ApplicationInput::RegisterSwarmBoundaryCondition`` and assigning the
+function that allocates the device-side boundary condition
+objects. Then the ``parthenon/mesh/swarm_*_bv`` variable can be
+assigned to the name you registered. An example is given in the
+``particles`` example.
 
 Outputs
 --------

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particles/main.cpp
+++ b/example/particles/main.cpp
@@ -34,26 +34,10 @@ int main(int argc, char *argv[]) {
   // Redefine parthenon defaults
   pman.app_input->ProcessPackages = particles_example::ProcessPackages;
   pman.app_input->ProblemGenerator = particles_example::ProblemGenerator;
-  if (pman.pinput->GetString("parthenon/mesh", "ix1_bc") == "user") {
-    // In this case, we are setting a custom swarm boundary condition while still using
-    // a default parthenon boundary condition for cell variables. In general, one can
-    // provide both custom cell variable and swarm boundary conditions. However, to use
-    // custom boundary conditions for either cell variables or swarms, the parthenon
-    // boundary must be set to "user" and both cell variable and swarm boundaries provided
-    // as here.
-    pman.app_input->boundary_conditions[parthenon::BoundaryFace::inner_x1] =
-        parthenon::BoundaryFunction::OutflowInnerX1;
-    pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::inner_x1] =
-        particles_example::SetSwarmIX1UserBC;
-  }
-  if (pman.pinput->GetString("parthenon/mesh", "ox1_bc") == "user") {
-    // Again, we use a default parthenon boundary condition for cell variables but a
-    // custom swarm boundary condition.
-    pman.app_input->boundary_conditions[parthenon::BoundaryFace::outer_x1] =
-        parthenon::BoundaryFunction::OutflowOuterX1;
-    pman.app_input->swarm_boundary_conditions[parthenon::BoundaryFace::outer_x1] =
-        particles_example::SetSwarmOX1UserBC;
-  }
+  pman.app_input->RegisterSwarmBoundaryCondition(parthenon::BoundaryFace::inner_x1,
+                                                 &particles_example::SetSwarmIX1UserBC);
+  pman.app_input->RegisterSwarmBoundaryCondition(parthenon::BoundaryFace::outer_x1,
+                                                 &particles_example::SetSwarmOX1UserBC);
   pman.ParthenonInitPackagesAndMesh();
 
   // This needs to be scoped so that the driver object is destructed before Finalize

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -16,6 +16,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -23,6 +24,8 @@
 #include "bvals/boundary_conditions.hpp"
 #include "defs.hpp"
 #include "interface/state_descriptor.hpp"
+#include "interface/swarm_boundaries.hpp"
+#include "kokkos_abstraction.hpp"
 #include "parameter_input.hpp"
 #include "parthenon_arrays.hpp"
 #include "utils/error_checking.hpp"
@@ -31,11 +34,61 @@ namespace parthenon {
 
 class ApplicationInput {
  public:
-  ApplicationInput();
+  ApplicationInput() {
+    RegisterBoundaryCondition(BoundaryFace::inner_x1, "outflow",
+                              &BoundaryFunction::OutflowInnerX1);
+    RegisterBoundaryCondition(BoundaryFace::outer_x1, "outflow",
+                              &BoundaryFunction::OutflowOuterX1);
+    RegisterBoundaryCondition(BoundaryFace::inner_x2, "outflow",
+                              &BoundaryFunction::OutflowInnerX2);
+    RegisterBoundaryCondition(BoundaryFace::outer_x2, "outflow",
+                              &BoundaryFunction::OutflowOuterX2);
+    RegisterBoundaryCondition(BoundaryFace::inner_x3, "outflow",
+                              &BoundaryFunction::OutflowInnerX3);
+    RegisterBoundaryCondition(BoundaryFace::outer_x3, "outflow",
+                              &BoundaryFunction::OutflowOuterX3);
+    RegisterBoundaryCondition(BoundaryFace::inner_x1, "reflecting",
+                              &BoundaryFunction::OutflowInnerX1);
+    RegisterBoundaryCondition(BoundaryFace::outer_x1, "reflecting",
+                              &BoundaryFunction::ReflectOuterX1);
+    RegisterBoundaryCondition(BoundaryFace::inner_x2, "reflecting",
+                              &BoundaryFunction::ReflectInnerX2);
+    RegisterBoundaryCondition(BoundaryFace::outer_x2, "reflecting",
+                              &BoundaryFunction::ReflectOuterX2);
+    RegisterBoundaryCondition(BoundaryFace::inner_x3, "reflecting",
+                              &BoundaryFunction::ReflectInnerX3);
+    RegisterBoundaryCondition(BoundaryFace::outer_x3, "reflecting",
+                              &BoundaryFunction::ReflectOuterX3);
+
+    // Currently outflow and periodic are the only particle BCs available
+    RegisterSwarmBoundaryCondition(BoundaryFace::inner_x1, "outflow",
+                                   &DeviceAllocate<ParticleBoundIX1Outflow>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::outer_x1, "outflow",
+                                   &DeviceAllocate<ParticleBoundOX1Outflow>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::inner_x2, "outflow",
+                                   &DeviceAllocate<ParticleBoundIX2Outflow>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::outer_x2, "outflow",
+                                   &DeviceAllocate<ParticleBoundOX2Outflow>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::inner_x3, "outflow",
+                                   &DeviceAllocate<ParticleBoundIX3Outflow>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::outer_x3, "outflow",
+                                   &DeviceAllocate<ParticleBoundOX3Outflow>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::inner_x1, "periodic",
+                                   &DeviceAllocate<ParticleBoundIX1Periodic>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::outer_x1, "periodic",
+                                   &DeviceAllocate<ParticleBoundOX1Periodic>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::inner_x2, "periodic",
+                                   &DeviceAllocate<ParticleBoundIX2Periodic>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::outer_x2, "periodic",
+                                   &DeviceAllocate<ParticleBoundOX2Periodic>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::inner_x3, "periodic",
+                                   &DeviceAllocate<ParticleBoundIX3Periodic>);
+    RegisterSwarmBoundaryCondition(BoundaryFace::outer_x3, "periodic",
+                                   &DeviceAllocate<ParticleBoundOX3Periodic>);
+  }
 
   // ParthenonManager functions
-  std::function<Packages_t(std::unique_ptr<ParameterInput> &)>
-  ProcessPackages = nullptr;
+  std::function<Packages_t(std::unique_ptr<ParameterInput> &)> ProcessPackages = nullptr;
 
   // Mesh functions
   std::function<void(Mesh *, ParameterInput *)> InitUserMeshData = nullptr;
@@ -63,17 +116,63 @@ class ApplicationInput {
   std::function<void(MeshBlock *, ParameterInput *)> MeshBlockUserWorkBeforeOutput =
       nullptr;
 
+  // Boundary conditions
   void RegisterBoundaryCondition(BoundaryFace face, const std::string &name,
                                  BValFunc condition) {
-    if (boundary_conditions_[face].contains
+    if (boundary_conditions_[face].count(name) > 0) {
+
+      PARTHENON_THROW("Boundary condition " + name + " at face " + std::to_string(face) +
+                      "already registered.");
+    }
+    boundary_conditions_[face][name] = condition;
   }
   void RegisterSwarmBoundaryCondition(BoundaryFace face, const std::string &name,
-                                      SBValFunc condition);
+                                      SBValFunc condition) {
+    if (swarm_boundary_conditions_[face].count(name) > 0) {
+      PARTHENON_THROW("Swarm boundary condition " + name + " at face " +
+                      std::to_string(face) + "already registered.");
+    }
+    swarm_boundary_conditions_[face][name] = condition;
+  }
+  template <typename T>
+  void RegisterSwarmBoundaryCondition(BoundaryFace face, const std::string &name) {
+    RegisterSwarmBoundaryCondition(face, name, &DeviceAllocate<T>);
+  }
   void RegisterBoundaryCondition(BoundaryFace face, BValFunc condition) {
     RegisterBoundaryCondition(face, "user", condition);
   }
+  template <typename T>
+  void RegisterSwarmBoundaryCondition(BoundaryFace face) {
+    RegisterSwarmBoundaryCondition(face, "user", &DeviceAllocate<T>);
+  }
   void RegisterSwarmBoundaryCondition(BoundaryFace face, SBValFunc condition) {
     RegisterSwarmBoundaryCondition(face, "user", condition);
+  }
+  // Getters
+  BValFunc GetBoundaryCondition(BoundaryFace face, const std::string &name) const {
+    if (boundary_conditions_[face].count(name) == 0) {
+      std::stringstream msg;
+      msg << "Boundary condition " << name << " at face " << face << "not registered!\n"
+          << "Available conditions for this face are:\n";
+      for (const auto &[name, func] : boundary_conditions_[face]) {
+        msg << name << "\n";
+      }
+      PARTHENON_THROW(msg);
+    }
+    return boundary_conditions_[face].at(name);
+  }
+  SBValFunc GetSwarmBoundaryCondition(BoundaryFace face, const std::string &name) const {
+    if (swarm_boundary_conditions_[face].count(name) == 0) {
+      std::stringstream msg;
+      msg << "Swarm boundary condition " << name << " at face " << face
+          << "not registered!\n"
+          << "Available conditions for this face are:\n";
+      for (const auto &[name, func] : swarm_boundary_conditions_[face]) {
+        msg << name << "\n";
+      }
+      PARTHENON_THROW(msg);
+    }
+    return swarm_boundary_conditions_[face].at(name);
   }
 
  private:

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -120,7 +120,6 @@ class ApplicationInput {
   void RegisterBoundaryCondition(BoundaryFace face, const std::string &name,
                                  BValFunc condition) {
     if (boundary_conditions_[face].count(name) > 0) {
-
       PARTHENON_THROW("Boundary condition " + name + " at face " + std::to_string(face) +
                       "already registered.");
     }

--- a/src/application_input.hpp
+++ b/src/application_input.hpp
@@ -181,5 +181,4 @@ class ApplicationInput {
 };
 
 } // namespace parthenon
-
 #endif // APPLICATION_INPUT_HPP_

--- a/src/bvals/boundary_flag.cpp
+++ b/src/bvals/boundary_flag.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/bvals/boundary_flag.cpp
+++ b/src/bvals/boundary_flag.cpp
@@ -35,100 +35,14 @@ namespace parthenon {
 //  condition. Typically called in Mesh() ctor and in pgen/*.cpp files.
 
 BoundaryFlag GetBoundaryFlag(const std::string &input_string) {
-  if (input_string == "reflecting") {
-    return BoundaryFlag::reflect;
-  } else if (input_string == "outflow") {
-    return BoundaryFlag::outflow;
-  } else if (input_string == "periodic") {
+  if (input_string == "periodic") {
     return BoundaryFlag::periodic;
   } else if (input_string == "none") {
     return BoundaryFlag::undef;
   } else if (input_string == "block") {
     return BoundaryFlag::block;
-  } else if (input_string == "user") {
-    return BoundaryFlag::user;
   } else {
-    std::stringstream msg;
-    msg << "### FATAL ERROR in GetBoundaryFlag" << std::endl
-        << "Input string=" << input_string << "\n"
-        << "is an invalid boundary type" << std::endl;
-    PARTHENON_FAIL(msg);
-  }
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn GetBoundaryString(BoundaryFlag input_flag)
-//  \brief Parses enumerated type BoundaryFlag internal integer representation to return
-//  string describing the boundary condition. Typicall used to format descriptive errors
-//  or diagnostics. Inverse of GetBoundaryFlag().
-
-std::string GetBoundaryString(BoundaryFlag input_flag) {
-  switch (input_flag) {
-  case BoundaryFlag::block: // -1
-    return "block";
-  case BoundaryFlag::undef: // 0
-    return "none";
-  case BoundaryFlag::reflect:
-    return "reflecting";
-  case BoundaryFlag::outflow:
-    return "outflow";
-  case BoundaryFlag::periodic:
-    return "periodic";
-  case BoundaryFlag::user:
-    return "user";
-  default:
-    std::stringstream msg;
-    msg << "### FATAL ERROR in GetBoundaryString" << std::endl
-        << "Input enum class BoundaryFlag=" << static_cast<int>(input_flag) << "\n"
-        << "is an invalid boundary type" << std::endl;
-    PARTHENON_FAIL(msg);
-    break;
-  }
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn CheckBoundaryFlag(BoundaryFlag block_flag, CoordinateDirection dir)
-//  \brief Called in each MeshBlock's BoundaryValues() constructor. Mesh() ctor only
-//  checks the validity of user's input mesh/ixn_bc, oxn_bc string values corresponding to
-//  a BoundaryFlag enumerator before passing it to a MeshBlock and then BoundaryBase
-//  object. However, not all BoundaryFlag enumerators can be used in all directions as a
-//  valid MeshBlock boundary.
-
-void CheckBoundaryFlag(BoundaryFlag block_flag, CoordinateDirection dir) {
-  std::stringstream msg;
-  msg << "### FATAL ERROR in CheckBoundaryFlag" << std::endl
-      << "Attempting to set invalid MeshBlock boundary= " << GetBoundaryString(block_flag)
-      << "\nin x" << dir << " direction" << std::endl;
-  switch (dir) {
-  case CoordinateDirection::X1DIR:
-    switch (block_flag) {
-    case BoundaryFlag::undef:
-      PARTHENON_FAIL(msg);
-      break;
-    default:
-      break;
-    }
-    break;
-  case CoordinateDirection::X2DIR:
-    switch (block_flag) {
-    case BoundaryFlag::undef:
-      PARTHENON_FAIL(msg);
-      break;
-    default:
-      break;
-    }
-    break;
-  case CoordinateDirection::X3DIR:
-    switch (block_flag) {
-    case BoundaryFlag::undef:
-      PARTHENON_FAIL(msg);
-      break;
-    default:
-      break;
-    }
-    break;
-  default:
-    PARTHENON_FAIL(msg);
+    return BoundaryFlag::user;
   }
 }
 

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -53,36 +53,19 @@ BoundaryValues::BoundaryValues(std::weak_ptr<MeshBlock> wpmb, BoundaryFlag *inpu
     : BoundaryBase(wpmb.lock()->pmy_mesh, wpmb.lock()->loc, wpmb.lock()->block_size,
                    input_bcs),
       pmy_block_(wpmb) {
-  // Check BC functions for each of the 6 boundaries in turn ---------------------
-  for (int i = 0; i < 6; i++) {
-    switch (block_bcs[i]) {
-    case BoundaryFlag::reflect:
-    case BoundaryFlag::outflow:
-      apply_bndry_fn_[i] = true;
-      break;
-    default: // already initialized to false in class
-      break;
-    }
-  }
   // Inner x1
   nface_ = 2;
   nedge_ = 0;
-  CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x1], CoordinateDirection::X1DIR);
-  CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x1], CoordinateDirection::X1DIR);
 
   std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   if (!pmb->block_size.symmetry(X2DIR)) {
     nface_ = 4;
     nedge_ = 4;
-    CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x2], CoordinateDirection::X2DIR);
-    CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x2], CoordinateDirection::X2DIR);
   }
 
   if (!pmb->block_size.symmetry(X3DIR)) {
     nface_ = 6;
     nedge_ = 12;
-    CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x3], CoordinateDirection::X3DIR);
-    CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x3], CoordinateDirection::X3DIR);
   }
 
   // prevent reallocation of contiguous memory space for each of 4x possible calls to
@@ -133,36 +116,21 @@ BoundarySwarms::BoundarySwarms(std::weak_ptr<MeshBlock> wpmb, BoundaryFlag *inpu
                    input_bcs),
       pmy_block_(wpmb) {
   // Check BC functions for each of the 6 boundaries in turn ---------------------
-  // TODO(BRR) Add physical particle boundary conditions, maybe using the below code
-  /*for (int i = 0; i < 6; i++) {
-    switch (block_bcs[i]) {
-    case BoundaryFlag::reflect:
-    case BoundaryFlag::outflow:
-      apply_bndry_fn_[i] = true;
-      break;
-    default: // already initialized to false in class
-      break;
-    }
-  }*/
+  // TODO(BRR) Add physical particle boundary conditions
+
   // Inner x1
   nface_ = 2;
   nedge_ = 0;
-  CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x1], CoordinateDirection::X1DIR);
-  CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x1], CoordinateDirection::X1DIR);
 
   std::shared_ptr<MeshBlock> pmb = GetBlockPointer();
   if (!pmb->block_size.symmetry(X2DIR)) {
     nface_ = 4;
     nedge_ = 4;
-    CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x2], CoordinateDirection::X2DIR);
-    CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x2], CoordinateDirection::X2DIR);
   }
 
   if (!pmb->block_size.symmetry(X3DIR)) {
     nface_ = 6;
     nedge_ = 12;
-    CheckBoundaryFlag(block_bcs[BoundaryFace::inner_x3], CoordinateDirection::X3DIR);
-    CheckBoundaryFlag(block_bcs[BoundaryFace::outer_x3], CoordinateDirection::X3DIR);
   }
 }
 

--- a/src/bvals/bvals.cpp
+++ b/src/bvals/bvals.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -50,9 +50,6 @@ struct RegionSize;
 
 // free functions to return boundary flag given input string, and vice versa
 BoundaryFlag GetBoundaryFlag(const std::string &input_string);
-std::string GetBoundaryString(BoundaryFlag input_flag);
-// + confirming that the MeshBlock's boundaries are all valid selections
-void CheckBoundaryFlag(BoundaryFlag block_flag, CoordinateDirection dir);
 
 //----------------------------------------------------------------------------------------
 //! \class BoundaryBase
@@ -133,11 +130,6 @@ class BoundarySwarms : public BoundaryBase, BoundaryCommunication {
   std::weak_ptr<MeshBlock> pmy_block_;
   int nface_, nedge_;
 
-  // if a BoundaryPhysics or user fn should be applied at each MeshBlock boundary
-  // false --> e.g. block, polar, periodic boundaries
-  // bool apply_bndry_fn_[6]{}; // C++11: in-class initializer of non-static member
-  // C++11: direct-list-initialization -> value init of array -> zero init of each scalar
-
   /// Returns shared pointer to a block
   std::shared_ptr<MeshBlock> GetBlockPointer() {
     if (pmy_block_.expired()) {
@@ -184,11 +176,6 @@ class BoundaryValues : public BoundaryBase, // public BoundaryPhysics,
   // ptr to MeshBlock containing this BoundaryValues
   std::weak_ptr<MeshBlock> pmy_block_;
   int nface_, nedge_; // used only in fc/flux_correction_fc.cpp calculations
-
-  // if a BoundaryPhysics or user fn should be applied at each MeshBlock boundary
-  // false --> e.g. block, polar, periodic boundaries
-  bool apply_bndry_fn_[6]{}; // C++11: in-class initializer of non-static member
-  // C++11: direct-list-initialization -> value init of array -> zero init of each scalar
 
   /// Returns shared pointer to a block
   std::shared_ptr<MeshBlock> GetBlockPointer() {

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -85,7 +85,7 @@ enum {
 // int to index raw arrays (not ParArrayNDs)--> enumerator vals are explicitly specified
 
 // identifiers for boundary conditions
-enum class BoundaryFlag { block = -1, undef, reflect, outflow, periodic, user };
+enum class BoundaryFlag { block = -1, undef, periodic, user };
 
 // identifiers for types of neighbor blocks (connectivity with current MeshBlock)
 enum class NeighborConnect {

--- a/src/bvals/bvals_interfaces.hpp
+++ b/src/bvals/bvals_interfaces.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -92,56 +92,15 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
   Kokkos::deep_copy(marked_for_removal_, marked_for_removal_h);
 }
 
-template <class BOutflow, class BPeriodic, int iFace>
-void Swarm::AllocateBoundariesImpl_(MeshBlock *pmb) {
-  std::stringstream msg;
-  auto &bcs = pmb->pmy_mesh->mesh_bcs;
-  if (bcs[iFace] == BoundaryFlag::outflow) {
-    bounds_uptrs[iFace] = DeviceAllocate<BOutflow>();
-  } else if (bcs[iFace] == BoundaryFlag::periodic) {
-    bounds_uptrs[iFace] = DeviceAllocate<BPeriodic>();
-  } else if (bcs[iFace] == BoundaryFlag::user) {
-    if (pmb->pmy_mesh->SwarmBndryFnctn[iFace] != nullptr) {
-      bounds_uptrs[iFace] = pmb->pmy_mesh->SwarmBndryFnctn[iFace]();
-    } else {
-      msg << (iFace % 2 == 0 ? "i" : "o") << "x" << iFace / 2 + 1
-          << " user boundary requested but provided function is null!";
-      PARTHENON_THROW(msg);
-    }
-  } else {
-    msg << (iFace % 2 == 0 ? "i" : "o") << "x" << iFace / 2 + 1 << " boundary flag "
-        << static_cast<int>(bcs[iFace]) << " not supported!";
-    PARTHENON_THROW(msg);
-  }
-}
-
 void Swarm::AllocateBoundaries() {
   auto pmb = GetBlockPointer();
   std::stringstream msg;
 
-  auto &bcs = pmb->pmy_mesh->mesh_bcs;
-
-  AllocateBoundariesImpl_<ParticleBoundIX1Outflow, ParticleBoundIX1Periodic, 0>(
-      pmb.get());
-  AllocateBoundariesImpl_<ParticleBoundOX1Outflow, ParticleBoundOX1Periodic, 1>(
-      pmb.get());
-  AllocateBoundariesImpl_<ParticleBoundIX2Outflow, ParticleBoundIX2Periodic, 2>(
-      pmb.get());
-  AllocateBoundariesImpl_<ParticleBoundOX2Outflow, ParticleBoundOX2Periodic, 3>(
-      pmb.get());
-  AllocateBoundariesImpl_<ParticleBoundIX3Outflow, ParticleBoundIX3Periodic, 4>(
-      pmb.get());
-  AllocateBoundariesImpl_<ParticleBoundOX3Outflow, ParticleBoundOX3Periodic, 5>(
-      pmb.get());
-
-  for (int n = 0; n < 6; n++) {
+  for (int n = 0; n < BOUNDARY_NFACES; ++n) {
+    // Not possible for this to be nullptr, as AppInput would have
+    // thrown an error
+    bounds_uptrs[n] = pmb->pmy_mesh->SwarmBndryFnctn[n]();
     bounds_d.bounds[n] = bounds_uptrs[n].get();
-    std::stringstream msg;
-    msg << "Boundary condition on face " << n << " missing.\n"
-        << "Please set it to `outflow`, `periodic`, or `user` in the input deck.\n"
-        << "If you set it to user, you must also manually set "
-        << "the swarm boundary pointer in your application." << std::endl;
-    PARTHENON_REQUIRE(bounds_d.bounds[n] != nullptr, msg);
   }
 }
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1158,9 +1158,9 @@ bool Mesh::SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size
 // \!fn void Mesh::GetBlockSize(const LogicalLocation &loc) const
 // \brief Find the (hyper-)rectangular region of the grid covered by the block at
 //        logical location loc
-
 RegionSize Mesh::GetBlockSize(const LogicalLocation &loc) const {
   RegionSize block_size = GetBlockSize();
+  bool valid_region = true;
   for (auto &dir : {X1DIR, X2DIR, X3DIR}) {
     block_size.xrat(dir) = mesh_size.xrat(dir);
     block_size.symmetry(dir) = mesh_size.symmetry(dir);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -79,13 +79,25 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
                  pin->GetInteger("parthenon/mesh", "nx3")},
                 {false, pin->GetInteger("parthenon/mesh", "nx2") == 1,
                  pin->GetInteger("parthenon/mesh", "nx3") == 1}),
-      mesh_bcs{
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ix1_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ox1_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ix2_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ox2_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ix3_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ox3_bc", "reflecting"))},
+      mesh_bc_names{pin->GetOrAddString("parthenon/mesh", "ix1_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ox1_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ix2_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ox2_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ix3_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ox3_bc", "reflecting")},
+      // TODO(JMM): This probably needs a per-package treatment too
+      swarm_bc_names{pin->GetOrAddString("parthenon/mesh", "swarm_ix1_bc",
+                                         mesh_bc_names[BoundaryFace::inner_x1]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ox1_bc",
+                                         mesh_bc_names[BoundaryFace::outer_x1]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ix2_bc",
+                                         mesh_bc_names[BoundaryFace::inner_x2]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ox2_bc",
+                                         mesh_bc_names[BoundaryFace::outer_x2]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ix3_bc",
+                                         mesh_bc_names[BoundaryFace::inner_x3]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ox3_bc",
+                                         mesh_bc_names[BoundaryFace::outer_x3])},
       ndim((mesh_size.nx(X3DIR) > 1) ? 3 : ((mesh_size.nx(X2DIR) > 1) ? 2 : 1)),
       adaptive(pin->GetOrAddString("parthenon/mesh", "refinement", "none") == "adaptive"
                    ? true
@@ -109,6 +121,12 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
   RegionSize block_size;
   BoundaryFlag block_bcs[6];
   std::int64_t nbmax;
+
+  // BCs
+  for (int f = 0; f < BOUNDARY_NFACES; ++f) {
+    mesh_bcs[f] = GetBoundaryFlag(mesh_bc_names[f]);
+    swarm_bcs[f] = GetBoundaryFlag(swarm_bc_names[f]);
+  }
 
   // mesh test
   if (mesh_test > 0) Globals::nranks = mesh_test;
@@ -455,13 +473,25 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
                  pin->GetInteger("parthenon/mesh", "nx3")},
                 {false, pin->GetInteger("parthenon/mesh", "nx2") == 1,
                  pin->GetInteger("parthenon/mesh", "nx3") == 1}),
-      mesh_bcs{
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ix1_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ox1_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ix2_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ox2_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ix3_bc", "reflecting")),
-          GetBoundaryFlag(pin->GetOrAddString("parthenon/mesh", "ox3_bc", "reflecting"))},
+      mesh_bc_names{pin->GetOrAddString("parthenon/mesh", "ix1_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ox1_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ix2_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ox2_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ix3_bc", "reflecting"),
+                    pin->GetOrAddString("parthenon/mesh", "ox3_bc", "reflecting")},
+      // TODO(JMM): This probably needs a per-package treatment too
+      swarm_bc_names{pin->GetOrAddString("parthenon/mesh", "swarm_ix1_bc",
+                                         mesh_bc_names[BoundaryFace::inner_x1]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ox1_bc",
+                                         mesh_bc_names[BoundaryFace::outer_x1]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ix2_bc",
+                                         mesh_bc_names[BoundaryFace::inner_x2]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ox2_bc",
+                                         mesh_bc_names[BoundaryFace::outer_x2]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ix3_bc",
+                                         mesh_bc_names[BoundaryFace::inner_x3]),
+                     pin->GetOrAddString("parthenon/mesh", "swarm_ox3_bc",
+                                         mesh_bc_names[BoundaryFace::outer_x3])},
       ndim((mesh_size.nx(X3DIR) > 1) ? 3 : ((mesh_size.nx(X2DIR) > 1) ? 2 : 1)),
       adaptive(pin->GetOrAddString("parthenon/mesh", "refinement", "none") == "adaptive"
                    ? true
@@ -485,6 +515,12 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   RegionSize block_size;
   BoundaryFlag block_bcs[6];
 
+  // BCs
+  for (int f = 0; f < BOUNDARY_NFACES; ++f) {
+    mesh_bcs[f] = GetBoundaryFlag(mesh_bc_names[f]);
+    swarm_bcs[f] = GetBoundaryFlag(swarm_bc_names[f]);
+  }
+
   // mesh test
   if (mesh_test > 0) Globals::nranks = mesh_test;
 
@@ -506,7 +542,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   root_level = rr.GetAttr<int>("Info", "RootLevel");
 
   const auto bc = rr.GetAttrVec<std::string>("Info", "BoundaryConditions");
-  for (int i = 0; i < 6; i++) {
+  for (int i = 0; i < BOUNDARY_NFACES; i++) {
     block_bcs[i] = GetBoundaryFlag(bc[i]);
   }
 
@@ -851,48 +887,14 @@ void Mesh::OutputMeshStructure(const int ndim,
 //----------------------------------------------------------------------------------------
 //  Enroll user-defined functions for boundary conditions
 void Mesh::EnrollBndryFncts_(ApplicationInput *app_in) {
-  static const BValFunc outflow[6] = {
-      BoundaryFunction::OutflowInnerX1, BoundaryFunction::OutflowOuterX1,
-      BoundaryFunction::OutflowInnerX2, BoundaryFunction::OutflowOuterX2,
-      BoundaryFunction::OutflowInnerX3, BoundaryFunction::OutflowOuterX3};
-  static const BValFunc reflect[6] = {
-      BoundaryFunction::ReflectInnerX1, BoundaryFunction::ReflectOuterX1,
-      BoundaryFunction::ReflectInnerX2, BoundaryFunction::ReflectOuterX2,
-      BoundaryFunction::ReflectInnerX3, BoundaryFunction::ReflectOuterX3};
-
-  for (int f = 0; f < BOUNDARY_NFACES; f++) {
-    switch (mesh_bcs[f]) {
-    case BoundaryFlag::reflect:
-      MeshBndryFnctn[f] = reflect[f];
-      break;
-    case BoundaryFlag::outflow:
-      MeshBndryFnctn[f] = outflow[f];
-      break;
-    case BoundaryFlag::user:
-      if (app_in->boundary_conditions[f] != nullptr) {
-        MeshBndryFnctn[f] = app_in->boundary_conditions[f];
-      } else {
-        std::stringstream msg;
-        msg << "A user boundary condition for face " << f
-            << " was requested. but no condition was enrolled." << std::endl;
-        PARTHENON_THROW(msg);
-      }
-      break;
-    default: // periodic/block BCs handled elsewhere.
-      break;
+  for (int f = 0; f < BOUNDARY_NFACES; ++f) {
+    auto face = static_cast<BoundaryFace>(f);
+    if (mesh_bcs[f] == BoundaryFlag::user) { // not block, periodic, or none
+      MeshBndryFnctn[f] = app_in->GetBoundaryCondition(face, mesh_bc_names[f]);
     }
-
-    switch (mesh_bcs[f]) {
-    case BoundaryFlag::user:
-      if (app_in->swarm_boundary_conditions[f] != nullptr) {
-        // This is checked to be non-null later in Swarm::AllocateBoundaries, in case user
-        // boundaries are requested but no swarms are used.
-        SwarmBndryFnctn[f] = app_in->swarm_boundary_conditions[f];
-      }
-      break;
-    default: // Default BCs handled elsewhere
-      break;
-    }
+    // Swarms are always done with this mechanism. Periodic not a
+    // different codepath.
+    SwarmBndryFnctn[f] = app_in->GetSwarmBoundaryCondition(face, swarm_bc_names[f]);
   }
 }
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -519,6 +519,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   for (int f = 0; f < BOUNDARY_NFACES; ++f) {
     mesh_bcs[f] = GetBoundaryFlag(mesh_bc_names[f]);
     swarm_bcs[f] = GetBoundaryFlag(swarm_bc_names[f]);
+    block_bcs[i] = mesh_bcs[i];
   }
 
   // mesh test
@@ -540,11 +541,6 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   nbdel = rr.GetAttr<int>("Info", "NBDel");
   nbtotal = rr.GetAttr<int>("Info", "NumMeshBlocks");
   root_level = rr.GetAttr<int>("Info", "RootLevel");
-
-  const auto bc = rr.GetAttrVec<std::string>("Info", "BoundaryConditions");
-  for (int i = 0; i < BOUNDARY_NFACES; i++) {
-    block_bcs[i] = GetBoundaryFlag(bc[i]);
-  }
 
   // Allow for user overrides to default Parthenon functions
   if (app_in->InitUserMeshData != nullptr) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -519,7 +519,7 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   for (int f = 0; f < BOUNDARY_NFACES; ++f) {
     mesh_bcs[f] = GetBoundaryFlag(mesh_bc_names[f]);
     swarm_bcs[f] = GetBoundaryFlag(swarm_bc_names[f]);
-    block_bcs[i] = mesh_bcs[i];
+    block_bcs[f] = mesh_bcs[f];
   }
 
   // mesh test
@@ -1161,7 +1161,6 @@ bool Mesh::SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size
 
 RegionSize Mesh::GetBlockSize(const LogicalLocation &loc) const {
   RegionSize block_size = GetBlockSize();
-  bool valid_region = true;
   for (auto &dir : {X1DIR, X2DIR, X3DIR}) {
     block_size.xrat(dir) = mesh_size.xrat(dir);
     block_size.symmetry(dir) = mesh_size.symmetry(dir);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -104,7 +104,10 @@ class Mesh {
   const bool is_restart;
   RegionSize mesh_size;
   RegionSize base_block_size;
+  std::string mesh_bc_names[BOUNDARY_NFACES];
+  std::string swarm_bc_names[BOUNDARY_NFACES];
   BoundaryFlag mesh_bcs[BOUNDARY_NFACES];
+  BoundaryFlag swarm_bcs[BOUNDARY_NFACES];
   const int ndim; // number of dimensions
   const bool adaptive, multilevel, multigrid;
   int nbtotal, nbnew, nbdel;

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -135,7 +135,7 @@ void MeshBlock::Initialize(int igid, int ilid, LogicalLocation iloc,
   // mesh-related objects
   // Boundary
   pbval = std::make_unique<BoundaryValues>(shared_from_this(), input_bcs, pin);
-  pbval->SetBoundaryFlags(boundary_flag);
+  pbval->SetBoundaryFlags(boundary_flag); // TODO(JMM): Does this DO anything now?
   pbswarm = std::make_unique<BoundarySwarms>(shared_from_this(), input_bcs, pin);
   pbswarm->SetBoundaryFlags(boundary_flag);
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -186,7 +186,9 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     // Boundary conditions
     std::vector<std::string> boundary_condition_str(BOUNDARY_NFACES);
     for (size_t i = 0; i < boundary_condition_str.size(); i++) {
-      boundary_condition_str[i] = GetBoundaryString(pm->mesh_bcs[i]);
+      // JMM: This appears to be purely for analysis, as it is not
+      // read in for restarts.
+      boundary_condition_str[i] = pm->mesh_bc_names[i];
     }
 
     HDF5WriteAttribute("BoundaryConditions", boundary_condition_str, info_group);

--- a/tst/unit/test_mesh_data.cpp
+++ b/tst/unit/test_mesh_data.cpp
@@ -104,7 +104,7 @@ TEST_CASE("MeshData works as expected for simple packs", "[MeshData]") {
                 }
               });
         }
-        auto &var = pmbd->Get("v6");
+        auto &var = pmbd->Get("v6").data;
         par_for(
             loop_pattern_mdrange_tag, "initialize v6", DevExecSpace(), kb.s, kb.e + 1,
             jb.s, jb.e + 1, ib.s, ib.e + 1, KOKKOS_LAMBDA(int k, int j, int i) {

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -59,11 +59,6 @@ class ParticleBoundIX1User : public ParticleBound {
   }
 };
 
-std::unique_ptr<ParticleBound, DeviceDeleter<parthenon::DevMemSpace>>
-SetSwarmIX1UserBC() {
-  return DeviceAllocate<ParticleBoundIX1User>();
-}
-
 TEST_CASE("Swarm memory management", "[Swarm]") {
   std::stringstream is;
   is << "<parthenon/mesh>" << endl;
@@ -76,17 +71,20 @@ TEST_CASE("Swarm memory management", "[Swarm]") {
   is << "nx1 = 4" << endl;
   is << "nx2 = 4" << endl;
   is << "nx3 = 4" << endl;
+  is << "swarm_ix1_bc = user" << endl;
+  is << "swarm_ox1_bc = outflow" << endl;
+  is << "swarm_ix2_bc = outflow" << endl;
+  is << "swarm_ox2_bc = outflow" << endl;
+  is << "swarm_ix3_bc = outflow" << endl;
+  is << "swarm_ox3_bc = outflow" << endl;
   auto pin = std::make_shared<ParameterInput>();
   pin->LoadFromStream(is);
   auto app_in = std::make_shared<ApplicationInput>();
+  app_in->RegisterSwarmBoundaryCondition<ParticleBoundIX1User>(
+      parthenon::BoundaryFace::inner_x1);
   Packages_t packages;
   auto meshblock = std::make_shared<MeshBlock>(1, 1);
   auto mesh = std::make_shared<Mesh>(pin.get(), app_in.get(), packages, 1);
-  mesh->mesh_bcs[0] = BoundaryFlag::user;
-  mesh->SwarmBndryFnctn[0] = SetSwarmIX1UserBC;
-  for (int i = 1; i < 6; i++) {
-    mesh->mesh_bcs[i] = BoundaryFlag::outflow;
-  }
   meshblock->pmy_mesh = mesh.get();
   Metadata m;
   auto swarm = std::make_shared<Swarm>("test swarm", m, NUMINIT);

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## API Breaking change

When registering user boundary functions, the mechanism changes from assigning the function pointer to an array. You now must call `ApplicationInput::RegisterBoundaryCondition` and give the custom boundary condition a name. This also eliminates the need for the `user` boundary flag in the input file, although that flag is implicitly still supported.

## PR Summary

A discussion on the new downstream code headed by @brryan @pdmullen indicated a desire to set mesh-level boundary conditions without using the `user` flag. Here I implement this feature. The changes I made are:
1. `ApplicationInput` now has a registration function where you register either a grid or particle boundary condition, with a function pointer (or a class in the case of swarm bounds) and a name.
2. ALL boundary conditions (except periodic) use this mechanism. Reflecting boundaries are, for example, registered in the constructor for `ApplicationInput` with the `"reflecting"` name.
3. `BoundaryFlag`s are dramatically simplified, indicating (essentially) only whether or not boundaries are periodic.
4. The mesh no longer uses flags to set function pointers. Instead, it just pulls the functions from `ApplicationInput`.
5. For (sort of) backwards compatibility, if you register a function without naming it, it's named "user."
6. Swarm boundaries are now decoupled from mesh boundaries. Although by default, they are set to the same value as the mesh.

The advantage of this is that you can now call (in your main function)
```C++
pman->app_input.RegisterBoundaryCondition(parthenon::BoundaryFace::inner_x1, "my_bc", &my_bc_func);
```
and then in the input file just use
```
<parthenon/mesh>
ix1_bc = my_bc
```

I think the refactored code is also significantly cleaner and easier to read. Also I put a link to the parthenon paper in the readme.


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] Change is breaking (API, behavior, ...)
  - [x] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [x] PR is marked as breaking
  - [x] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
