### PR TITLE
fix param bool bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### Changed (changing behavior/API/variables/...)
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR1023]](https://github.com/parthenon-hpc-lab/parthenon/pull/1023) Fix broken param of a scalar bool
 - [[PR1012]](https://github.com/parthenon-hpc-lab/parthenon/pull/1012) Remove accidentally duplicated code
 - [[PR992]](https://github.com/parthenon-hpc-lab/parthenon/pull/992) Allow custom PR ops with sparse pools
 - [[PR988]](https://github.com/parthenon-hpc-lab/parthenon/pull/988) Fix bug in neighbor finding routine for small, periodic, refined meshes

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -147,6 +147,9 @@ TEST_CASE("A set of params can be dumped to file", "[params][output]") {
     Real scalar = 3.0;
     params.Add("scalar", scalar, restart);
 
+    bool boolscalar = false;
+    params.Add("boolscalar", boolscalar, restart);
+
     std::vector<int> vector = {0, 1, 2};
     params.Add("vector", vector, only_mutable);
 
@@ -217,6 +220,9 @@ TEST_CASE("A set of params can be dumped to file", "[params][output]") {
         Real test_scalar = 0.0;
         rparams.Add("scalar", test_scalar, restart);
 
+        bool test_bool = true;
+        rparams.Add("boolscalar", test_bool, restart);
+
         std::vector<int> test_vector;
         rparams.Add("vector", test_vector, only_mutable);
 
@@ -234,6 +240,10 @@ TEST_CASE("A set of params can be dumped to file", "[params][output]") {
         AND_THEN("The values for the restartable params are updated to match the file") {
           auto test_scalar = rparams.Get<Real>("scalar");
           REQUIRE(std::abs(test_scalar - scalar) <= 1e-10);
+
+          auto test_bool = rparams.Get<bool>("boolscalar");
+          REQUIRE(test_bool == boolscalar);
+
           auto test_hostarr = params.Get<parthenon::HostArray2D<Real>>("hostarr2d");
           REQUIRE(test_hostarr.extent_int(0) == hostarr.extent_int(0));
           REQUIRE(test_hostarr.extent_int(1) == hostarr.extent_int(1));


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Issue #1021 , raised by by @BenWibking @pgrete  is that  `parthenon` will fail to read a single boolean from the params file upon restart. The issue, it turns out, was caused by me. To save code, scalar values of hdf5 params are read as vectors. For all types except booleans, this works very well. For booleans, unfortunately `std::vector<bool>` and `std::vector<string>` are special, and not implemented in the same way as `std::vector<T>`. 

I thought I could short-circuit this, and introduced this bug. I tried to use a `Kokkos::View` to read a `std::vector<bool>`. This works for true vectors of bools, but not for the scalar case. 

This PR removes the optimistic hack I had introduced and reads boolean params properly.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
