### PR TITLE
find_package(Threads) on install

### DIFF
--- a/cmake/parthenonConfig.cmake.in
+++ b/cmake/parthenonConfig.cmake.in
@@ -38,6 +38,8 @@ if(${Kokkos_BUILT_WITH_CUDA})
   endif()
 endif()
 
+find_package(Threads)
+
 if(@MPI_FOUND@)
   find_package(MPI REQUIRED COMPONENTS CXX)
 endif()


### PR DESCRIPTION
Runs `find_package(Threads)` when consuming installed cmake target.

Fixes issue with missing `Threads::Threads` target.

