### PR TITLE
Vector history not being output if no scalar history present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1058]](https://github.com/parthenon-hpc-lab/parthenon/pull/1058) Vector history not being output if no scalar history present
 - [[PR 1057]](https://github.com/parthenon-hpc-lab/parthenon/pull/1057) Fix history output after restarts
 - [[PR 1053]](https://github.com/parthenon-hpc-lab/parthenon/pull/1053) Set the correct root level on restart
 - [[PR 1024]](https://github.com/parthenon-hpc-lab/parthenon/pull/1024) Add features to history output

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -85,22 +85,21 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
 
     // Get "base" MeshData, which always exists but may not be populated yet
     auto &md_base = pm->mesh_data.Get();
+    // Populated with all blocks
+    if (md_base->NumBlocks() == 0) {
+      md_base->Set(pm->block_list, pm);
+    } else if (md_base->NumBlocks() != pm->block_list.size()) {
+      PARTHENON_WARN(
+          "Resetting \"base\" MeshData to contain all blocks. This indicates that "
+          "the \"base\" MeshData container has been modified elsewhere. Double check "
+          "that the modification was intentional and is compatible with this reset.")
+      md_base->Set(pm->block_list, pm);
+    }
 
     // Check if the package has enrolled scalar history functions which are stored in the
     // Params under the `hist_param_key` name.
     if (params.hasKey(hist_param_key)) {
       const auto &hist_vars = params.Get<HstVar_list>(hist_param_key);
-      // Populated with all blocks
-      if (md_base->NumBlocks() == 0) {
-        md_base->Set(pm->block_list, pm);
-      } else if (md_base->NumBlocks() != pm->block_list.size()) {
-        PARTHENON_WARN(
-            "Resetting \"base\" MeshData to contain all blocks. This indicates that "
-            "the \"base\" MeshData container has been modified elsewhere. Double check "
-            "that the modification was intentional and is compatible with this reset.")
-        md_base->Set(pm->block_list, pm);
-      }
-
       for (const auto &hist_var : hist_vars) {
         auto result = hist_var.hst_fun(md_base.get());
         results[hist_var.hst_op].push_back(result);

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -79,22 +79,22 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     }
   }
 
+  // Get "base" MeshData, which always exists but may not be populated yet
+  auto &md_base = pm->mesh_data.Get();
+  // Populated with all blocks
+  if (md_base->NumBlocks() == 0) {
+    md_base->Set(pm->block_list, pm);
+  } else if (md_base->NumBlocks() != pm->block_list.size()) {
+    PARTHENON_WARN(
+        "Resetting \"base\" MeshData to contain all blocks. This indicates that "
+        "the \"base\" MeshData container has been modified elsewhere. Double check "
+        "that the modification was intentional and is compatible with this reset.")
+    md_base->Set(pm->block_list, pm);
+  }
+
   // Loop over all packages of the application
   for (const auto &pkg : packages) {
     const auto &params = pkg.second->AllParams();
-
-    // Get "base" MeshData, which always exists but may not be populated yet
-    auto &md_base = pm->mesh_data.Get();
-    // Populated with all blocks
-    if (md_base->NumBlocks() == 0) {
-      md_base->Set(pm->block_list, pm);
-    } else if (md_base->NumBlocks() != pm->block_list.size()) {
-      PARTHENON_WARN(
-          "Resetting \"base\" MeshData to contain all blocks. This indicates that "
-          "the \"base\" MeshData container has been modified elsewhere. Double check "
-          "that the modification was intentional and is compatible with this reset.")
-      md_base->Set(pm->block_list, pm);
-    }
 
     // Check if the package has enrolled scalar history functions which are stored in the
     // Params under the `hist_param_key` name.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Running vector history downstream, I just ran into another bug: If a package *only* has vector history outputs enrolled, these will be ignored by an earlier `continue` statement in the loop over history variables triggered by a lack of scalar history outputs. 

Trivial fix, works downstream for me.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
