### PR TITLE
Catch task failures from threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1049]](https://github.com/parthenon-hpc-lab/parthenon/pull/1049) Catch task failures from threads
 - [[PR 1024]](https://github.com/parthenon-hpc-lab/parthenon/pull/1024) Add features to history output
 - [[PR 1031]](https://github.com/parthenon-hpc-lab/parthenon/pull/1031) Fix bug in non-cell centered AMR
 

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -46,7 +46,7 @@ using Real = double;
 // X3DIR z, phi, etc...
 enum CoordinateDirection { NODIR = -1, X0DIR = 0, X1DIR = 1, X2DIR = 2, X3DIR = 3 };
 enum class BlockLocation { Left = 0, Center = 1, Right = 2 };
-enum class TaskStatus { complete, incomplete, iterate };
+enum class TaskStatus { complete, incomplete, iterate, fail };
 
 enum class AmrTag : int { derefine = -1, same = 0, refine = 1 };
 enum class RefinementOp_t { Prolongation, Restriction, None };

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -65,8 +65,8 @@ struct RegionSize {
   RegionSize() = default;
   RegionSize(std::array<Real, 3> xmin, std::array<Real, 3> xmax, std::array<Real, 3> xrat,
              std::array<int, 3> nx)
-      : xmin_(xmin), xmax_(xmax), xrat_(xrat),
-        nx_(nx), symmetry_{nx[0] == 1, nx[1] == 1, nx[2] == 1} {}
+      : xmin_(xmin), xmax_(xmax), xrat_(xrat), nx_(nx),
+        symmetry_{nx[0] == 1, nx[1] == 1, nx[2] == 1} {}
   RegionSize(std::array<Real, 3> xmin, std::array<Real, 3> xmax, std::array<Real, 3> xrat,
              std::array<int, 3> nx, std::array<bool, 3> symmetry)
       : xmin_(xmin), xmax_(xmax), xrat_(xrat), nx_(nx), symmetry_(symmetry) {}

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -65,8 +65,8 @@ struct RegionSize {
   RegionSize() = default;
   RegionSize(std::array<Real, 3> xmin, std::array<Real, 3> xmax, std::array<Real, 3> xrat,
              std::array<int, 3> nx)
-      : xmin_(xmin), xmax_(xmax), xrat_(xrat), nx_(nx),
-        symmetry_{nx[0] == 1, nx[1] == 1, nx[2] == 1} {}
+      : xmin_(xmin), xmax_(xmax), xrat_(xrat),
+        nx_(nx), symmetry_{nx[0] == 1, nx[1] == 1, nx[2] == 1} {}
   RegionSize(std::array<Real, 3> xmin, std::array<Real, 3> xmax, std::array<Real, 3> xrat,
              std::array<int, 3> nx, std::array<bool, 3> symmetry)
       : xmin_(xmin), xmax_(xmax), xrat_(xrat), nx_(nx), symmetry_(symmetry) {}

--- a/src/tasks/tasks.hpp
+++ b/src/tasks/tasks.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/tasks/tasks.hpp
+++ b/src/tasks/tasks.hpp
@@ -32,7 +32,7 @@
 
 namespace parthenon {
 
-enum class TaskListStatus { complete }; // doesn't feel like we need this...
+enum class TaskListStatus { complete, fail };
 enum class TaskType { normal, completion };
 
 class TaskQualifier {
@@ -423,7 +423,10 @@ class TaskRegion {
     // then wait until everything is done
     pool.wait();
 
-    return TaskListStatus::complete;
+    // Check the results, so as to fire any exceptions from threads
+    // Return failure if a task failed
+    return (pool.check_task_returns() == TaskStatus::complete) ?
+            TaskListStatus::complete : TaskListStatus::fail;
   }
 
   TaskList &operator[](const int i) { return task_lists[i]; }

--- a/src/tasks/tasks.hpp
+++ b/src/tasks/tasks.hpp
@@ -425,8 +425,8 @@ class TaskRegion {
 
     // Check the results, so as to fire any exceptions from threads
     // Return failure if a task failed
-    return (pool.check_task_returns() == TaskStatus::complete) ?
-            TaskListStatus::complete : TaskListStatus::fail;
+    return (pool.check_task_returns() == TaskStatus::complete) ? TaskListStatus::complete
+                                                               : TaskListStatus::fail;
   }
 
   TaskList &operator[](const int i) { return task_lists[i]; }

--- a/src/tasks/thread_pool.hpp
+++ b/src/tasks/thread_pool.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2023-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
Previously, due to using a worker thread, Parthenon would drop any exceptions from Tasks executed in a TaskList.  Exceptions would crash the thread, but execution would continue as if it had finished normally.

This PR checks the futures associated with each task, to make sure there are not exceptions.  As a bonus, we can add a potentially non-fatal failure return TaskStatus::fail, which will be propagated up to the Driver.

This has in the past failed the `sparse_advection` tests, but that may have been due to incidental changes over the course of debugging and testing.  It seems to pass all tests reliably now, 3-4 times in a row (except a couple of gmg tests which it also fails on my machine even with threading disabled).  Should there turn out to still be a rare race condition, I've extended `ThreadVector` such that vectors of `Task`s or `TaskList`s could be swapped over to be thread-safe transparently.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
