### PR TITLE
[Trivial] add GetSize and GetIndex to sparse pack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR1081]](https://github.com/parthenon-hpc-lab/parthenon/pull/1081) Add GetSize and GetIndex to sparse pack
 - [[PR1020]](https://github.com/parthenon-hpc-lab/parthenon/pull/1020) Add bi- and trilinear interpolation routines
 - [[PR 1026]](https://github.com/parthenon-hpc-lab/parthenon/pull/1026) Particle BCs without relocatable device code
 - [[PR 1037]](https://github.com/parthenon-hpc-lab/parthenon/pull/1037) Add SwarmPacks

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -160,30 +160,30 @@ class SparsePack : public SparsePackBase {
   }
 
   // Host Bound overloads
-  inline int GetLowerBoundHost(const int b) const {
+  int GetLowerBoundHost(const int b) const {
     return (flat_ && (b > 0)) ? (bounds_h_(1, b - 1, nvar_) + 1) : 0;
   }
 
-  inline int GetUpperBoundHost(const int b) const { return bounds_h_(1, b, nvar_); }
+  int GetUpperBoundHost(const int b) const { return bounds_h_(1, b, nvar_); }
 
-  inline int GetLowerBoundHost(const int b, PackIdx idx) const {
+  int GetLowerBoundHost(const int b, PackIdx idx) const {
     static_assert(sizeof...(Ts) == 0);
     return bounds_h_(0, b, idx.VariableIdx());
   }
 
-  inline int GetUpperBoundHost(const int b, PackIdx idx) const {
+  int GetUpperBoundHost(const int b, PackIdx idx) const {
     static_assert(sizeof...(Ts) == 0);
     return bounds_h_(1, b, idx.VariableIdx());
   }
 
   template <class TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
-  inline int GetLowerBoundHost(const int b, const TIn &) const {
+  int GetLowerBoundHost(const int b, const TIn &) const {
     const int vidx = GetTypeIdx<TIn, Ts...>::value;
     return bounds_h_(0, b, vidx);
   }
 
   template <class TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
-  inline int GetUpperBoundHost(const int b, const TIn &) const {
+  int GetUpperBoundHost(const int b, const TIn &) const {
     const int vidx = GetTypeIdx<TIn, Ts...>::value;
     return bounds_h_(1, b, vidx);
   }
@@ -194,7 +194,7 @@ class SparsePack : public SparsePackBase {
     return GetUpperBound(b, t) - GetLowerBound(b, t) + 1;
   }
   template <typename T>
-  inline int GetSizeHost(const int b, const T &t) const {
+  int GetSizeHost(const int b, const T &t) const {
     return GetUpperBoundHost(b, t) - GetLowerBoundHost(b, t) + 1;
   }
 
@@ -204,7 +204,7 @@ class SparsePack : public SparsePackBase {
     return GetLowerBound(b, var) + var.idx;
   }
   template <typename TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
-  inline int GetIndexHost(const int b, const TIn &var) const {
+  int GetIndexHost(const int b, const TIn &var) const {
     return GetLowerBoundHost(b, var) + var.idx;
   }
 
@@ -231,17 +231,17 @@ class SparsePack : public SparsePackBase {
     return (... && Contains(b, Args()));
   }
   // Host versions
-  inline bool ContainsHost(const int b) const { return GetUpperBoundHost(b) >= 0; }
+  bool ContainsHost(const int b) const { return GetUpperBoundHost(b) >= 0; }
   template <typename T>
-  inline bool ContainsHost(const int b, const T t) const {
+  bool ContainsHost(const int b, const T t) const {
     return GetUpperBoundHost(b, t) >= 0;
   }
   template <typename... Args>
-  inline bool ContainsHost(const int b, Args... args) const {
+  bool ContainsHost(const int b, Args... args) const {
     return (... && ContainsHost(b, args));
   }
   template <typename... Args, REQUIRES(sizeof...(Args) > 0)>
-  inline bool ContainsHost(const int b) const {
+  bool ContainsHost(const int b) const {
     return (... && ContainsHost(b, Args()));
   }
 

--- a/src/interface/sparse_pack.hpp
+++ b/src/interface/sparse_pack.hpp
@@ -160,34 +160,52 @@ class SparsePack : public SparsePackBase {
   }
 
   // Host Bound overloads
-  KOKKOS_INLINE_FUNCTION int GetLowerBoundHost(const int b) const {
+  inline int GetLowerBoundHost(const int b) const {
     return (flat_ && (b > 0)) ? (bounds_h_(1, b - 1, nvar_) + 1) : 0;
   }
 
-  KOKKOS_INLINE_FUNCTION int GetUpperBoundHost(const int b) const {
-    return bounds_h_(1, b, nvar_);
-  }
+  inline int GetUpperBoundHost(const int b) const { return bounds_h_(1, b, nvar_); }
 
-  KOKKOS_INLINE_FUNCTION int GetLowerBoundHost(const int b, PackIdx idx) const {
+  inline int GetLowerBoundHost(const int b, PackIdx idx) const {
     static_assert(sizeof...(Ts) == 0);
     return bounds_h_(0, b, idx.VariableIdx());
   }
 
-  KOKKOS_INLINE_FUNCTION int GetUpperBoundHost(const int b, PackIdx idx) const {
+  inline int GetUpperBoundHost(const int b, PackIdx idx) const {
     static_assert(sizeof...(Ts) == 0);
     return bounds_h_(1, b, idx.VariableIdx());
   }
 
   template <class TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
-  KOKKOS_INLINE_FUNCTION int GetLowerBoundHost(const int b, const TIn &) const {
+  inline int GetLowerBoundHost(const int b, const TIn &) const {
     const int vidx = GetTypeIdx<TIn, Ts...>::value;
     return bounds_h_(0, b, vidx);
   }
 
   template <class TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
-  KOKKOS_INLINE_FUNCTION int GetUpperBoundHost(const int b, const TIn &) const {
+  inline int GetUpperBoundHost(const int b, const TIn &) const {
     const int vidx = GetTypeIdx<TIn, Ts...>::value;
     return bounds_h_(1, b, vidx);
+  }
+
+  // Number of components of a variable on a block
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION int GetSize(const int b, const T &t) const {
+    return GetUpperBound(b, t) - GetLowerBound(b, t) + 1;
+  }
+  template <typename T>
+  inline int GetSizeHost(const int b, const T &t) const {
+    return GetUpperBoundHost(b, t) - GetLowerBoundHost(b, t) + 1;
+  }
+
+  // Index in pack
+  template <typename TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
+  KOKKOS_INLINE_FUNCTION int GetIndex(const int b, const TIn &var) const {
+    return GetLowerBound(b, var) + var.idx;
+  }
+  template <typename TIn, REQUIRES(IncludesType<TIn, Ts...>::value)>
+  inline int GetIndexHost(const int b, const TIn &var) const {
+    return GetLowerBoundHost(b, var) + var.idx;
   }
 
   /* Usage:
@@ -213,19 +231,17 @@ class SparsePack : public SparsePackBase {
     return (... && Contains(b, Args()));
   }
   // Host versions
-  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b) const {
-    return GetUpperBoundHost(b) >= 0;
-  }
+  inline bool ContainsHost(const int b) const { return GetUpperBoundHost(b) >= 0; }
   template <typename T>
-  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b, const T t) const {
+  inline bool ContainsHost(const int b, const T t) const {
     return GetUpperBoundHost(b, t) >= 0;
   }
   template <typename... Args>
-  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b, Args... args) const {
+  inline bool ContainsHost(const int b, Args... args) const {
     return (... && ContainsHost(b, args));
   }
   template <typename... Args, REQUIRES(sizeof...(Args) > 0)>
-  KOKKOS_INLINE_FUNCTION bool ContainsHost(const int b) const {
+  inline bool ContainsHost(const int b) const {
     return (... && ContainsHost(b, Args()));
   }
 

--- a/tst/unit/test_sparse_pack.cpp
+++ b/tst/unit/test_sparse_pack.cpp
@@ -217,6 +217,9 @@ TEST_CASE("Test behavior of sparse packs", "[SparsePack]") {
         REQUIRE(pack.ContainsHost(2, v5()));
         REQUIRE(!pack.ContainsHost(2, v1(), v3(), v5()));
         REQUIRE(pack.ContainsHost<v1, v5>(2));
+        REQUIRE(pack.GetSizeHost(2, v1()) == 1);
+        REQUIRE(pack.GetSizeHost(2, v3()) == 0);
+        REQUIRE(pack.GetSizeHost(1, v3()) == 3);
       }
 
       THEN("A sparse pack correctly loads this data and can be read from v3 on all "


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Upstreaming a few features we use in riot. Mainly a cheap way of getting the number of sparse IDs of a variable on a block and the "index" in the pack on a given block.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
