### PR TITLE
WIP: Store pmb->gid in VariableState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1010]](https://github.com/parthenon-hpc-lab/parthenon/pull/1010) Store pmb->gid in VariableState
 - [[PR 852]](https://github.com/parthenon-hpc-lab/parthenon/pull/852) Add Mesh version of UserWorkBeforeOutput
 - [[PR 998]](https://github.com/parthenon-hpc-lab/parthenon/pull/998) tensor indices added to sparse pack
 - [[PR 999]](https://github.com/parthenon-hpc-lab/parthenon/pull/999) Add a post-initialization hook

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -39,6 +39,8 @@ Variable<T>::Variable(const std::string &base_name, const Metadata &metadata,
                            "Mismatch between sparse flag and sparse ID");
   uid_ = get_uid_(label());
 
+  pmb_gid_ = wpmb.lock().get()->gid;
+
   if (m_.getAssociated() == "") {
     m_.Associate(label());
   }

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -170,12 +170,15 @@ class Variable {
   /// (Metadata::FillGhost is set)
   void AllocateFluxesAndCoarse(std::weak_ptr<MeshBlock> wpmb);
 
-  VariableState MakeVariableState() const { return VariableState(m_, sparse_id_, dims_); }
+  VariableState MakeVariableState() const {
+    return VariableState(m_, sparse_id_, pmb_gid_, dims_);
+  }
 
   Metadata m_;
   const std::string base_name_;
   const int sparse_id_;
   const std::array<int, MAX_VARIABLE_DIMENSION> dims_, coarse_dims_;
+  int pmb_gid_;
 
   // Machinery for giving each variable a unique ID that is faster to
   // evaluate than a string. Safe so long as the number of MPI ranks

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable_state.cpp
+++ b/src/interface/variable_state.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable_state.cpp
+++ b/src/interface/variable_state.cpp
@@ -16,12 +16,13 @@
 
 namespace parthenon {
 
-VariableState::VariableState(const Metadata &md, int sparse_id,
+VariableState::VariableState(const Metadata &md, int sparse_id, int pmb_gid,
                              const std::array<int, MAX_VARIABLE_DIMENSION> &dims) {
   allocation_threshold = md.GetAllocationThreshold();
   deallocation_threshold = md.GetDeallocationThreshold();
   sparse_default_val = md.GetDefaultValue();
   this->sparse_id = sparse_id;
+  this->pmb_gid = pmb_gid;
 
   tensor_shape[0] = dims[3];
   tensor_shape[1] = dims[4];

--- a/src/interface/variable_state.hpp
+++ b/src/interface/variable_state.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/variable_state.hpp
+++ b/src/interface/variable_state.hpp
@@ -29,7 +29,7 @@ static constexpr int InvalidSparseID = std::numeric_limits<int>::min();
 
 struct VariableState : public empty_state_t {
   explicit VariableState(
-      const Metadata &md, int sparse_id = InvalidSparseID,
+      const Metadata &md, int sparse_id = InvalidSparseID, int pmb_gid = -1,
       const std::array<int, MAX_VARIABLE_DIMENSION> &dims = [] {
         std::array<int, MAX_VARIABLE_DIMENSION> d;
         for (int i = 0; i < MAX_VARIABLE_DIMENSION; ++i)
@@ -39,26 +39,27 @@ struct VariableState : public empty_state_t {
 
   KOKKOS_INLINE_FUNCTION
   VariableState(Real alloc, Real dealloc, Real sparse_default_val = 0.0,
-                int sparse_id = InvalidSparseID)
+                int sparse_id = InvalidSparseID, int pmb_gid = -1)
       : allocation_threshold(alloc), deallocation_threshold(dealloc),
-        sparse_default_val(sparse_default_val), sparse_id(sparse_id) {}
+        sparse_default_val(sparse_default_val), sparse_id(sparse_id), pmb_gid(pmb_gid) {}
 
   KOKKOS_INLINE_FUNCTION
-  VariableState(Real alloc, Real dealloc, int sparse_id)
+  VariableState(Real alloc, Real dealloc, int sparse_id, int pmb_gid)
       : allocation_threshold(alloc), deallocation_threshold(dealloc),
-        sparse_default_val(0.0), sparse_id(sparse_id) {}
+        sparse_default_val(0.0), sparse_id(sparse_id), pmb_gid(pmb_gid) {}
 
   KOKKOS_DEFAULTED_FUNCTION
   VariableState() = default;
 
   KOKKOS_INLINE_FUNCTION
   explicit VariableState(const empty_state_t &)
-      : VariableState(0.0, 0.0, 0.0, InvalidSparseID) {}
+      : VariableState(0.0, 0.0, 0.0, InvalidSparseID, -1) {}
 
   Real allocation_threshold;
   Real deallocation_threshold;
   Real sparse_default_val;
   int sparse_id;
+  int pmb_gid;
   int vector_component = NODIR;
   bool initialized = true;
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In addition to `sparse_id`, it would be also nice to be able to access the current block `gid` in a `SparsePack` via

```c++
pack(b, var()).gid
```
This utility is added in this MR, by adding `gid` to `VariableState`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
