### PR TITLE
A few Kokkos quality of life improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [[PR 1019]](https://github.com/parthenon-hpc-lab/parthenon/pull/1019) Enable output for non-cell-centered variables
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 1078]](https://github.com/parthenon-hpc-lab/parthenon/pull/1078) Add reduction fallback in 1D. Add IndexRange overload for 1D par loops
 - [[PR 1024]](https://github.com/parthenon-hpc-lab/parthenon/pull/1024) Add .outN. to history output filenames
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -38,6 +38,11 @@ using Real = double;
 #endif
 #endif
 
+struct IndexRange {
+  int s = 0; /// Starting Index (inclusive)
+  int e = 0; /// Ending Index (inclusive)
+};
+
 // Enum speficying whether or not you requested a flux variable in
 // GetVariablesByFlag type methods
 // TODO(JMM): Is this the right place for this?

--- a/src/mesh/domain.hpp
+++ b/src/mesh/domain.hpp
@@ -23,15 +23,12 @@
 #include <type_traits>
 #include <vector>
 
+#include <Kokkos_Core.hpp>
+
 #include "basic_types.hpp"
 #include "defs.hpp"
 
 namespace parthenon {
-
-struct IndexRange {
-  int s = 0; /// Starting Index (inclusive)
-  int e = 0; /// Ending Index (inclusive)
-};
 
 // Assuming we have a block
 //

--- a/src/prolong_restrict/pr_loops.hpp
+++ b/src/prolong_restrict/pr_loops.hpp
@@ -171,8 +171,7 @@ InnerHostProlongationRestrictionLoop(std::size_t buf, const ProResInfoArrHost_t 
   auto coarse = info(buf).coarse;
   auto fine = info(buf).fine;
   par_for(
-      PARTHENON_AUTO_LABEL, 0, 0, 0, 0, 0, idxer.size() - 1,
-      KOKKOS_LAMBDA(const int, const int, const int ii) {
+      PARTHENON_AUTO_LABEL, 0, idxer.size() - 1, KOKKOS_LAMBDA(const int ii) {
         const auto [t, u, v, k, j, i] = idxer(ii);
         if (idxer.IsActive(k, j, i)) {
           Stencil::template Do<DIM, FEL, CEL>(t, u, v, k, j, i, ckb, cjb, cib, kb, jb, ib,


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In #1075  @brryan recently reported that 1D `par_reduce` doesn't seem to work. I think this is because it's not supported for the all loop patterns, including simd for loops, which are default on CPU builds. I resolve this by just falling back to Kokkos for all loop patterns in 1D.  

I also add overloads in 1D for `IndexRange` instead of a start and end pair of indices. If this is desirable I can add overloads and fallbacks for other patterns and dimensions in a later pull request.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
