### PR TITLE
correctly exclude flux vars from searches by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1070]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Correctly exclude flux vars from searches by default
 - [[PR 1049]](https://github.com/parthenon-hpc-lab/parthenon/pull/1049) Catch task failures from threads
 - [[PR 1058]](https://github.com/parthenon-hpc-lab/parthenon/pull/1058) Vector history not being output if no scalar history present
 - [[PR 1057]](https://github.com/parthenon-hpc-lab/parthenon/pull/1057) Fix history output after restarts

--- a/doc/sphinx/src/interface/metadata.rst
+++ b/doc/sphinx/src/interface/metadata.rst
@@ -180,6 +180,24 @@ classes may be allocated. The behaviours are the following:
    mask errors in the ``FillDerived`` implementation in downstream
    codes.*
 
+Requesting or excluding flux variables from searches
+-----------------------------------------------------
+
+As discussed above, fluxes are themselves ``Metadata::OneCopy``
+variables. A flux variable will have ``Metadata::Flux`` flag
+set. Several functions allow one to request variables by various
+properties such as name, unique ID, or metadata flag. These functions
+often take an optional enum argument ``FluxRequest``. This variable
+can take on the values ``FluxRequest::Any``, ``FluxRequest::NoFlux``,
+and ``FluxRequest::OnlyFlux``. The default is
+``FluxRequest::NoFlux``. Specifying ``FluxRequest::NoFlux`` enforces
+that no variables returned by the search will be flux
+variables. Specifying ``FluxRequest::OnlyFlux`` specifically pulls out
+the flux variable **associated** with the variable
+requested. ``FluxRequest::Any`` does not modify search parameters. You
+will get flux or non-flux variables, and variable associations will be
+ignored.
+
 Application Metadata Flags
 ---------------------------
 

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -38,6 +38,11 @@ using Real = double;
 #endif
 #endif
 
+// Enum speficying whether or not you requested a flux variable in
+// GetVariablesByFlag type methods
+// TODO(JMM): Is this the right place for this?
+enum class FluxRequest { NoFlux, OnlyFlux, Any };
+
 // needed for arrays dimensioned over grid directions
 // enumerator type only used in Mesh::EnrollUserMeshGenerator()
 // X0DIR time-like direction

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -193,7 +193,7 @@ const VariableFluxPack<T> &MeshBlockData<T>::PackVariablesAndFluxesImpl(
     const std::vector<std::string> &var_names, const std::vector<std::string> &flx_names,
     const std::vector<int> &sparse_ids, PackIndexMap *map, vpack_types::UidVecPair *key) {
   return PackListedVariablesAndFluxes(
-      GetVariablesByName(var_names, sparse_ids),
+      GetVariablesByName(var_names, sparse_ids, FluxRequest::NoFlux),
       GetVariablesByName(flx_names, sparse_ids, FluxRequest::OnlyFlux), map, key);
 }
 
@@ -203,7 +203,7 @@ const VariableFluxPack<T> &MeshBlockData<T>::PackVariablesAndFluxesImpl(
     const Metadata::FlagCollection &flags, const std::vector<int> &sparse_ids,
     PackIndexMap *map, vpack_types::UidVecPair *key) {
   return PackListedVariablesAndFluxes(
-      GetVariablesByFlag(flags, sparse_ids),
+      GetVariablesByFlag(flags, sparse_ids, FluxRequest::NoFlux),
       GetVariablesByFlag(flags, sparse_ids, FluxRequest::OnlyFlux), map, key);
 }
 
@@ -211,7 +211,7 @@ const VariableFluxPack<T> &MeshBlockData<T>::PackVariablesAndFluxesImpl(
 template <typename T>
 const VariableFluxPack<T> &MeshBlockData<T>::PackVariablesAndFluxesImpl(
     const std::vector<int> &sparse_ids, PackIndexMap *map, vpack_types::UidVecPair *key) {
-  return PackListedVariablesAndFluxes(GetAllVariables(sparse_ids),
+  return PackListedVariablesAndFluxes(GetAllVariables(sparse_ids, FluxRequest::NoFlux),
                                       GetAllVariables(sparse_ids, FluxRequest::OnlyFlux),
                                       map, key);
 }

--- a/src/interface/meshblock_data.cpp
+++ b/src/interface/meshblock_data.cpp
@@ -259,8 +259,10 @@ MeshBlockData<T>::GetVariablesByName(const std::vector<std::string> &names,
     if (itr != varMap_.end()) {
       const auto &v = itr->second;
       // this name exists, add it
+      const auto &m = v->metadata();
+      if ((flux != FluxRequest::Any) && m.IsSet(Metadata::Flux)) continue;
       if (flux == FluxRequest::OnlyFlux) {
-        const auto &vf = varMap_.at(v->metadata().GetFluxName());
+        const auto &vf = varMap_.at(m.GetFluxName());
         var_list.Add(vf, sparse_ids_set);
       } else {
         var_list.Add(v, sparse_ids_set);
@@ -273,8 +275,10 @@ MeshBlockData<T>::GetVariablesByName(const std::vector<std::string> &names,
       for (const auto iter : sparse_pool.pool()) {
         // this variable must exist, if it doesn't something is very wrong
         const auto &v = varMap_.at(MakeVarLabel(name, iter.first));
+        const auto &m = v->metadata();
+        if ((flux != FluxRequest::Any) && m.IsSet(Metadata::Flux)) continue;
         if (flux == FluxRequest::OnlyFlux) {
-          const auto &vf = varMap_.at(v->metadata().GetFluxName());
+          const auto &vf = varMap_.at(m.GetFluxName());
           var_list.Add(vf, sparse_ids_set);
         } else {
           var_list.Add(v, sparse_ids_set);
@@ -336,8 +340,9 @@ MeshBlockData<T>::GetVariablesByUid(const std::vector<Uid_t> &uids,
   typename MeshBlockData<T>::VarList var_list;
   for (auto i : uids) {
     auto v = GetVarPtr(i);
+    const auto &m = v->metadata();
+    if ((flux != FluxRequest::Any) && m.IsSet(Metadata::Flux)) continue;
     if (flux == FluxRequest::OnlyFlux) {
-      const auto &m = v->metadata();
       if (!m.IsSet(Metadata::WithFluxes)) {
         PARTHENON_FAIL("Flux of var " + v->label() +
                        " requested, but var does not have fluxes.");

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -22,6 +22,7 @@
 #include <utility>
 #include <vector>
 
+#include "basic_types.hpp"
 #include "interface/data_collection.hpp"
 #include "interface/sparse_pack_base.hpp"
 #include "interface/variable.hpp"
@@ -227,34 +228,38 @@ class MeshBlockData {
   /// Get list of variables and labels by names (either a full variable name or sparse
   /// base name), optionally selecting only given sparse ids
   VarList GetVariablesByName(const std::vector<std::string> &names,
-                             const std::vector<int> &sparse_ids = {}, bool flux = false);
+                             const std::vector<int> &sparse_ids = {},
+                             const FluxRequest flux = FluxRequest::NoFlux);
 
   /// Get list of variables and UIDs by metadata flags (must match all flags if
   /// match_all is true, otherwise must only match at least one), optionally selecting
   /// only given sparse ids
   VarList GetVariablesByFlag(const Metadata::FlagCollection &flags,
-                             const std::vector<int> &sparse_ids = {}, bool flux = false);
+                             const std::vector<int> &sparse_ids = {},
+                             const FluxRequest flux = FluxRequest::NoFlux);
 
   // Get list of variables specified by unique identifiers
-  VarList GetVariablesByUid(const std::vector<Uid_t> &uids, bool flux = false);
+  VarList GetVariablesByUid(const std::vector<Uid_t> &uids,
+                            const FluxRequest flux = FluxRequest::NoFlux);
 
   /// Get list of all variables and labels, optionally selecting only given sparse ids
-  VarList GetAllVariables(const std::vector<int> &sparse_ids = {}, bool flux = false) {
+  VarList GetAllVariables(const std::vector<int> &sparse_ids = {},
+                          const FluxRequest flux = FluxRequest::NoFlux) {
     return GetVariablesByFlag(Metadata::FlagCollection(), sparse_ids, flux);
   }
 
   std::vector<Uid_t> GetVariableUIDs(const std::vector<std::string> &names,
                                      const std::vector<int> &sparse_ids = {},
-                                     bool flux = false) {
+                                     const FluxRequest flux = FluxRequest::NoFlux) {
     return GetVariablesByName(names, sparse_ids, flux).unique_ids();
   }
   std::vector<Uid_t> GetVariableUIDs(const Metadata::FlagCollection &flags,
                                      const std::vector<int> &sparse_ids = {},
-                                     bool flux = false) {
+                                     const FluxRequest flux = FluxRequest::NoFlux) {
     return GetVariablesByFlag(flags, sparse_ids, flux).unique_ids();
   }
   std::vector<Uid_t> GetVariableUIDs(const std::vector<int> &sparse_ids = {},
-                                     bool flux = false) {
+                                     const FluxRequest flux = FluxRequest::NoFlux) {
     return GetAllVariables(sparse_ids, flux).unique_ids();
   }
 

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -573,7 +573,10 @@ class Metadata {
   const std::string &getAssociated() const { return associated_; }
 
   void SetFluxName(const std::string &name) { flux_var_ = name; }
-  const std::string &GetFluxName() const { return flux_var_; }
+  const std::string &GetFluxName() const {
+    PARTHENON_DEBUG_REQUIRE(IsSet(WithFluxes), "Variable has a flux.");
+    return flux_var_;
+  }
 
   const std::vector<std::string> getComponentLabels() const noexcept {
     return component_labels_;

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -159,6 +159,11 @@ fail(const char *const message, const char *const filename, int const linenumber
   }
 }
 
+[[noreturn]] inline void fail(std::string const &message, const char *const filename,
+                              int const linenumber) {
+  fail(message.c_str(), filename, linenumber);
+}
+
 [[noreturn]] inline void fail(std::stringstream const &message,
                               const char *const filename, int const linenumber) {
   fail(message.str().c_str(), filename, linenumber);

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2021-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/unit/test_meshblock_data_iterator.cpp
+++ b/tst/unit/test_meshblock_data_iterator.cpp
@@ -38,6 +38,7 @@
 #include "parthenon_arrays.hpp"
 
 using parthenon::DevExecSpace;
+using parthenon::FluxRequest;
 using parthenon::loop_pattern_mdrange_tag;
 using parthenon::MeshBlock;
 using parthenon::MeshBlockData;
@@ -115,6 +116,17 @@ TEST_CASE("Can pull variables from containers based on Metadata",
           REQUIRE(m.AnyFlagsSet(Metadata::Independent, Metadata::Derived));
           REQUIRE(m.IsSet(Metadata::WithFluxes));
           REQUIRE(!(m.IsSet(Metadata::ForceRemeshComm)));
+          REQUIRE(!(m.IsSet(Metadata::Flux)));
+        }
+      }
+      WHEN("We construct a list of only fluxes") {
+        auto varlist = mbd.GetVariablesByFlag(flags, {}, FluxRequest::OnlyFlux).vars();
+        THEN("The list contains the desired variables") {
+          REQUIRE(varlist.size() > 0);
+          for (const auto &v : varlist) {
+            const auto &m = v->metadata();
+            REQUIRE(m.IsSet(Metadata::Flux));
+          }
         }
       }
       WHEN("We construct a metadata flag collection with only unions") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

PR #1043 introduced an unexpected bug/interaction. When searching for vars by flag or by unique ID, it's possible to accidentally include fluxes, since they are now variables. To retain previous behavior, I introduce an enum `FluxRequest`, which can take on the values `Any`, `NoFlux`, or `OnlyFlux`. If `Any` is specified, the search does nothing special for fluxes. If `NoFlux` is specified, flux vars are explicitly excluded. If `OnlyFlux` is specified, behavior is a little special. Vars that *have* fluxes are searched for, and then the fluxes *of* those variables are returned.

I add a test to ensure the unexpected behavior is no longer present and confirmed in riot that the bug is now resolved.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
