### PR TITLE
Thread UIDs through `data_collection`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1060]](https://github.com/parthenon-hpc-lab/parthenon/pull/1060) Add the ability to request new MeshData/MeshBlockData objects by selecting variables by UID.
 - [[PR1039]](https://github.com/parthenon-hpc-lab/parthenon/pull/1039) Add ability to output custom coordinate positions for Visit/Paraview
 - [[PR1019](https://github.com/parthenon-hpc-lab/parthenon/pull/1019) Enable output for non-cell-centered variables
 

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -22,36 +22,14 @@
 namespace parthenon {
 
 template <typename T>
-std::shared_ptr<T> &
-DataCollection<T>::Add(const std::string &name, const std::shared_ptr<T> &src,
-                       const std::vector<std::string> &field_names, const bool shallow) {
-  auto it = containers_.find(name);
+std::shared_ptr<T> &DataCollection<T>::Add(const std::string &label) {
+  // error check for duplicate names
+  auto it = containers_.find(label);
   if (it != containers_.end()) {
-    if (!(it->second)->Contains(field_names)) {
-      PARTHENON_THROW(name +
-                      "already exists in collection but does not contain field names");
-    }
     return it->second;
   }
-
-  auto c = std::make_shared<T>(name);
-  c->Initialize(src.get(), field_names, shallow);
-
-  Set(name, c);
-
-  return containers_[name];
-}
-template <typename T>
-std::shared_ptr<T> &DataCollection<T>::Add(const std::string &label,
-                                           const std::shared_ptr<T> &src,
-                                           const std::vector<std::string> &flags) {
-  return Add(label, src, flags, false);
-}
-template <typename T>
-std::shared_ptr<T> &DataCollection<T>::AddShallow(const std::string &label,
-                                                  const std::shared_ptr<T> &src,
-                                                  const std::vector<std::string> &flags) {
-  return Add(label, src, flags, true);
+  containers_[label] = std::make_shared<T>();
+  return containers_[label];
 }
 
 std::shared_ptr<MeshData<Real>> &

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -49,7 +49,7 @@ class DataCollection {
                           const std::vector<ID_t> &fields, const bool shallow) {
     auto it = containers_.find(name);
     if (it != containers_.end()) {
-      if ((fields.size() > 0) && !(it->second)->ContainsExactly(fields)) {
+      if (fields.size() && !(it->second)->ContainsExactly(fields)) {
         PARTHENON_THROW(name + " already exists in collection but fields do not match.");
       }
       return it->second;

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -49,7 +49,7 @@ class DataCollection {
                           const std::vector<ID_t> &fields, const bool shallow) {
     auto it = containers_.find(name);
     if (it != containers_.end()) {
-      if (!(it->second)->ContainsExactly(fields)) {
+      if ((fields.size() > 0) && !(it->second)->ContainsExactly(fields)) {
         PARTHENON_THROW(name + " already exists in collection but fields do not match.");
       }
       return it->second;

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -49,9 +49,8 @@ class DataCollection {
                           const std::vector<ID_t> &fields, const bool shallow) {
     auto it = containers_.find(name);
     if (it != containers_.end()) {
-      if (!(it->second)->Contains(fields)) {
-        PARTHENON_THROW(name +
-                        " already exists in collection but does not contain fields");
+      if (!(it->second)->ContainsExactly(fields)) {
+        PARTHENON_THROW(name + " already exists in collection but fields do not match.");
       }
       return it->second;
     }

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -17,31 +17,6 @@
 namespace parthenon {
 
 template <typename T>
-void MeshData<T>::Initialize(const MeshData<T> *src,
-                             const std::vector<std::string> &names, const bool shallow) {
-  if (src == nullptr) {
-    PARTHENON_THROW("src points at null");
-  }
-  pmy_mesh_ = src->GetParentPointer();
-  const int nblocks = src->NumBlocks();
-  block_data_.resize(nblocks);
-
-  grid = src->grid;
-  if (grid.type == GridType::two_level_composite) {
-    int gmg_level = src->grid.logical_level - pmy_mesh_->GetGMGMinLogicalLevel();
-    for (int i = 0; i < nblocks; i++) {
-      block_data_[i] = pmy_mesh_->gmg_block_lists[gmg_level][i]->meshblock_data.Add(
-          stage_name_, src->GetBlockData(i), names, shallow);
-    }
-  } else {
-    for (int i = 0; i < nblocks; i++) {
-      block_data_[i] = pmy_mesh_->block_list[i]->meshblock_data.Add(
-          stage_name_, src->GetBlockData(i), names, shallow);
-    }
-  }
-}
-
-template <typename T>
 void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh, int ndim) {
   const int nblocks = blocks.size();
   ndim_ = ndim;
@@ -59,6 +34,17 @@ void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh) {
     ndim = pmesh->ndim;
   }
   Set(blocks, pmesh, ndim);
+}
+
+template <typename T>
+std::shared_ptr<MeshBlock> MeshData<T>::GetBlock(const int i, const MeshData<T> *src,
+                                                 const Mesh *pmesh) const {
+  if (src->grid.type == GridType::two_level_composite) {
+    int gmg_level = src->grid.logical_level - pmesh->GetGMGMinLogicalLevel();
+    return pmesh->gmg_block_lists[gmg_level][i];
+  } else {
+    return pmesh->block_list[i];
+  }
 }
 
 template class MeshData<Real>;

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -40,8 +40,8 @@ template <typename T>
 std::shared_ptr<MeshBlock> MeshData<T>::GetBlock(const int i, const MeshData<T> *src,
                                                  const Mesh *pmesh) const {
   if (src->grid.type == GridType::two_level_composite) {
-    int gmg_level = src->grid.logical_level - pmesh->GetGMGMinLogicalLevel();
-    return pmesh->gmg_block_lists[gmg_level][i];
+    // JMM: need .at() here, not operator[] because of const correctness.
+    return pmesh->gmg_block_lists.at(src->grid.logical_level)[i];
   } else {
     return pmesh->block_list[i];
   }

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -37,8 +37,9 @@ void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh) {
 }
 
 template <typename T>
-std::shared_ptr<MeshBlock> MeshData<T>::GetBlock(const int i, const MeshData<T> *src,
-                                                 const Mesh *pmesh) const {
+std::shared_ptr<MeshBlock> MeshData<T>::GetSourceBlockPointer_(const int i,
+                                                               const MeshData<T> *src,
+                                                               const Mesh *pmesh) const {
   if (src->grid.type == GridType::two_level_composite) {
     // JMM: need .at() here, not operator[] because of const correctness.
     return pmesh->gmg_block_lists.at(src->grid.logical_level)[i];

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -36,18 +36,6 @@ void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh) {
   Set(blocks, pmesh, ndim);
 }
 
-template <typename T>
-std::shared_ptr<MeshBlock> MeshData<T>::GetSourceBlockPointer_(const int i,
-                                                               const MeshData<T> *src,
-                                                               const Mesh *pmesh) const {
-  if (src->grid.type == GridType::two_level_composite) {
-    // JMM: need .at() here, not operator[] because of const correctness.
-    return pmesh->gmg_block_lists.at(src->grid.logical_level)[i];
-  } else {
-    return pmesh->block_list[i];
-  }
-}
-
 template class MeshData<Real>;
 
 } // namespace parthenon

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -256,7 +256,7 @@ class MeshData {
     grid = src->grid;
     for (int i = 0; i < nblocks; ++i) {
       block_data_[i] =
-          GetBlock(i, src, pmy_mesh_)
+          GetSourceBlockPointer_(i, src, pmy_mesh_)
               ->meshblock_data.Add(stage_name_, src->GetBlockData(i), vars, shallow);
     }
   }
@@ -445,8 +445,8 @@ class MeshData {
   SparsePackCache &GetSparsePackCache() { return sparse_pack_cache_; }
 
  private:
-  std::shared_ptr<MeshBlock> GetBlock(const int i, const MeshData<T> *src,
-                                      const Mesh *pmesh) const;
+  std::shared_ptr<MeshBlock> GetSourceBlockPointer_(const int i, const MeshData<T> *src,
+                                                    const Mesh *pmesh) const;
 
   int ndim_;
   Mesh *pmy_mesh_;

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -248,8 +248,24 @@ class MeshData {
 
   void Set(BlockList_t blocks, Mesh *pmesh, int ndim);
   void Set(BlockList_t blocks, Mesh *pmesh);
-  void Initialize(const MeshData<T> *src, const std::vector<std::string> &names,
-                  const bool shallow);
+
+  template <typename ID_t>
+  void Initialize(const MeshData<T> *src, const std::vector<ID_t> &vars,
+                  const bool shallow) {
+    if (src == nullptr) {
+      PARTHENON_THROW("src points at null");
+    }
+    pmy_mesh_ = src->GetParentPointer();
+    const int nblocks = src->NumBlocks();
+    block_data_.resize(nblocks);
+
+    grid = src->grid;
+    for (int i = 0; i < nblocks; ++i) {
+      block_data_[i] =
+          GetBlock(i, src, pmy_mesh_)
+              ->meshblock_data.Add(stage_name_, src->GetBlockData(i), vars, shallow);
+    }
+  }
 
   const std::shared_ptr<MeshBlockData<T>> &GetBlockData(int n) const {
     assert(n >= 0 && n < block_data_.size());
@@ -426,16 +442,18 @@ class MeshData {
     return true;
   }
 
-  bool Contains(const std::vector<std::string> &names) const {
-    for (const auto &b : block_data_) {
-      if (!b->Contains(names)) return false;
-    }
-    return true;
+  template <typename Vars_t>
+  bool Contains(const Vars_t &vars) const noexcept {
+    return std::all_of(block_data_.begin(), block_data_.end(),
+                       [this, vars](const auto &b) { return b->Contains(vars); });
   }
 
   SparsePackCache &GetSparsePackCache() { return sparse_pack_cache_; }
 
  private:
+  std::shared_ptr<MeshBlock> GetBlock(const int i, const MeshData<T> *src,
+                                      const Mesh *pmesh) const;
+
   int ndim_;
   Mesh *pmy_mesh_;
   BlockDataList_t<T> block_data_;

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -79,45 +79,6 @@ void MeshBlockData<T>::AddField(const std::string &base_name, const Metadata &me
   }
 }
 
-// TODO(JMM): Move to unique IDs at some point
-template <typename T>
-void MeshBlockData<T>::Initialize(const MeshBlockData<T> *src,
-                                  const std::vector<std::string> &names,
-                                  const bool shallow_copy) {
-  assert(src != nullptr);
-  SetBlockPointer(src);
-  resolved_packages_ = src->resolved_packages_;
-  is_shallow_ = shallow_copy;
-
-  auto add_var = [=](auto var) {
-    if (shallow_copy || var->IsSet(Metadata::OneCopy)) {
-      Add(var);
-    } else {
-      Add(var->AllocateCopy(pmy_block));
-    }
-  };
-
-  // special case when the list of names is empty, copy everything
-  if (names.empty()) {
-    for (auto v : src->GetVariableVector()) {
-      add_var(v);
-    }
-  } else {
-    auto var_map = src->GetVariableMap();
-
-    for (const auto &name : names) {
-      bool found = false;
-      auto v = var_map.find(name);
-      if (v != var_map.end()) {
-        found = true;
-        add_var(v->second);
-      }
-      PARTHENON_REQUIRE_THROWS(found, "MeshBlockData::CopyFrom: Variable '" + name +
-                                          "' not found");
-    }
-  }
-}
-
 /// Queries related to variable packs
 /// This is a helper function that queries the cache for the given pack.
 /// The strings are the keys and the lists are the values.

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -113,7 +113,7 @@ class MeshBlockData {
   template <typename ID_t>
   void Initialize(const MeshBlockData<T> *src, const std::vector<ID_t> &vars,
                   const bool shallow_copy) {
-    assert(src != nullptr);
+    PARTHENON_DEBUG_REQUIRE(src != nullptr, "Source data must be non-null.");
     SetBlockPointer(src);
     resolved_packages_ = src->resolved_packages_;
     is_shallow_ = shallow_copy;
@@ -133,7 +133,7 @@ class MeshBlockData {
       }
     } else {
       for (const auto &v : vars) {
-        add_var(GetVarPtr(v));
+        add_var(src->GetVarPtr(v));
       }
     }
   }
@@ -150,14 +150,13 @@ class MeshBlockData {
   const MapToVars<T> &GetVariableMap() const noexcept { return varMap_; }
 
   std::shared_ptr<Variable<T>> GetVarPtr(const std::string &label) const {
-    auto it = varMap_.find(label);
-    PARTHENON_REQUIRE_THROWS(it != varMap_.end(),
+    PARTHENON_REQUIRE_THROWS(varMap_.count(label),
                              "Couldn't find variable '" + label + "'");
-    return it->second;
+    return varMap_.at(label);
   }
   std::shared_ptr<Variable<T>> GetVarPtr(const Uid_t &uid) const {
     PARTHENON_REQUIRE_THROWS(varUidMap_.count(uid),
-                             "Variable ID " + std::to_string(uid) + "not found!");
+                             "Variable ID " + std::to_string(uid) + " not found!");
     return varUidMap_.at(uid);
   }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -123,8 +123,8 @@ class Mesh {
   std::vector<LogicalLocMap_t> gmg_grid_locs;
   std::vector<BlockList_t> gmg_block_lists;
   std::vector<DataCollection<MeshData<Real>>> gmg_mesh_data;
-  int GetGMGMaxLevel() { return gmg_grid_locs.size() - 1; }
-  int GetGMGMinLogicalLevel() { return gmg_min_logical_level_; }
+  int GetGMGMaxLevel() const { return gmg_grid_locs.size() - 1; }
+  int GetGMGMinLogicalLevel() const { return gmg_min_logical_level_; }
 
   // functions
   void Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *app_in);

--- a/tst/unit/test_data_collection.cpp
+++ b/tst/unit/test_data_collection.cpp
@@ -116,5 +116,34 @@ TEST_CASE("Adding MeshBlockData objects to a DataCollection", "[DataCollection]"
         REQUIRE(hxv2(0) == hv2(0));
       }
     }
+    AND_WHEN("We want only a subset of variables in a new MeshBlockData by UID") {
+      // reset vars
+      par_for(
+          loop_pattern_flatrange_tag, "init vars", DevExecSpace(), 0, 0,
+          KOKKOS_LAMBDA(const int i) { v2(0) = 222; });
+      std::vector<parthenon::Uid_t> uids;
+      uids.push_back(mbd->UniqueID("var2"));
+      uids.push_back(mbd->UniqueID("var3"));
+      auto x = d.Add("part", mbd, uids);
+      THEN("Requesting the missing variables should throw") {
+        REQUIRE_THROWS(x->Get("var1"));
+      }
+      AND_THEN("Requesting the specified variables should work as expected") {
+        auto &xv2 = x->Get("var2").data;
+        auto &xv3 = x->Get("var3").data;
+        par_for(
+            loop_pattern_flatrange_tag, "init vars", DevExecSpace(), 0, 0,
+            KOKKOS_LAMBDA(const int i) {
+              xv2(0) = 22;
+              xv3(0) = 33;
+            });
+        auto hv2 = v2.GetHostMirrorAndCopy();
+        auto hv3 = v3.GetHostMirrorAndCopy();
+        auto hxv2 = xv2.GetHostMirrorAndCopy();
+        auto hxv3 = xv3.GetHostMirrorAndCopy();
+        REQUIRE(hxv3(0) != hv3(0));
+        REQUIRE(hxv2(0) == hv2(0));
+      }
+    }
   }
 }

--- a/tst/unit/test_data_collection.cpp
+++ b/tst/unit/test_data_collection.cpp
@@ -91,7 +91,8 @@ TEST_CASE("Adding MeshBlockData objects to a DataCollection", "[DataCollection]"
       }
     }
     AND_WHEN("We want only a subset of variables in a new MeshBlockData") {
-      // reset vars
+      // reset vars so that we can check this is overwritten/or is a
+      // new stage
       par_for(
           loop_pattern_flatrange_tag, "init vars", DevExecSpace(), 0, 0,
           KOKKOS_LAMBDA(const int i) { v2(0) = 222; });
@@ -117,7 +118,8 @@ TEST_CASE("Adding MeshBlockData objects to a DataCollection", "[DataCollection]"
       }
     }
     AND_WHEN("We want only a subset of variables in a new MeshBlockData by UID") {
-      // reset vars
+      // reset vars so that we can check this is overwritten/or is a
+      // new stage
       par_for(
           loop_pattern_flatrange_tag, "init vars", DevExecSpace(), 0, 0,
           KOKKOS_LAMBDA(const int i) { v2(0) = 222; });


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

This PR adds the ability to request a new `MeshData` or `MeshBlockData` object by requesting a subset of unique IDs of variables from the parent object, rather than by using only variable names. This should make UID-based operations more usable and thus unlock a bit of performance by minimizing string comparisons. Needed in riot and I suspect also KHARMA.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
