### PR TITLE
add fail on edge case in Mesh Data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [[PR 1031]](https://github.com/parthenon-hpc-lab/parthenon/pull/1031) Fix bug in non-cell centered AMR
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1064]](https://github.com/parthenon-hpc-lab/parthenon/pull/1064) Forbid erroneous edge case when adding MeshData on a partition
 - [[PR 1035]](https://github.com/parthenon-hpc-lab/parthenon/pull/1035) Fix multigrid infrastructure to work with forest
 - [[PR 1048]](https://github.com/parthenon-hpc-lab/parthenon/pull/1048) Tiny fixes to custom coords logic
 - [[PR 1028]](https://github.com/parthenon-hpc-lab/parthenon/pull/1028) Internal reorganization of LogicalLocation files

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -36,7 +36,7 @@ void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh) {
   Set(blocks, pmesh, ndim);
 }
 
-template< typename T>
+template <typename T>
 bool MeshData<T>::BlockDataIsWholeRank_() const {
   return block_data_.size() == (pmy_mesh_->block_list).size();
 }

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -36,6 +36,11 @@ void MeshData<T>::Set(BlockList_t blocks, Mesh *pmesh) {
   Set(blocks, pmesh, ndim);
 }
 
+template< typename T>
+bool MeshData<T>::BlockDataIsWholeRank_() const {
+  return block_data_.size() == (pmy_mesh_->block_list).size();
+}
+
 template class MeshData<Real>;
 
 } // namespace parthenon

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -262,6 +262,9 @@ class MeshData {
     // modifying DataCollection::GetOrAdd. In the future we should
     // make that "just work (tm)."
     grid = src->grid;
+    PARTHENON_REQUIRE((grid.type == GridType::two_level_composite) ||
+                          src->BlockDataIsWholeRank_(),
+                      "Add may only be called on all blocks on a rank");
     for (int i = 0; i < nblocks; ++i) {
       auto pmbd = src->GetBlockData(i);
       block_data_[i] = pmbd->GetBlockSharedPointer()->meshblock_data.Add(
@@ -460,6 +463,8 @@ class MeshData {
   SparsePackCache &GetSparsePackCache() { return sparse_pack_cache_; }
 
  private:
+  bool BlockDataIsWholeRank_() const;
+
   int ndim_;
   Mesh *pmy_mesh_;
   BlockDataList_t<T> block_data_;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

As discussed in MR #1060 and in the parthenon call, there are edge cases when you add mesh data on a partition. This just prevents you from doing that.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
