### PR TITLE
Enables compilation with nvhpc-sdk.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -308,7 +308,8 @@ endif()
 # Therefore, we don't use the Kokkos_ENABLE_CUDA_CONSTEXPR option add the flag manually.
 # Also, not checking for NVIDIA as nvcc_wrapper is identified as GNU so we just make sure
 # the flag is not added when compiling with Clang for Cuda.
-if (Kokkos_ENABLE_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+if (Kokkos_ENABLE_CUDA AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
+   AND NOT CMAKE_CXX_COMPILER_ID STREQUAL "NVHPC" )
    target_compile_options(parthenon PUBLIC --expt-relaxed-constexpr)
 endif()
 


### PR DESCRIPTION
Very minor change to avoid unrecognized flag when building with nvidia-hpc-sdk. This facilitates Venado Acceptance testing, but also should help vendors build parthenon for ats5 benchmarking.
