### PR TITLE
add macOS CI

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -41,6 +41,6 @@ jobs:
 
      - uses: actions/upload-artifact@v3
         with:
-          name: configure-log-unit-${{ matrix.device }}
+          name: configure-log-unit-macos
           path: build/CMakeFiles/CMakeOutput.log
           retention-days: 3

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-14
+    runs-on: macos-latest
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -1,0 +1,46 @@
+name: CI macOS
+
+on: [pull_request]
+
+# Cancel "duplicated" workflows triggered by pushes to internal
+# branches with associated PRs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: 1
+  CMAKE_BUILD_PARALLEL_LEVEL: 4 # num threads for build
+
+jobs:
+  build:
+    runs-on: macos-14
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+        cache: 'pip' # caching pip dependencies
+
+    - name: Configure
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+
+    - name: Build
+        run: cmake --build build
+
+    - name: Test
+        run: |
+          cd build
+          ctest -LE 'regression'
+
+     - uses: actions/upload-artifact@v3
+        with:
+          name: configure-log-unit-${{ matrix.device }}
+          path: build/CMakeFiles/CMakeOutput.log
+          retention-days: 3


### PR DESCRIPTION
Adds macOS CI on GitHub actions.

## PR Summary

This helps ensure Parthenon runs smoothly on macOS.

This PR may not complete successfully when it's first run (most likely due to missing dependencies), since GitHub provides no way to test actions before running them in production. If this happens, I will create a new PR to fix any issues that arise.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
