### PR TITLE
Add host labels and an overload for operator<< in sparsepack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1068]](https://github.com/parthenon-hpc-lab/parthenon/pull/1068) Add ability to dump sparse pack contents as a string
 - [[PR 1043]](https://github.com/parthenon-hpc-lab/parthenon/pull/1043) Unify flux correction with boundary communication, make fluxes variables, allow fluxes for non-cell fields
 - [[PR 1060]](https://github.com/parthenon-hpc-lab/parthenon/pull/1060) Add the ability to request new MeshData/MeshBlockData objects by selecting variables by UID.
 - [[PR1039]](https://github.com/parthenon-hpc-lab/parthenon/pull/1039) Add ability to output custom coordinate positions for Visit/Paraview

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <functional>
+#include <iostream>
 #include <limits>
 #include <map>
 #include <memory>
@@ -356,6 +357,11 @@ class SparsePack : public SparsePackBase {
     return (... && ContainsHost(b, Args()));
   }
 
+  // Informational
+  auto LabelHost(int b, int idx) const { return pack_h_(0, b, idx).label(); }
+  template <typename... Vars>
+  friend std::ostream &operator<<(std::ostream &os, const SparsePack<Vars...> &sp);
+
   // operator() overloads
   using TE = TopologicalElement;
   KOKKOS_INLINE_FUNCTION auto &operator()(const int b, const TE el, const int idx) const {
@@ -486,6 +492,19 @@ class SparsePack : public SparsePackBase {
     return std::make_tuple(&(*this)(b, el, vts, k, j, i)...);
   }
 };
+
+template <typename... Vars>
+inline std::ostream &operator<<(std::ostream &os, const SparsePack<Vars...> &sp) {
+  os << "Sparse pack contains on each block:\n";
+  for (int b = 0; b < sp.GetNBlocks(); b++) {
+    os << "\tb = " << b << "\n";
+    for (int n = sp.GetLowerBoundHost(b); n <= sp.GetUpperBoundHost(b); n++) {
+      os << "\t\t" << sp.LabelHost(b, n) << "\n";
+    }
+  }
+  os << "\n";
+  return os;
+}
 
 } // namespace parthenon
 

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -56,8 +56,9 @@ class SparsePackBase {
   using alloc_t = std::vector<int>;
   using include_t = std::vector<bool>;
   using pack_t = ParArray3D<ParArray3D<Real, VariableState>>;
+  using pack_h_t = typename pack_t::HostMirror;
   using bounds_t = ParArray3D<int>;
-  using bounds_h_t = typename ParArray3D<int>::HostMirror;
+  using bounds_h_t = typename bounds_t::HostMirror;
   using coords_t = ParArray1D<ParArray0D<Coordinates_t>>;
 
   // Returns a SparsePackBase object that is either newly created or taken
@@ -86,6 +87,7 @@ class SparsePackBase {
                               const std::vector<bool> &include_block);
 
   pack_t pack_;
+  pack_h_t pack_h_;
   bounds_t bounds_;
   bounds_h_t bounds_h_;
   coords_t coords_;

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -146,6 +146,10 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
             },
             nwrong);
         REQUIRE(nwrong == 0);
+
+        AND_THEN("A sparse pack can correctly output variable names") {
+          REQUIRE(sparse_pack.LabelHost(0, 0) == "v7");
+        }
       }
     }
   }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I'm chasing down a bug in riot right now and it's been useful to be able to print the contents of a `SparsePack` object. This adds the capability to do so with a `LabelHost` function that can be called on host and a stream operator overload if you just want to dump the whole pack.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
