### PR TITLE
Address XDMF/Visit Issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1079]](https://github.com/parthenon-hpc-lab/parthenon/pull/1079) Address XDMF/Visit Issues
 - [[PR 1026]](https://github.com/parthenon-hpc-lab/parthenon/pull/1026) Particle BCs without relocatable device code
 - [[PR 1037]](https://github.com/parthenon-hpc-lab/parthenon/pull/1037) Add SwarmPacks
 - [[PR 1068]](https://github.com/parthenon-hpc-lab/parthenon/pull/1068) Add ability to dump sparse pack contents as a string
@@ -18,6 +19,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1079]](https://github.com/parthenon-hpc-lab/parthenon/pull/1079) Address XDMF/Visit Issues
 - [[PR 1071]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Fix bug in static mesh refinement related to redefinition of Mesh::root_level
 - [[PR 1073]](https://github.com/parthenon-hpc-lab/parthenon/pull/1073) Fix bug in AMR and sparse restarts
 - [[PR 1070]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Correctly exclude flux vars from searches by default

--- a/src/outputs/output_parameters.hpp
+++ b/src/outputs/output_parameters.hpp
@@ -50,12 +50,13 @@ struct OutputParameters {
   bool sparse_seed_nans;
   int hdf5_compression_level;
   bool write_xdmf;
+  bool write_swarm_xdmf;
   // TODO(felker): some of the parameters in this class are not initialized in constructor
   OutputParameters()
       : block_number(0), next_time(0.0), dt(-1.0), file_number(0),
         include_ghost_zones(false), cartesian_vector(false),
         single_precision_output(false), sparse_seed_nans(false),
-        hdf5_compression_level(5), write_xdmf(false) {}
+        hdf5_compression_level(5), write_xdmf(false), write_swarm_xdmf(false) {}
 };
 
 } // namespace parthenon

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -280,6 +280,9 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
         }
 #ifdef ENABLE_HDF5
         op.write_xdmf = pin->GetOrAddBoolean(op.block_name, "write_xdmf", true);
+        op.write_swarm_xdmf =
+            (restart) ? false
+                      : pin->GetOrAddBoolean(op.block_name, "write_swarm_xdmf", true);
         pnew_type = new PHDF5Output(op, restart);
 #else
         msg << "### FATAL ERROR in Outputs constructor" << std::endl

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -282,7 +282,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
         op.write_xdmf = pin->GetOrAddBoolean(op.block_name, "write_xdmf", true);
         op.write_swarm_xdmf =
             (restart) ? false
-                      : pin->GetOrAddBoolean(op.block_name, "write_swarm_xdmf", true);
+                      : pin->GetOrAddBoolean(op.block_name, "write_swarm_xdmf", false);
         pnew_type = new PHDF5Output(op, restart);
 #else
         msg << "### FATAL ERROR in Outputs constructor" << std::endl

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -1,6 +1,6 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2020-2023 The Parthenon collaboration
+// Copyright(C) 2020-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
 // (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -520,6 +520,12 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       }
     }
     if (output_params.write_swarm_xdmf) {
+      // TODO(@pdmullen): Here and above, we have worked with temp vectors pos_tmp and
+      // swarm_positions so that we can take the existing swarm position data structures
+      // and recast them into a format that XDMF/VisIt prefers.  Future efforts may (1)
+      // eliminate the extra geometry dump and/or (2) directly write the auxillary
+      // positions via low-level HDF writes, such that the vector manipulation below is
+      // unnecessary.
       const int npart = pos_tmp.size() / 3;
       std::vector<Real> swarm_positions(pos_tmp.size());
       int spcnt = 0;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -34,6 +34,7 @@
 
 #include "driver/driver.hpp"
 #include "interface/metadata.hpp"
+#include "interface/swarm_default_names.hpp"
 #include "mesh/mesh.hpp"
 #include "mesh/meshblock.hpp"
 #include "outputs/output_utils.hpp"
@@ -485,6 +486,17 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       local_count[rank] = swinfo.count_on_rank;
       global_count[rank] = swinfo.global_count;
     };
+    auto SetCountsParticlePositions = [&](const SwarmInfo &swinfo) {
+      for (int i = 0; i < 6; ++i) {
+        local_offset[i] = 0; // reset everything
+        local_count[i] = 0;
+        global_count[i] = 0;
+      }
+      local_offset[0] = swinfo.global_offset;
+      local_count[0] = swinfo.count_on_rank;
+      global_count[0] = swinfo.global_count;
+      local_count[1] = global_count[1] = 3;
+    };
     auto &int_vars = std::get<SwarmInfo::MapToVarVec<int>>(swinfo.vars);
     for (auto &[vname, swmvarvec] : int_vars) {
       const auto &vinfo = swinfo.var_info.at(vname);
@@ -493,6 +505,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       HDF5WriteND(g_var, vname, host_data.data(), vinfo.tensor_rank + 1, local_offset,
                   local_count, global_count, pl_xfer, H5P_DEFAULT);
     }
+    std::vector<Real> pos_tmp; // tmp vector to (potentially) hold particle positions
     auto &rvars = std::get<SwarmInfo::MapToVarVec<Real>>(swinfo.vars);
     for (auto &[vname, swmvarvec] : rvars) {
       const auto &vinfo = swinfo.var_info.at(vname);
@@ -500,7 +513,26 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       SetCounts(swinfo, vinfo);
       HDF5WriteND(g_var, vname, host_data.data(), vinfo.tensor_rank + 1, local_offset,
                   local_count, global_count, pl_xfer, H5P_DEFAULT);
+      if (output_params.write_swarm_xdmf &&
+          (vname == swarm_position::x::name() || vname == swarm_position::y::name() ||
+           vname == swarm_position::z::name())) {
+        pos_tmp.insert(pos_tmp.end(), host_data.begin(), host_data.end());
+      }
     }
+    if (output_params.write_swarm_xdmf) {
+      const int npart = pos_tmp.size() / 3;
+      std::vector<Real> swarm_positions(pos_tmp.size());
+      int spcnt = 0;
+      for (int i = 0; i < npart; ++i) {
+        swarm_positions[spcnt++] = pos_tmp[i];
+        swarm_positions[spcnt++] = pos_tmp[npart + i];
+        swarm_positions[spcnt++] = pos_tmp[2 * npart + i];
+      }
+      SetCountsParticlePositions(swinfo);
+      HDF5WriteND(g_var, "swarm_positions", swarm_positions.data(), 2, local_offset,
+                  local_count, global_count, pl_xfer, H5P_DEFAULT);
+    }
+
     // If swarm does not contain an "id" object, generate a sequential
     // one for vis.
     if (swinfo.var_info.count("id") == 0) {
@@ -515,10 +547,11 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   }
   Kokkos::Profiling::popRegion(); // write particle data
 
-  if (output_params.write_xdmf) {
+  if (output_params.write_xdmf || output_params.write_swarm_xdmf) {
     Kokkos::Profiling::pushRegion("genXDMF");
     // generate XDMF companion file
-    XDMF::genXDMF(filename, pm, tm, theDomain, nx1, nx2, nx3, all_vars_info, swarm_info);
+    XDMF::genXDMF(filename, pm, tm, theDomain, nx1, nx2, nx3, all_vars_info, swarm_info,
+                  output_params.write_xdmf, output_params.write_swarm_xdmf);
     Kokkos::Profiling::popRegion(); // genXDMF
   }
 

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -39,8 +39,6 @@
 #include "outputs/parthenon_xdmf.hpp"
 #include "utils/utils.hpp"
 
-#define PARTHENON_ENABLE_PARTICLE_XDMF 0
-
 namespace parthenon {
 using namespace OutputUtils;
 
@@ -63,6 +61,12 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
                                      const int nx3, const int nx2, const int nx1,
                                      const bool do_lowerd, const bool isVector,
                                      MetadataFlag where);
+static std::string ParticlePositionRef(const std::string &prefix,
+                                       const std::string &swmname,
+                                       const std::string &varname,
+                                       const std::string &hdffile,
+                                       const std::string &datatype,
+                                       const std::string &extradims, int particle_count);
 static std::string ParticleDatasetRef(const std::string &prefix,
                                       const std::string &swmname,
                                       const std::string &varname,
@@ -79,7 +83,8 @@ static std::string LocationToStringRef(MetadataFlag where);
 
 void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int nx1,
              int nx2, int nx3, const std::vector<VarInfo> &var_list,
-             const AllSwarmInfo &all_swarm_info) {
+             const AllSwarmInfo &all_swarm_info, const bool mesh_xdmf,
+             const bool swarm_xdmf) {
   using namespace HDF5;
   using namespace OutputUtils;
   using namespace impl;
@@ -90,145 +95,173 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
   if (Globals::my_rank != 0) {
     return;
   }
-  std::string filename_aux = hdfFile + ".xdmf";
-  std::ofstream xdmf;
-  hsize_t dims[H5_NDIM] = {0}; // zero-initialized
 
-  // check whether or not coordinates field is provided and find it if it is present
-  auto coords_it = std::find_if(var_list.begin(), var_list.end(),
-                                [](const auto &v) { return v.is_coordinate_field; });
-  const int ndim_mesh = (nx3 > 1) + (nx2 > 1) + (nx1 > 1);
-  const bool output_coords = (ndim_mesh > 1) && (coords_it != var_list.end());
-  if ((coords_it != var_list.end()) && (ndim_mesh < 2) && (Globals::my_rank == 0)) {
-    PARTHENON_WARN("Custom coordinates not supported in XDMF for 1D meshes. Reverting to "
-                   "3DRectMesh");
-  }
+  if (mesh_xdmf) {
+    std::string filename_aux = hdfFile + ".xdmf";
+    std::ofstream xdmf;
+    hsize_t dims[H5_NDIM] = {0}; // zero-initialized
 
-  // open file
-  xdmf = std::ofstream(filename_aux.c_str(), std::ofstream::trunc);
-
-  // Write header
-  xdmf << R"(<?xml version="1.0" ?>)" << std::endl;
-  xdmf << R"(<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">)" << std::endl;
-  xdmf << R"(<Xdmf Version="3.0">)" << std::endl;
-  xdmf << R"(<Information Name="TimeVaryingMetaData" Value="True"/>)" << std::endl;
-  xdmf << "  <Domain>" << std::endl;
-  xdmf << R"(  <Grid Name="Mesh" GridType="Collection">)" << std::endl;
-  if (tm != nullptr) {
-    xdmf << R"(    <Information Name="Cycle" Value=")" << tm->ncycle << R"("/>)"
-         << std::endl;
-    xdmf << R"(    <Time Value=")" << tm->time << R"("/>)" << std::endl;
-  }
-
-  // Now write Grid for each block
-  int ndim;
-  dims[0] = pm->nbtotal;
-  const int n3_offset = output_coords ? (nx3 > 1) : 1;
-  const int n2_offset = output_coords ? (nx2 > 1) : 1;
-  std::string mesh_type, dimstring;
-  if (output_coords) {
-    if (nx3 > 1) {
-      mesh_type = "3DSMesh";
-      dimstring = StringPrintf("%d %d %d", nx3 + n3_offset, nx2 + n2_offset, nx1 + 1);
-    } else if (nx2 > 1) {
-      mesh_type = "2DSMesh";
-      dimstring = StringPrintf("%d %d", nx2 + n2_offset, nx1 + 1);
-    } else {
-      PARTHENON_FAIL("Custom coordinates not supported in XDMF for 1D meshes.");
+    // check whether or not coordinates field is provided and find it if it is present
+    auto coords_it = std::find_if(var_list.begin(), var_list.end(),
+                                  [](const auto &v) { return v.is_coordinate_field; });
+    const int ndim_mesh = (nx3 > 1) + (nx2 > 1) + (nx1 > 1);
+    const bool output_coords = (ndim_mesh > 1) && (coords_it != var_list.end());
+    if ((coords_it != var_list.end()) && (ndim_mesh < 2) && (Globals::my_rank == 0)) {
+      PARTHENON_WARN(
+          "Custom coordinates not supported in XDMF for 1D meshes. Reverting to "
+          "3DRectMesh");
     }
-  } else {
-    mesh_type = "3DRectMesh";
-    dimstring = StringPrintf("%d %d %d", nx3 + n3_offset, nx2 + n2_offset, nx1 + 1);
-  }
-  for (int ib = 0; ib < pm->nbtotal; ib++) {
-    xdmf << StringPrintf("    <Grid GridType=\"Uniform\" Name=\"%d\">\n", ib);
-    xdmf << StringPrintf("      <Topology TopologyType=\"%s\" Dimensions=\"%s\"/>\n",
-                         mesh_type.c_str(), dimstring.c_str());
-    xdmf << StringPrintf("      <Geometry GeometryType=\"%s\">\n",
-                         output_coords ? "X_Y_Z" : "VXVYVZ");
+
+    // open file
+    xdmf = std::ofstream(filename_aux.c_str(), std::ofstream::trunc);
+
+    // Write header
+    xdmf << R"(<?xml version="1.0" ?>)" << std::endl;
+    xdmf << R"(<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">)" << std::endl;
+    xdmf << R"(<Xdmf Version="3.0">)" << std::endl;
+    xdmf << R"(<Information Name="TimeVaryingMetaData" Value="True"/>)" << std::endl;
+    xdmf << "  <Domain>" << std::endl;
+    xdmf << R"(  <Grid Name="Mesh" GridType="Collection">)" << std::endl;
+    if (tm != nullptr) {
+      xdmf << R"(    <Information Name="Cycle" Value=")" << tm->ncycle << R"("/>)"
+           << std::endl;
+      xdmf << R"(    <Time Value=")" << tm->time << R"("/>)" << std::endl;
+    }
+
+    // Now write Grid for each block
+    int ndim;
+    dims[0] = pm->nbtotal;
+    const int n3_offset = output_coords ? (nx3 > 1) : 1;
+    const int n2_offset = output_coords ? (nx2 > 1) : 1;
+    std::string mesh_type, dimstring;
     if (output_coords) {
-      ndim = coords_it->FillShape<hsize_t>(domain, &(dims[1])) + 1;
-      for (int d = 0; d < 3; ++d) {
-        xdmf << StringPrintf(
-                    "        <DataItem ItemType=\"Hyperslab\" Dimensions=\"%s\">\n"
-                    "          <DataItem Dimensions=\"3 5\" NumberType=\"Int\" "
-                    "Format=\"XML\">\n"
-                    "            %d %d 0 0 0\n"
-                    "            1 1 1 1 1\n"
-                    "            1 1 %d %d %d\n"
-                    "          </DataItem>\n",
-                    dimstring.c_str(), ib, d, nx3 + (nx3 > 1), nx2 + (nx2 > 1),
-                    nx1 + (nx1 > 1))
-             << stringXdmfArrayRef("          ", hdfFile + ":/", coords_it->label, dims,
-                                   ndim, "Float", 8)
-             << "        </DataItem>\n";
+      if (nx3 > 1) {
+        mesh_type = "3DSMesh";
+        dimstring = StringPrintf("%d %d %d", nx3 + n3_offset, nx2 + n2_offset, nx1 + 1);
+      } else if (nx2 > 1) {
+        mesh_type = "2DSMesh";
+        dimstring = StringPrintf("%d %d", nx2 + n2_offset, nx1 + 1);
+      } else {
+        PARTHENON_FAIL("Custom coordinates not supported in XDMF for 1D meshes.");
       }
     } else {
-      BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx1, hdfFile, "x");
-      BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx2, hdfFile, "y");
-      BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx3, hdfFile, "z");
+      mesh_type = "3DRectMesh";
+      dimstring = StringPrintf("%d %d %d", nx3 + n3_offset, nx2 + n2_offset, nx1 + 1);
     }
-    xdmf << "      </Geometry>" << std::endl;
-
-    // write graphics variables
-    for (const auto &vinfo : var_list) {
-      // Skip coordinates field. This is output elsewhere.
-      if (output_coords && vinfo.is_coordinate_field) continue;
-      // JMM: Faces/Edges in xdmf appear to be not fully supported by
-      // Visit/Paraview.
-      if ((vinfo.where != MetadataFlag({Metadata::Cell})) &&
-          (vinfo.where != MetadataFlag({Metadata::Node}))) {
-        continue;
+    for (int ib = 0; ib < pm->nbtotal; ib++) {
+      xdmf << StringPrintf("    <Grid GridType=\"Uniform\" Name=\"%d\">\n", ib);
+      xdmf << StringPrintf("      <Topology TopologyType=\"%s\" Dimensions=\"%s\"/>\n",
+                           mesh_type.c_str(), dimstring.c_str());
+      xdmf << StringPrintf("      <Geometry GeometryType=\"%s\">\n",
+                           output_coords ? "X_Y_Z" : "VXVYVZ");
+      if (output_coords) {
+        ndim = coords_it->FillShape<hsize_t>(domain, &(dims[1])) + 1;
+        for (int d = 0; d < 3; ++d) {
+          xdmf << StringPrintf(
+                      "        <DataItem ItemType=\"Hyperslab\" Dimensions=\"%s\">\n"
+                      "          <DataItem Dimensions=\"3 5\" NumberType=\"Int\" "
+                      "Format=\"XML\">\n"
+                      "            %d %d 0 0 0\n"
+                      "            1 1 1 1 1\n"
+                      "            1 1 %d %d %d\n"
+                      "          </DataItem>\n",
+                      dimstring.c_str(), ib, d, nx3 + (nx3 > 1), nx2 + (nx2 > 1),
+                      nx1 + (nx1 > 1))
+               << stringXdmfArrayRef("          ", hdfFile + ":/", coords_it->label, dims,
+                                     ndim, "Float", 8)
+               << "        </DataItem>\n";
+        }
+      } else {
+        BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx1, hdfFile, "x");
+        BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx2, hdfFile, "y");
+        BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx3, hdfFile, "z");
       }
-      ndim = vinfo.FillShape<hsize_t>(domain, &(dims[1])) + 1;
-      const int num_components = vinfo.num_components;
-      nx3 = dims[ndim - 3];
-      nx2 = dims[ndim - 2];
-      nx1 = dims[ndim - 1];
-      writeXdmfSlabVariableRef(xdmf, vinfo.label, vinfo.component_labels, hdfFile, ib,
-                               num_components, ndim, dims, nx3, nx2, nx1, output_coords,
-                               vinfo.is_vector, vinfo.where);
+      xdmf << "      </Geometry>" << std::endl;
+
+      // write graphics variables
+      for (const auto &vinfo : var_list) {
+        // Skip coordinates field. This is output elsewhere.
+        if (output_coords && vinfo.is_coordinate_field) continue;
+        // JMM: Faces/Edges in xdmf appear to be not fully supported by
+        // Visit/Paraview.
+        if ((vinfo.where != MetadataFlag({Metadata::Cell})) &&
+            (vinfo.where != MetadataFlag({Metadata::Node}))) {
+          continue;
+        }
+        ndim = vinfo.FillShape<hsize_t>(domain, &(dims[1])) + 1;
+        const int num_components = vinfo.num_components;
+        nx3 = dims[ndim - 3];
+        nx2 = dims[ndim - 2];
+        nx1 = dims[ndim - 1];
+        writeXdmfSlabVariableRef(xdmf, vinfo.label, vinfo.component_labels, hdfFile, ib,
+                                 num_components, ndim, dims, nx3, nx2, nx1, output_coords,
+                                 vinfo.is_vector, vinfo.where);
+      }
+      xdmf << "    </Grid>" << std::endl;
     }
+
+    // Cleanup
     xdmf << "    </Grid>" << std::endl;
+    xdmf << "  </Domain>" << std::endl;
+    xdmf << "</Xdmf>" << std::endl;
+    xdmf.close();
   }
+
   // Particles are defined as their own "mesh"
-#if PARTHENON_ENABLE_PARTICLE_XDMF
-  for (const auto &[swmname, swminfo] : all_swarm_info.all_info) {
-    xdmf << StringPrintf(
-        "    <Grid GridType=\"Uniform\" Name=\"%s\">\n"
-        "      <Topology TopologyType=\"Polyvertex\" Dimensions=\"%d\" "
-        "NodesPerElement=\"%d\">\n"
-        "        <DataItem Format=\"HDF\" Dimensions=\"%d\" NumberType=\"Int\">\n"
-        "          %s:/%s/SwarmVars/id\n"
-        "        </DataItem>\n"
-        "      </Topology>\n"
-        "      <Geometry GeometryType=\"VXVYVZ\">\n",
-        swmname.c_str(), swminfo.global_count, swminfo.global_count, swminfo.global_count,
-        hdfFile.c_str(), swmname.c_str());
-    xdmf << ParticleDatasetRef("        ", swmname, swarm_position::x::name(), hdfFile,
-                               "Float", "", swminfo.global_count);
-    xdmf << ParticleDatasetRef("        ", swmname, swarm_position::y::name(), hdfFile,
-                               "Float", "", swminfo.global_count);
-    xdmf << ParticleDatasetRef("        ", swmname, swarm_position::z::name(), hdfFile,
-                               "Float", "", swminfo.global_count);
-    xdmf << "      </Geometry>" << std::endl;
-    for (const auto &[varname, varinfo] : swminfo.var_info) {
-      if ((varname == "id") || (varname == swarm_position::x::name()) ||
-          (varname == swarm_position::y::name()) ||
-          (varname == swarm_position::z::name())) {
-        continue; // We already did this one!
-      }
-      ParticleVariableRef(xdmf, varname, varinfo, swmname, hdfFile, swminfo.global_count);
-    }
-    xdmf << "    </Grid>" << std::endl;
-  }
-#endif
+  if (swarm_xdmf && all_swarm_info.all_info.size() > 0) {
+    std::string sfilename_aux = hdfFile + ".swarm.xdmf";
+    std::ofstream pxdmf;
+    hsize_t dims[H5_NDIM] = {0}; // zero-initialized
 
-  // Cleanup
-  xdmf << "    </Grid>" << std::endl;
-  xdmf << "  </Domain>" << std::endl;
-  xdmf << "</Xdmf>" << std::endl;
-  xdmf.close();
+    // open file
+    pxdmf = std::ofstream(sfilename_aux.c_str(), std::ofstream::trunc);
+
+    // Write header
+    pxdmf << R"(<?xml version="1.0" ?>)" << std::endl;
+    pxdmf << R"(<!DOCTYPE Xdmf SYSTEM "Xdmf.dtd">)" << std::endl;
+    pxdmf << R"(<Xdmf Version="3.0">)" << std::endl;
+    pxdmf << R"(<Information Name="TimeVaryingMetaData" Value="True"/>)" << std::endl;
+    pxdmf << "  <Domain>" << std::endl;
+    pxdmf << R"(  <Grid Name="Mesh" GridType="Collection">)" << std::endl;
+    if (tm != nullptr) {
+      pxdmf << R"(    <Information Name="Cycle" Value=")" << tm->ncycle << R"("/>)"
+            << std::endl;
+      pxdmf << R"(    <Time Value=")" << tm->time << R"("/>)" << std::endl;
+    }
+
+    for (const auto &[swmname, swminfo] : all_swarm_info.all_info) {
+      pxdmf << StringPrintf("    <Grid GridType=\"Uniform\" Name=\"%s\">\n"
+                            "      <Topology TopologyType=\"Polyvertex\" "
+                            "NodesPerElement=\"%d\">\n"
+                            "      </Topology>\n"
+                            "      <Geometry GeometryType=\"XYZ\">\n",
+                            swmname.c_str(), swminfo.global_count, swminfo.global_count,
+                            swminfo.global_count, hdfFile.c_str(), swmname.c_str());
+      pxdmf << ParticlePositionRef("        ", swmname, "swarm_positions", hdfFile,
+                                   "Float", "", swminfo.global_count);
+      pxdmf << "      </Geometry>" << std::endl;
+      for (const auto &[varname, varinfo] : swminfo.var_info) {
+        if ((varname == swarm_position::x::name()) ||
+            (varname == swarm_position::y::name()) ||
+            (varname == swarm_position::z::name())) {
+          continue; // We already did this one!
+        }
+        ParticleVariableRef(pxdmf, varname, varinfo, swmname, hdfFile,
+                            swminfo.global_count);
+      }
+      if (swminfo.var_info.count("id") == 0) {
+        auto swid = SwarmVarInfo(1, 1, 1, 1, 1, 0, "Int", false);
+        ParticleVariableRef(pxdmf, "id", swid, swmname, hdfFile, swminfo.global_count);
+      }
+      pxdmf << "    </Grid>" << std::endl;
+    }
+
+    // Cleanup
+    pxdmf << "    </Grid>" << std::endl;
+    pxdmf << "  </Domain>" << std::endl;
+    pxdmf << "</Xdmf>" << std::endl;
+    pxdmf.close();
+  }
 }
 
 namespace impl {
@@ -352,6 +385,23 @@ static void writeXdmfSlabVariableRef(std::ofstream &fid, const std::string &name
   }
   // TODO(BRR) Support tensor dims 2 and 3
 }
+static std::string ParticlePositionRef(const std::string &prefix,
+                                       const std::string &swmname,
+                                       const std::string &varname,
+                                       const std::string &hdffile,
+                                       const std::string &datatype,
+                                       const std::string &extradims, int particle_count) {
+  std::string precision_string = (datatype == "Float") ? " Precision=\"8\"" : "";
+  auto part =
+      StringPrintf("%s<DataItem Format=\"HDF\" Dimensions=\"%s%d 3\" Name=\"%s\" "
+                   "NumberType=\"%s\"%s>\n"
+                   "%s  %s:/%s/SwarmVars/%s\n"
+                   "%s</DataItem>\n",
+                   prefix.c_str(), extradims.c_str(), particle_count, varname.c_str(),
+                   datatype.c_str(), precision_string.c_str(), prefix.c_str(),
+                   hdffile.c_str(), swmname.c_str(), varname.c_str(), prefix.c_str());
+  return part;
+}
 static std::string ParticleDatasetRef(const std::string &prefix,
                                       const std::string &swmname,
                                       const std::string &varname,
@@ -462,7 +512,7 @@ static void BlockCoordRegularRef(std::ofstream &xdmf, int nbtot, int ib, int nx,
       "            %d 0 1\n"
       "            1 1 %d\n"
       "          </DataItem>\n",
-      nx + (nx > 1), ib, nx + (nx > 1));
+      nx + 1, ib, nx + 1);
   writeXdmfArrayRef(xdmf, "          ", hdfFile + ":/Locations/", dir, dims, 2, "Float",
                     8);
   xdmf << "        </DataItem>" << std::endl;

--- a/src/outputs/parthenon_xdmf.hpp
+++ b/src/outputs/parthenon_xdmf.hpp
@@ -30,7 +30,8 @@ namespace parthenon {
 namespace XDMF {
 void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int nx1,
              int nx2, int nx3, const std::vector<OutputUtils::VarInfo> &var_list,
-             const OutputUtils::AllSwarmInfo &all_swarm_info);
+             const OutputUtils::AllSwarmInfo &all_swarm_info, const bool mesh_xdmf,
+             const bool swarm_xdmf);
 } // namespace XDMF
 } // namespace parthenon
 

--- a/src/outputs/parthenon_xdmf.hpp
+++ b/src/outputs/parthenon_xdmf.hpp
@@ -1,9 +1,9 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2020-2023 The Parthenon collaboration
+// Copyright(C) 2020-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

Visualizing HDF5 + XDMF files generated through `develop` with VisIt produces strange artifacts wherein 2D datasets often show a protruding X3 feature (which looks like a skyscraper).  This MR attempts to fix such artifacting by adjusting the data dumped in `HyperSlab` `DataItem`s.  

Parthenon particles cannot be visualized in VisIt currently, and their corresponding mesh is not even dumped in our current XDMF files.  For the life of me, I cannot get VisIt to interpret `VXVYVZ` type geometries for `Polyvertex` meshes.  I find that in order to get Visit to read our `Polyvertex` mesh, I must recast the geometry as an array of type `{{x1, y1, z2}, {x2, y2, z2}...}`.  Even after that change, I cannot get Visit to see the `Polyvertex` mesh unless it is its own XDMF file.  Visit can still plot particles on top of field variables if both XDMF files are read and a correlation is instantiated (VisIt prompts users automatically for this).  This MR enables users to optionally dump out swarm XDMF files, which, if enabled, also dumps restructured particle geometry in the corresponding HDF5 file.  Restart files should remain unchanged.  

This is gross.  Feel free to shoot down this MR. 

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
