### PR TITLE
[TRIVIAL] unsuppress test output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [[PR978]](https://github.com/parthenon-hpc-lab/parthenon/pull/978) remove erroneous sparse check
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1017]](https://github.com/parthenon-hpc-lab/parthenon/pull/1017) Make regression tests more verbose on failure
 - [[PR 1007]](https://github.com/parthenon-hpc-lab/parthenon/pull/1007) Split template instantiations for HDF5 Read/Write attributes to speed up compile times
 - [[PR 990]](https://github.com/parthenon-hpc-lab/parthenon/pull/990) Partial refactor of HDF5 I/O code for readability/extendability
 - [[PR 982]](https://github.com/parthenon-hpc-lab/parthenon/pull/982) add some gut check testing for parthenon-VIBE

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -2,7 +2,7 @@
 # Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -242,7 +242,7 @@ class TestManager:
         print(" ".join(run_command))
         sys.stdout.flush()
         try:
-            proc = subprocess.run(run_command, check=True, stdout=PIPE, stderr=PIPE)
+            proc = subprocess.run(run_command, check=True)
             self.parameters.stdouts.append(proc.stdout)
         except subprocess.CalledProcessError as err:
             print("\n*****************************************************************")

--- a/tst/regression/utils/test_case.py
+++ b/tst/regression/utils/test_case.py
@@ -17,7 +17,7 @@
 import os
 from shutil import rmtree
 import subprocess
-from subprocess import PIPE
+from subprocess import PIPE, STDOUT
 import sys
 from shutil import which
 
@@ -242,7 +242,8 @@ class TestManager:
         print(" ".join(run_command))
         sys.stdout.flush()
         try:
-            proc = subprocess.run(run_command, check=True)
+            proc = subprocess.run(run_command, check=True, stdout=PIPE, stderr=STDOUT)
+            print(proc.stdout.decode())
             self.parameters.stdouts.append(proc.stdout)
         except subprocess.CalledProcessError as err:
             print("\n*****************************************************************")


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Regression test outputs suppress both stdout and stderr from the driver. When debugging this is annoying. Since things are integrated with `ctest` and `ctest`suppresses output for tests that pass (or fail) by default anyway, it's also redundant. This PR makes output (when you ask ctest to be verbose) significantly more verbose, by including driver stdout/stderr output. 

The main benefit of this is we now see, e.g., `PARTHENON_THROW`, `PARTHENON_FAIL`, `PARTHENON_REQUIRE` outputs and any print statements we add by hand when debugging tests. The main disadvantage is that output is way more verbose. It *may* also *slightly* change performance but not by much I think.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
