### PR TITLE
Fix history output after restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1057]](https://github.com/parthenon-hpc-lab/parthenon/pull/1057) Fix history output after restarts
 - [[PR 1024]](https://github.com/parthenon-hpc-lab/parthenon/pull/1024) Add features to history output
 - [[PR 1031]](https://github.com/parthenon-hpc-lab/parthenon/pull/1031) Fix bug in non-cell centered AMR
 

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -62,7 +62,15 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
   // If "packages" not provided, output history for all packages
   auto &requested_packages = output_params.packages;
   Dictionary<std::shared_ptr<StateDescriptor>> packages;
+
+    printf("block: %s\n", output_params.block_name.c_str());
+    printf("All my packages???\n");
+    for (const auto &pkg_name : requested_packages) {
+      printf("  %s\n", pkg_name.c_str());
+    }
+
   if (requested_packages.empty()) {
+    printf("Here??\n");
     packages = pm->packages.AllPackages();
   } else {
     const auto &all_packages = pm->packages.AllPackages();

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -62,7 +62,6 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
   // If "packages" not provided, output history for all packages
   auto &requested_packages = output_params.packages;
   Dictionary<std::shared_ptr<StateDescriptor>> packages;
-
   if (requested_packages.empty()) {
     packages = pm->packages.AllPackages();
   } else {

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -63,14 +63,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
   auto &requested_packages = output_params.packages;
   Dictionary<std::shared_ptr<StateDescriptor>> packages;
 
-    printf("block: %s\n", output_params.block_name.c_str());
-    printf("All my packages???\n");
-    for (const auto &pkg_name : requested_packages) {
-      printf("  %s\n", pkg_name.c_str());
-    }
-
   if (requested_packages.empty()) {
-    printf("Here??\n");
     packages = pm->packages.AllPackages();
   } else {
     const auto &all_packages = pm->packages.AllPackages();

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -200,7 +200,8 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       }
 
       if (op.file_type == "hst") {
-        // Do not use GetOrAddVector because it will pollute the input parameters for restarts
+        // Do not use GetOrAddVector because it will pollute the input parameters for
+        // restarts
         if (pin->DoesParameterExist(pib->block_name, "packages")) {
           op.packages = pin->GetVector<std::string>(pib->block_name, "packages");
         } else {

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -200,28 +200,11 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       }
 
       if (op.file_type == "hst") {
-        printf("param exists? %i\n", static_cast<int>(pin->DoesParameterExist(pib->block_name, "packages")));
+        // Do not use GetOrAddVector because it will pollute the input parameters for restarts
         if (pin->DoesParameterExist(pib->block_name, "packages")) {
-        op.packages = pin->GetVector<std::string>(pib->block_name, "packages");
+          op.packages = pin->GetVector<std::string>(pib->block_name, "packages");
         } else {
           op.packages = std::vector<std::string>();
-        }
-        //op.packages = pin->GetOrAddVector<std::string>(pib->block_name, "packages",
-        //                                               std::vector<std::string>());
-        //if (op.packages.size() == 1) {
-        //  if (op.packages[0] == "") {
-        //    // Betrayed by GetOrAddVector
-        //    op.packages = std::vector<std::string>();
-        //  }
-        //}
-        // DEBUG
-        printf("hst\n");
-        printf("block: %s\n", op.block_name.c_str());
-        printf("npacks: %i\n", op.packages.size());
-        printf("packages:\n");
-        for (auto pkg : op.packages) {
-          printf("  %s\n", pkg.c_str());
-
         }
       }
 

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -200,8 +200,29 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       }
 
       if (op.file_type == "hst") {
-        op.packages = pin->GetOrAddVector<std::string>(pib->block_name, "packages",
-                                                       std::vector<std::string>());
+        printf("param exists? %i\n", static_cast<int>(pin->DoesParameterExist(pib->block_name, "packages")));
+        if (pin->DoesParameterExist(pib->block_name, "packages")) {
+        op.packages = pin->GetVector<std::string>(pib->block_name, "packages");
+        } else {
+          op.packages = std::vector<std::string>();
+        }
+        //op.packages = pin->GetOrAddVector<std::string>(pib->block_name, "packages",
+        //                                               std::vector<std::string>());
+        //if (op.packages.size() == 1) {
+        //  if (op.packages[0] == "") {
+        //    // Betrayed by GetOrAddVector
+        //    op.packages = std::vector<std::string>();
+        //  }
+        //}
+        // DEBUG
+        printf("hst\n");
+        printf("block: %s\n", op.block_name.c_str());
+        printf("npacks: %i\n", op.packages.size());
+        printf("packages:\n");
+        for (auto pkg : op.packages) {
+          printf("  %s\n", pkg.c_str());
+
+        }
       }
 
       // set output variable and optional data format string used in formatted writes


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@pgrete identified a bug in my recent history PR that caused history outputs, that use the default case of outputting all packages' histories, to fail after restarts. 

This was because I used `pkgs = pin->GetOrAddVector(block, packages, std::vector())` to get the names of packages, and I checked if `pkgs` was empty to determine whether to do the default case of outputting all packages. Well, if you do `GetOrAdd` like that, the parameters class will tell the restart file that you actually had an input file that looked like:
```
<parthenon/output3>
packages=
```
which, after restart, `GetOrAddVector` will interpret as a length-1 vector that contains `""`. 

I addressed this by first checking for the presence of `packages` in the output block, and only if it exists calling `GetVector`. My initial opinion is that this is *not* a problem with the `GetOrAddVector` implementation but I'm curious if others think we should modify that behavior. 

Fixes #1056 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
