### PR TITLE
[trivial] make the 1 tasked thread persistent

### DIFF
--- a/src/tasks/tasks.hpp
+++ b/src/tasks/tasks.hpp
@@ -479,7 +479,7 @@ class TaskCollection {
     return regions.back();
   }
   TaskListStatus Execute() {
-    ThreadPool pool(1);
+    static ThreadPool pool(1);
     return Execute(pool);
   }
   TaskListStatus Execute(ThreadPool &pool) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When @jdolence added the tasking infrastructure, he made the thread pool create and destroy a thread every cycle. The cost for this performance-wise is minimal, but it apparently interferes with profiling tools such as caliper. In a later PR, @jdolence will lift the thread pool above the tasking making it truly persistent. Until then, I just make the thread pool static. Since there's only one thread, this is equivalent as far as correctness, but should be faster (slightly) and play nicer with profiling tools.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
