### PR TITLE
Bug fix in non-cell centered AMR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 
 ### Fixed (not changing behavior/API/variables/...)
-
+- [[PR 1031]](https://github.com/parthenon-hpc-lab/parthenon/pull/1031) Fix bug in non-cell centered AMR
 
 ### Infrastructure (changes irrelevant to downstream codes)
 

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -997,7 +997,6 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
     // Initialize the "base" MeshData object
     mesh_data.Get()->Set(block_list, this);
-
   } // AMR Recv and unpack data
 
   ResetLoadBalanceVariables();

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -936,6 +936,10 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       PARTHENON_MPI_CHECK(
           MPI_Waitall(send_reqs.size(), send_reqs.data(), MPI_STATUSES_IGNORE));
 #endif
+    
+    // init meshblock data
+    for (auto &pmb : block_list) 
+      pmb->InitMeshBlockUserData(pmb, pin);
 
     // Internal refinement relies on the fine shared values, which are only consistent
     // after being updated with any previously fine versions
@@ -998,6 +1002,10 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     PreCommFillDerived();
     CommunicateBoundaries();
     FillDerived();
+
+    // Initialize the "base" MeshData object
+    mesh_data.Get()->Set(block_list, this);
+  
   } // AMR Recv and unpack data
 
   ResetLoadBalanceVariables();

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -939,11 +939,11 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
     // Internal refinement relies on the fine shared values, which are only consistent
     // after being updated with any previously fine versions
-    Metadata::FlagCollection fc; 
-    fc.TakeUnion(Metadata::Face, Metadata::Edge, Metadata::Node); 
+    Metadata::FlagCollection fc;
+    fc.TakeUnion(Metadata::Face, Metadata::Edge, Metadata::Node);
     fc.TakeIntersection(Metadata::FillGhost);
     std::vector<std::string> noncc_names = GetVariableNames(fc);
-    
+
     if (noncc_names.size() > 0) {
       // A block newly refined and prolongated may have neighbors which were
       // already refined to the new level.
@@ -960,20 +960,20 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
       // Re-initialize the mesh with our temporary ownership/neighbor configurations.
       // No buffers are different when we switch to the final precedence order.
-      SetSameLevelNeighbors(block_list, leaf_grid_locs, this->GetRootGridInfo(), nbs, false,
-                            0, newly_refined);
+      SetSameLevelNeighbors(block_list, leaf_grid_locs, this->GetRootGridInfo(), nbs,
+                            false, 0, newly_refined);
       BuildCommunicationBuffers();
       std::string noncc = "mesh_internal_noncc";
       for (int i = 0; i < DefaultNumPartitions(); ++i) {
         auto &md = mesh_data.GetOrAdd("base", i);
-        auto &md_noncc = mesh_data.AddShallow(noncc, md, noncc_names); 
+        auto &md_noncc = mesh_data.AddShallow(noncc, md, noncc_names);
       }
 
-      CommunicateBoundaries(noncc); // Called to make sure shared values are correct, ghosts 
-                                    // of non-cell centered vars may get some junk
+      CommunicateBoundaries(noncc); // Called to make sure shared values are correct,
+                                    // ghosts of non-cell centered vars may get some junk
       refinement::ProlongateInternal(resolved_packages.get(), prolongation_cache,
-                                 block_list[0]->cellbounds,
-                                 block_list[0]->c_cellbounds);
+                                     block_list[0]->cellbounds,
+                                     block_list[0]->c_cellbounds);
     }
 
     // Rebuild just the ownership model, this time weighting the "new" fine blocks just
@@ -986,7 +986,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     BuildGMGHierarchy(nbs, pin, app_in);
     if (noncc_names.size() == 0) BuildCommunicationBuffers();
 
-    // Clear the boundary caches so they rebuild on next communication with the 
+    // Clear the boundary caches so they rebuild on next communication with the
     // correct ownership
     const int num_partitions = DefaultNumPartitions();
     for (int i = 0; i < num_partitions; i++) {
@@ -996,8 +996,8 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
     // Call to fill ghosts with real data and fill derived quantities
     PreCommFillDerived();
-    CommunicateBoundaries(); 
-    FillDerived(); 
+    CommunicateBoundaries();
+    FillDerived();
   } // AMR Recv and unpack data
 
   ResetLoadBalanceVariables();

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -941,7 +941,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     for (auto &pmb : block_list)
       pmb->InitMeshBlockUserData(pmb.get(), pin);
 
-    // Find the non-cell centered fields that are communicated  
+    // Find the non-cell centered fields that are communicated
     Metadata::FlagCollection fc;
     fc.TakeUnion(Metadata::Face, Metadata::Edge, Metadata::Node);
     fc.TakeIntersection(Metadata::FillGhost);

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -962,7 +962,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       }
       SetSameLevelNeighbors(block_list, leaf_grid_locs, this->GetRootGridInfo(), nbs,
                             false, 0, newly_refined);
-      BuildBoundaryBuffers();
+      BuildTagMapAndBoundaryBuffers();
       std::string noncc = "mesh_internal_noncc";
       for (int i = 0; i < DefaultNumPartitions(); ++i) {
         auto &md = mesh_data.GetOrAdd("base", i);
@@ -988,7 +988,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     BuildGMGHierarchy(nbs, pin, app_in);
     // Ownership does not impact anything about the buffers, so we don't need to
     // rebuild them if they were built above
-    if (noncc_names.size() == 0) BuildBoundaryBuffers();
+    if (noncc_names.size() == 0) BuildTagMapAndBoundaryBuffers();
 
     // Call to fill ghosts with real data and fill derived quantities
     PreCommFillDerived();

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -941,8 +941,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     for (auto &pmb : block_list)
       pmb->InitMeshBlockUserData(pmb.get(), pin);
 
-    // Internal refinement relies on the fine shared values, which are only consistent
-    // after being updated with any previously fine versions
+    // Find the non-cell centered fields that are communicated  
     Metadata::FlagCollection fc;
     fc.TakeUnion(Metadata::Face, Metadata::Edge, Metadata::Node);
     fc.TakeIntersection(Metadata::FillGhost);

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -962,7 +962,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       }
       SetSameLevelNeighbors(block_list, leaf_grid_locs, this->GetRootGridInfo(), nbs,
                             false, 0, newly_refined);
-      BuildCommunicationBuffers();
+      BuildBoundaryBuffers();
       std::string noncc = "mesh_internal_noncc";
       for (int i = 0; i < DefaultNumPartitions(); ++i) {
         auto &md = mesh_data.GetOrAdd("base", i);
@@ -988,7 +988,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     BuildGMGHierarchy(nbs, pin, app_in);
     // Ownership does not impact anything about the buffers, so we don't need to
     // rebuild them if they were built above
-    if (noncc_names.size() == 0) BuildCommunicationBuffers();
+    if (noncc_names.size() == 0) BuildBoundaryBuffers();
 
     // Call to fill ghosts with real data and fill derived quantities
     PreCommFillDerived();

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -936,9 +936,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       PARTHENON_MPI_CHECK(
           MPI_Waitall(send_reqs.size(), send_reqs.data(), MPI_STATUSES_IGNORE));
 #endif
-    
+
     // init meshblock data
-    for (auto &pmb : block_list) 
+    for (auto &pmb : block_list)
       pmb->InitMeshBlockUserData(pmb, pin);
 
     // Internal refinement relies on the fine shared values, which are only consistent
@@ -1005,7 +1005,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
     // Initialize the "base" MeshData object
     mesh_data.Get()->Set(block_list, this);
-  
+
   } // AMR Recv and unpack data
 
   ResetLoadBalanceVariables();

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -1,13 +1,13 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2020-2023 The Parthenon collaboration
+// Copyright(C) 2020-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
 // Athena++ astrophysical MHD code
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/mesh/amr_loadbalance.cpp
+++ b/src/mesh/amr_loadbalance.cpp
@@ -939,7 +939,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
 
     // init meshblock data
     for (auto &pmb : block_list)
-      pmb->InitMeshBlockUserData(pmb, pin);
+      pmb->InitMeshBlockUserData(pmb.get(), pin);
 
     // Internal refinement relies on the fine shared values, which are only consistent
     // after being updated with any previously fine versions
@@ -989,14 +989,6 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     }
     BuildGMGHierarchy(nbs, pin, app_in);
     if (noncc_names.size() == 0) BuildCommunicationBuffers();
-
-    // Clear the boundary caches so they rebuild on next communication with the
-    // correct ownership
-    const int num_partitions = DefaultNumPartitions();
-    for (int i = 0; i < num_partitions; i++) {
-      auto &md = mesh_data.GetOrAdd("base", i);
-      md->GetBvarsCache().clear();
-    }
 
     // Call to fill ghosts with real data and fill derived quantities
     PreCommFillDerived();

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -917,7 +917,7 @@ void Mesh::ApplyUserWorkBeforeOutput(Mesh *mesh, ParameterInput *pin,
   }
 }
 
-void Mesh::BuildCommunicationBuffers() {
+void Mesh::BuildBoundaryBuffers() {
   const int num_partitions = DefaultNumPartitions();
   const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
 
@@ -1138,7 +1138,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
     PreCommFillDerived();
 
-    BuildCommunicationBuffers();
+    BuildBoundaryBuffers();
 
     CommunicateBoundaries();
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -917,6 +917,161 @@ void Mesh::ApplyUserWorkBeforeOutput(Mesh *mesh, ParameterInput *pin,
   }
 }
 
+
+void Mesh::BuildCommunicationBuffers() {
+  const int num_partitions = DefaultNumPartitions();
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank); 
+
+  // Build densely populated communication tags
+  tag_map.clear();
+  for (int i = 0; i < num_partitions; i++) {
+    auto &md = mesh_data.GetOrAdd("base", i);
+    tag_map.AddMeshDataToMap<BoundaryType::any>(md);
+    for (int gmg_level = 0; gmg_level < gmg_mesh_data.size(); ++gmg_level) {
+      auto &mdg = gmg_mesh_data[gmg_level].GetOrAdd(gmg_level, "base", i);
+      // tag_map.AddMeshDataToMap<BoundaryType::any>(mdg);
+      tag_map.AddMeshDataToMap<BoundaryType::gmg_same>(mdg);
+      tag_map.AddMeshDataToMap<BoundaryType::gmg_prolongate_send>(mdg);
+      tag_map.AddMeshDataToMap<BoundaryType::gmg_restrict_send>(mdg);
+      tag_map.AddMeshDataToMap<BoundaryType::gmg_prolongate_recv>(mdg);
+      tag_map.AddMeshDataToMap<BoundaryType::gmg_restrict_recv>(mdg);
+    }
+  }
+  tag_map.ResolveMap();
+
+  // Create send/recv MPI_Requests for swarms 
+  for (int i = 0; i < nmb; ++i) {
+    auto &pmb = block_list[i];
+    pmb->swarm_data.Get()->SetupPersistentMPI();
+  }
+
+  // Wait for boundary buffers to be no longer in use 
+  bool can_delete;
+  std::int64_t test_iters = 0;
+  constexpr std::int64_t max_it = 1e10;
+  do {
+    can_delete = true;
+    for (auto &[k, comm] : boundary_comm_map) {
+      can_delete = comm.IsSafeToDelete() && can_delete;
+    }
+    test_iters++;
+  } while (!can_delete && test_iters < max_it);
+  PARTHENON_REQUIRE(
+      test_iters < max_it,
+      "Too many iterations waiting to delete boundary communication buffers.");
+  
+  // Clear boundary communication buffers
+  boundary_comm_map.clear();
+  boundary_comm_flxcor_map.clear();
+
+  // Build the boundary buffers for the current mesh
+  for (int i = 0; i < num_partitions; i++) {
+    auto &md = mesh_data.GetOrAdd("base", i);
+    BuildBoundaryBuffers(md);
+    for (int gmg_level = 0; gmg_level < gmg_mesh_data.size(); ++gmg_level) {
+      auto &mdg = gmg_mesh_data[gmg_level].GetOrAdd(gmg_level, "base", i);
+      BuildBoundaryBuffers(mdg);
+      BuildGMGBoundaryBuffers(mdg);
+    }
+  } 
+}
+
+void Mesh::CommunicateBoundaries() {
+  const int num_partitions = DefaultNumPartitions();
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);  
+  constexpr std::int64_t max_it = 1e10;
+  std::vector<bool> sent(num_partitions, false);
+  bool all_sent;
+  std::int64_t send_iters = 0;
+  do {
+    all_sent = true;
+    for (int i = 0; i < num_partitions; i++) {
+      auto &md = mesh_data.GetOrAdd("base", i);
+      if (!sent[i]) {
+        if (SendBoundaryBuffers(md) != TaskStatus::complete) {
+          all_sent = false;
+        } else {
+          sent[i] = true;
+        }
+      }
+    }
+    send_iters++;
+  } while (!all_sent && send_iters < max_it);
+  PARTHENON_REQUIRE(
+      send_iters < max_it,
+      "Too many iterations waiting to send boundary communication buffers.");
+
+  // wait to receive FillGhost variables
+  // TODO(someone) evaluate if ReceiveWithWait kind of logic is better, also related to
+  // https://github.com/lanl/parthenon/issues/418
+  std::vector<bool> received(num_partitions, false);
+  bool all_received;
+  std::int64_t receive_iters = 0;
+  do {
+    all_received = true;
+    for (int i = 0; i < num_partitions; i++) {
+      auto &md = mesh_data.GetOrAdd("base", i);
+      if (!received[i]) {
+        if (ReceiveBoundaryBuffers(md) != TaskStatus::complete) {
+          all_received = false;
+        } else {
+          received[i] = true;
+        }
+      }
+    }
+    receive_iters++;
+  } while (!all_received && receive_iters < max_it);
+  PARTHENON_REQUIRE(
+      receive_iters < max_it,
+      "Too many iterations waiting to receive boundary communication buffers.");
+
+  for (int i = 0; i < num_partitions; i++) {
+    auto &md = mesh_data.GetOrAdd("base", i);
+    // unpack FillGhost variables
+    SetBoundaries(md);
+  }
+
+  //  Now do prolongation, compute primitives, apply BCs
+  for (int i = 0; i < num_partitions; i++) {
+    auto &md = mesh_data.GetOrAdd("base", i);
+    if (multilevel) {
+      ApplyBoundaryConditionsOnCoarseOrFineMD(md, true);
+      ProlongateBoundaries(md);
+    }
+    ApplyBoundaryConditionsOnCoarseOrFineMD(md, false);
+  }
+}
+
+void Mesh::PreCommFillDerived() {
+  const int num_partitions = DefaultNumPartitions();
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank); 
+  // Pre comm fill derived
+  for (int i = 0; i < nmb; ++i) {
+    auto &mbd = block_list[i]->meshblock_data.Get();
+    Update::PreCommFillDerived(mbd.get());
+  }
+  for (int i = 0; i < num_partitions; ++i) {
+    auto &md = mesh_data.GetOrAdd("base", i);
+    Update::PreCommFillDerived(md.get());
+  }
+}
+
+void Mesh::FillDerived() {
+  const int num_partitions = DefaultNumPartitions();
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
+  for (int i = 0; i < num_partitions; i++) {
+    auto &md = mesh_data.GetOrAdd("base", i);
+    // Call MeshData based FillDerived functions
+    Update::FillDerived(md.get());
+  }
+
+  for (int i = 0; i < nmb; ++i) {
+    auto &mbd = block_list[i]->meshblock_data.Get();
+    // Call MeshBlockData based FillDerived functions
+    Update::FillDerived(mbd.get());
+  }
+}
+
 //----------------------------------------------------------------------------------------
 // \!fn void Mesh::Initialize(bool init_problem, ParameterInput *pin)
 // \brief  initialization before the main loop as well as during remeshing
@@ -982,143 +1137,18 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
                     [](auto &sp_block) { sp_block->SetAllVariablesToInitialized(); });
     }
 
-    // Pre comm fill derived
-    for (int i = 0; i < nmb; ++i) {
-      auto &mbd = block_list[i]->meshblock_data.Get();
-      Update::PreCommFillDerived(mbd.get());
-    }
-    for (int i = 0; i < num_partitions; ++i) {
-      auto &md = mesh_data.GetOrAdd("base", i);
-      Update::PreCommFillDerived(md.get());
-    }
+    PreCommFillDerived();    
 
-    // Build densely populated communication tags
-    tag_map.clear();
-    for (int i = 0; i < num_partitions; i++) {
-      auto &md = mesh_data.GetOrAdd("base", i);
-      tag_map.AddMeshDataToMap<BoundaryType::any>(md);
-      for (int gmg_level = 0; gmg_level < gmg_mesh_data.size(); ++gmg_level) {
-        auto &mdg = gmg_mesh_data[gmg_level].GetOrAdd(gmg_level, "base", i);
-        // tag_map.AddMeshDataToMap<BoundaryType::any>(mdg);
-        tag_map.AddMeshDataToMap<BoundaryType::gmg_same>(mdg);
-        tag_map.AddMeshDataToMap<BoundaryType::gmg_prolongate_send>(mdg);
-        tag_map.AddMeshDataToMap<BoundaryType::gmg_restrict_send>(mdg);
-        tag_map.AddMeshDataToMap<BoundaryType::gmg_prolongate_recv>(mdg);
-        tag_map.AddMeshDataToMap<BoundaryType::gmg_restrict_recv>(mdg);
-      }
-    }
-    tag_map.ResolveMap();
+    BuildCommunicationBuffers();
 
-    // Create send/recv MPI_Requests for all BoundaryData objects
-    for (int i = 0; i < nmb; ++i) {
-      auto &pmb = block_list[i];
-      pmb->swarm_data.Get()->SetupPersistentMPI();
-    }
-
-    // send FillGhost variables
-    bool can_delete;
-    std::int64_t test_iters = 0;
-    constexpr std::int64_t max_it = 1e10;
-    do {
-      can_delete = true;
-      for (auto &[k, comm] : boundary_comm_map) {
-        can_delete = comm.IsSafeToDelete() && can_delete;
-      }
-      test_iters++;
-    } while (!can_delete && test_iters < max_it);
-    PARTHENON_REQUIRE(
-        test_iters < max_it,
-        "Too many iterations waiting to delete boundary communication buffers.");
-
-    boundary_comm_map.clear();
-    boundary_comm_flxcor_map.clear();
-
-    for (int i = 0; i < num_partitions; i++) {
-      auto &md = mesh_data.GetOrAdd("base", i);
-      BuildBoundaryBuffers(md);
-      for (int gmg_level = 0; gmg_level < gmg_mesh_data.size(); ++gmg_level) {
-        auto &mdg = gmg_mesh_data[gmg_level].GetOrAdd(gmg_level, "base", i);
-        BuildBoundaryBuffers(mdg);
-        BuildGMGBoundaryBuffers(mdg);
-      }
-    }
-
-    std::vector<bool> sent(num_partitions, false);
-    bool all_sent;
-    std::int64_t send_iters = 0;
-    do {
-      all_sent = true;
-      for (int i = 0; i < num_partitions; i++) {
-        auto &md = mesh_data.GetOrAdd("base", i);
-        if (!sent[i]) {
-          if (SendBoundaryBuffers(md) != TaskStatus::complete) {
-            all_sent = false;
-          } else {
-            sent[i] = true;
-          }
-        }
-      }
-      send_iters++;
-    } while (!all_sent && send_iters < max_it);
-    PARTHENON_REQUIRE(
-        send_iters < max_it,
-        "Too many iterations waiting to send boundary communication buffers.");
-
-    // wait to receive FillGhost variables
-    // TODO(someone) evaluate if ReceiveWithWait kind of logic is better, also related to
-    // https://github.com/lanl/parthenon/issues/418
-    std::vector<bool> received(num_partitions, false);
-    bool all_received;
-    std::int64_t receive_iters = 0;
-    do {
-      all_received = true;
-      for (int i = 0; i < num_partitions; i++) {
-        auto &md = mesh_data.GetOrAdd("base", i);
-        if (!received[i]) {
-          if (ReceiveBoundaryBuffers(md) != TaskStatus::complete) {
-            all_received = false;
-          } else {
-            received[i] = true;
-          }
-        }
-      }
-      receive_iters++;
-    } while (!all_received && receive_iters < max_it);
-    PARTHENON_REQUIRE(
-        receive_iters < max_it,
-        "Too many iterations waiting to receive boundary communication buffers.");
-
-    for (int i = 0; i < num_partitions; i++) {
-      auto &md = mesh_data.GetOrAdd("base", i);
-      // unpack FillGhost variables
-      SetBoundaries(md);
-    }
-
-    //  Now do prolongation, compute primitives, apply BCs
-    for (int i = 0; i < num_partitions; i++) {
-      auto &md = mesh_data.GetOrAdd("base", i);
-      if (multilevel) {
-        ApplyBoundaryConditionsOnCoarseOrFineMD(md, true);
-        ProlongateBoundaries(md);
-      }
-      ApplyBoundaryConditionsOnCoarseOrFineMD(md, false);
-      // Call MeshData based FillDerived functions
-      Update::FillDerived(md.get());
-    }
-
-    for (int i = 0; i < nmb; ++i) {
-      auto &mbd = block_list[i]->meshblock_data.Get();
-      // Call MeshBlockData based FillDerived functions
-      Update::FillDerived(mbd.get());
-    }
+    CommunicateBoundaries();  
+    
+    FillDerived(); 
 
     if (init_problem && adaptive) {
       for (int i = 0; i < nmb; ++i) {
         block_list[i]->pmr->CheckRefinementCondition();
       }
-    }
-
-    if (init_problem && adaptive) {
       init_done = false;
       // caching nbtotal the private variable my be updated in the following function
       const int nb_before_loadbalance = nbtotal;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1138,7 +1138,7 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
     PreCommFillDerived();
 
-    BuildBoundaryBuffers();
+    BuildTagMapAndBoundaryBuffers();
 
     CommunicateBoundaries();
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -917,10 +917,9 @@ void Mesh::ApplyUserWorkBeforeOutput(Mesh *mesh, ParameterInput *pin,
   }
 }
 
-
 void Mesh::BuildCommunicationBuffers() {
   const int num_partitions = DefaultNumPartitions();
-  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank); 
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
 
   // Build densely populated communication tags
   tag_map.clear();
@@ -939,13 +938,13 @@ void Mesh::BuildCommunicationBuffers() {
   }
   tag_map.ResolveMap();
 
-  // Create send/recv MPI_Requests for swarms 
+  // Create send/recv MPI_Requests for swarms
   for (int i = 0; i < nmb; ++i) {
     auto &pmb = block_list[i];
     pmb->swarm_data.Get()->SetupPersistentMPI();
   }
 
-  // Wait for boundary buffers to be no longer in use 
+  // Wait for boundary buffers to be no longer in use
   bool can_delete;
   std::int64_t test_iters = 0;
   constexpr std::int64_t max_it = 1e10;
@@ -959,7 +958,7 @@ void Mesh::BuildCommunicationBuffers() {
   PARTHENON_REQUIRE(
       test_iters < max_it,
       "Too many iterations waiting to delete boundary communication buffers.");
-  
+
   // Clear boundary communication buffers
   boundary_comm_map.clear();
   boundary_comm_flxcor_map.clear();
@@ -973,12 +972,12 @@ void Mesh::BuildCommunicationBuffers() {
       BuildBoundaryBuffers(mdg);
       BuildGMGBoundaryBuffers(mdg);
     }
-  } 
+  }
 }
 
 void Mesh::CommunicateBoundaries(std::string md_name) {
   const int num_partitions = DefaultNumPartitions();
-  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);  
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
   constexpr std::int64_t max_it = 1e10;
   std::vector<bool> sent(num_partitions, false);
   bool all_sent;
@@ -1045,7 +1044,7 @@ void Mesh::CommunicateBoundaries(std::string md_name) {
 
 void Mesh::PreCommFillDerived() {
   const int num_partitions = DefaultNumPartitions();
-  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank); 
+  const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
   // Pre comm fill derived
   for (int i = 0; i < nmb; ++i) {
     auto &mbd = block_list[i]->meshblock_data.Get();
@@ -1138,13 +1137,13 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
                     [](auto &sp_block) { sp_block->SetAllVariablesToInitialized(); });
     }
 
-    PreCommFillDerived();    
+    PreCommFillDerived();
 
     BuildCommunicationBuffers();
 
-    CommunicateBoundaries();  
-    
-    FillDerived(); 
+    CommunicateBoundaries();
+
+    FillDerived();
 
     if (init_problem && adaptive) {
       for (int i = 0; i < nmb; ++i) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -917,7 +917,7 @@ void Mesh::ApplyUserWorkBeforeOutput(Mesh *mesh, ParameterInput *pin,
   }
 }
 
-void Mesh::BuildBoundaryBuffers() {
+void Mesh::BuildTagMapAndBoundaryBuffers() {
   const int num_partitions = DefaultNumPartitions();
   const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -928,7 +928,6 @@ void Mesh::BuildCommunicationBuffers() {
     tag_map.AddMeshDataToMap<BoundaryType::any>(md);
     for (int gmg_level = 0; gmg_level < gmg_mesh_data.size(); ++gmg_level) {
       auto &mdg = gmg_mesh_data[gmg_level].GetOrAdd(gmg_level, "base", i);
-      // tag_map.AddMeshDataToMap<BoundaryType::any>(mdg);
       tag_map.AddMeshDataToMap<BoundaryType::gmg_same>(mdg);
       tag_map.AddMeshDataToMap<BoundaryType::gmg_prolongate_send>(mdg);
       tag_map.AddMeshDataToMap<BoundaryType::gmg_restrict_send>(mdg);

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -332,7 +332,7 @@ class Mesh {
   void SetupMPIComms();
   void PopulateLeafLocationMap();
   void BuildCommunicationBuffers();
-  void CommunicateBoundaries();
+  void CommunicateBoundaries(std::string md_name = "base");
   void PreCommFillDerived();
   void FillDerived();
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -129,6 +129,7 @@ class Mesh {
 
   // functions
   void Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *app_in);
+
   bool SetBlockSizeAndBoundaries(LogicalLocation loc, RegionSize &block_size,
                                  BoundaryFlag *block_bcs);
   void OutputCycleDiagnostics();
@@ -330,6 +331,10 @@ class Mesh {
 
   void SetupMPIComms();
   void PopulateLeafLocationMap();
+  void BuildCommunicationBuffers();
+  void CommunicateBoundaries();
+  void PreCommFillDerived();
+  void FillDerived();
 
   // Transform from logical location coordinates to uniform mesh coordinates accounting
   // for root grid

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -331,7 +331,7 @@ class Mesh {
 
   void SetupMPIComms();
   void PopulateLeafLocationMap();
-  void BuildBoundaryBuffers();
+  void BuildTagMapAndBoundaryBuffers();
   void CommunicateBoundaries(std::string md_name = "base");
   void PreCommFillDerived();
   void FillDerived();

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -331,7 +331,7 @@ class Mesh {
 
   void SetupMPIComms();
   void PopulateLeafLocationMap();
-  void BuildCommunicationBuffers();
+  void BuildBoundaryBuffers();
   void CommunicateBoundaries(std::string md_name = "base");
   void PreCommFillDerived();
   void FillDerived();


### PR DESCRIPTION
## PR Summary
On develop, there is a bug that shows up when performing AMR on non-cell centered fields. Coming out of `RedistributeAndRefineMeshBlocks`, `FillDerived` may have been called using uninitialized non-cell centered data at certain locations on newly refined blocks. Additionally, the boundaries of those non-cell centered fields may have been filled with uninitialized neighbor data at certain locations. 

This PR fixes that by breaking out the different tasks in `Mesh::Initialize` and calling them in the correct order to ensure that non-cell centered fields are filled correctly in the interior before calling `FillDerived` (and `PreCommFillDerived`). Additionally, a second communication is added to make sure the ghost values are correctly filled. The extra communication uses mesh data that only contains the non-cell centered fields with FillGhost and does not occur if none of these fields exist. 

This bug strongly suggests that we need to add a regression test that stresses non-cell centered fields, but I think that will be a bit of work and too big for this PR. As @Yurlungur suggests in #1019, a transverse vector wave equation solver may be a good choice for this test. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] Adds a test for any bugs fixed.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
