### PR TITLE
Allow custom PR ops with sparse pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR992]](https://github.com/parthenon-hpc-lab/parthenon/pull/992) Allow custom PR ops with sparse pools
 - [[PR986]](https://github.com/parthenon-hpc-lab/parthenon/pull/986) Fix bug in sparse boundary communication BndInfo cacheing
 - [[PR978]](https://github.com/parthenon-hpc-lab/parthenon/pull/978) remove erroneous sparse check
 

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -103,7 +103,8 @@ MetadataFlag Metadata::GetUserFlag(const std::string &flagname) {
 namespace parthenon {
 Metadata::Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
                    const std::vector<std::string> &component_labels,
-                   const std::string &associated)
+                   const std::string &associated,
+                   const refinement::RefinementFunctions_t ref_funcs_)
     : shape_(shape), component_labels_(component_labels), associated_(associated) {
   // set flags
   for (const auto f : bits) {
@@ -126,8 +127,7 @@ Metadata::Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int>
   // If variable is refined, set a default prolongation/restriction op
   // TODO(JMM): This is dangerous. See Issue #844.
   if (IsRefined()) {
-    refinement_funcs_ = refinement::RefinementFunctions_t::RegisterOps<
-        refinement_ops::ProlongateSharedMinMod, refinement_ops::RestrictAverage>();
+    refinement_funcs_ = ref_funcs_;
   }
 
   // check if all flag constraints are satisfied, throw if not

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -316,9 +316,13 @@ class Metadata {
 
   // 4 constructors, this is the general constructor called by all other constructors, so
   // we do some sanity checks here
-  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
-           const std::vector<std::string> &component_labels = {},
-           const std::string &associated = "");
+  Metadata(
+      const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
+      const std::vector<std::string> &component_labels = {},
+      const std::string &associated = "",
+      const refinement::RefinementFunctions_t ref_funcs_ =
+          refinement::RefinementFunctions_t::RegisterOps<
+              refinement_ops::ProlongateSharedMinMod, refinement_ops::RestrictAverage>());
 
   // 1 constructor
   Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,
@@ -548,7 +552,6 @@ class Metadata {
 
   // Refinement stuff
   const refinement::RefinementFunctions_t &GetRefinementFunctions() const {
-    PARTHENON_REQUIRE_THROWS(IsRefined(), "Variable must be registered for refinement");
     return refinement_funcs_;
   }
   template <class ProlongationOp, class RestrictionOp,

--- a/src/interface/sparse_pool.cpp
+++ b/src/interface/sparse_pool.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/sparse_pool.cpp
+++ b/src/interface/sparse_pool.cpp
@@ -59,7 +59,7 @@ const Metadata &SparsePool::AddImpl(int sparse_id, const std::vector<int> &shape
       shared_metadata_.Flags(), shape.size() > 0 ? shape : shared_metadata_.Shape(),
       component_labels.size() > 0 ? component_labels
                                   : shared_metadata_.getComponentLabels(),
-      shared_metadata_.getAssociated());
+      shared_metadata_.getAssociated(), shared_metadata_.GetRefinementFunctions());
 
   this_metadata.SetSparseThresholds(shared_metadata_.GetAllocationThreshold(),
                                     shared_metadata_.GetDeallocationThreshold(),

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -229,18 +229,6 @@ TEST_CASE("Refinement Information in Metadata", "[Metadata]") {
       }
     }
   }
-  // JMM: I also wanted to test registration of refinement operations
-  // but this turns out to be impossible because Catch2 macros are not
-  // careful with commas, and the macro interprets commas within the
-  // template as separate arguments.
-  GIVEN("A metadata struct without the relevant flags set") {
-    Metadata m;
-    WHEN("We try to request refinement functions") {
-      THEN("It should fail") {
-        REQUIRE_THROWS_AS(m.GetRefinementFunctions(), std::runtime_error);
-      }
-    }
-  }
   GIVEN("A simple metadata object") {
     using FlagVec = std::vector<parthenon::MetadataFlag>;
     Metadata m(FlagVec{Metadata::Derived, Metadata::OneCopy});

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -383,7 +383,7 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
       }
     }
 
-    WHEN("We register a dense variable custom prolongation/restriction") {
+    WHEN("We register a dense variable with default prolongation/restriction") {
       pkg1->AddField("dense", m_provides);
       WHEN("We register a sparse variable with custom prolongation/restriction") {
         auto m_sparse_provides_ = m_sparse_provides;
@@ -391,8 +391,8 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
         pkg2->AddSparsePool("sparse", m_sparse_provides_, sparse_ids);
         THEN("We can perform dependency resolution") {
           auto pkg3 = ResolvePackages(packages);
-          AND_THEN("The two relevant prolongation restriction operators exist and have "
-                   "unique ids") {
+          AND_THEN("The two relevant prolongation restriction operators exist, are "
+                   "appropriately set, and have unique ids") {
             const auto my_funcs =
                 parthenon::refinement::RefinementFunctions_t::RegisterOps<MyProlongOp,
                                                                           MyRestrictOp>();
@@ -403,6 +403,12 @@ TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") 
             REQUIRE(pkg3->NumRefinementFuncs() == 2);
             REQUIRE((pkg3->RefinementFuncID(my_funcs)) !=
                     (pkg3->RefinementFuncID(cell_funcs)));
+            REQUIRE(pkg3->FieldMetadata("dense").GetRefinementFunctions() == cell_funcs);
+            for (int i = 0; i < sparse_ids.size(); i++) {
+              REQUIRE(
+                  pkg3->FieldMetadata("sparse", sparse_ids[i]).GetRefinementFunctions() ==
+                  my_funcs);
+            }
           }
         }
       }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
`AddSparsePool` copies the relevant `Metadata` for all entries in the pool.  Calling the `Metadata` constructor upon copying (unintentionally) overwrites any custom P/R operations that were previously enrolled via `m.RegisterRefinementOps`.

My changeset adds the default PR ops as an optional argument to the `Metadata` constructor.  When `IsRefined()`, this default argument is used to set the `refinement_funcs_` private member.  

With this change, when copying `Metadata` for all entries in the `SparsePool`, we can just pass `shared_metadata.GetRefinementFunctions()` to the argument list, resulting in the desired behavior.  

My changeset feels somewhat hacky, and invokes unnecessary `RegisterOps` calls due to the default argument.  Please be harsh... if anything, let this PR bring attention to the issue and a possible resolution, even if we eventually take a wildly different approach to solving it.  

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
