### PR TITLE
Correctly fill VariableFluxPack for edge fluxes in 2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1083]](https://github.com/parthenon-hpc-lab/parthenon/pull/1083) Correctly fill VariableFluxPack for edge fluxes in 2D
 - [[PR 1071]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Fix bug in static mesh refinement related to redefinition of Mesh::root_level
 - [[PR 1073]](https://github.com/parthenon-hpc-lab/parthenon/pull/1073) Fix bug in AMR and sparse restarts
 - [[PR 1070]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Correctly exclude flux vars from searches by default

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -452,9 +452,14 @@ class VariableFluxPack : public VariablePack<T> {
   // host only
   inline auto flux_alloc_status() const { return flux_alloc_status_; }
 
-  KOKKOS_FORCEINLINE_FUNCTION
-  const ViewOfParArrays<T> &flux(const int dir) const {
-    assert(dir > 0 && dir <= this->ndim_);
+  template <TopologicalType TT = TopologicalType::Face>
+  KOKKOS_FORCEINLINE_FUNCTION const ViewOfParArrays<T> &flux(const int dir) const {
+    assert(dir > 0);
+    if constexpr (TT == TopologicalType::Edge) {
+      assert(dir <= this->ndim_ || (this->ndim_ == 2 && dir == 3));
+    } else {
+      assert(dir <= this->ndim_);
+    }
     return f_[dir - 1];
   }
 
@@ -471,10 +476,11 @@ class VariableFluxPack : public VariablePack<T> {
   constexpr bool IsFluxAllocated(const int /*n*/) const { return true; }
 #endif
 
-  KOKKOS_FORCEINLINE_FUNCTION
-  T &flux(const int dir, const int n, const int k, const int j, const int i) const {
+  template <TopologicalType TT = TopologicalType::Face>
+  KOKKOS_FORCEINLINE_FUNCTION T &flux(const int dir, const int n, const int k,
+                                      const int j, const int i) const {
     assert(IsFluxAllocated(n));
-    return flux(dir)(n)(k, j, i);
+    return flux<TT>(dir)(n)(k, j, i);
   }
 
  private:
@@ -681,9 +687,15 @@ void FillFluxViews(const VariableVector<T> &vars, const int ndim,
         for (int i = 0; i < v->GetDim(4); i++) {
           host_al(vindex) = v->IsAllocated();
           if (v->IsAllocated()) {
-            host_f1(vindex) = v->data.Get(0, k, j, i);
-            if (ndim >= 2) host_f2(vindex) = v->data.Get(1, k, j, i);
-            if (ndim >= 3) host_f3(vindex) = v->data.Get(2, k, j, i);
+            if (v->IsSet(Metadata::Edge)) {
+              if (ndim >= 2) host_f3(vindex) = v->data.Get(2, k, j, i);
+              if (ndim >= 3) host_f2(vindex) = v->data.Get(1, k, j, i);
+              if (ndim >= 3) host_f1(vindex) = v->data.Get(0, k, j, i);
+            } else {
+              host_f1(vindex) = v->data.Get(0, k, j, i);
+              if (ndim >= 2) host_f2(vindex) = v->data.Get(1, k, j, i);
+              if (ndim >= 3) host_f3(vindex) = v->data.Get(2, k, j, i);
+            }
           }
 
           vindex++;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

* `X3` flux  is filled in 2D for `Metadata::Face`s with `Metadata::WithFluxes`. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->
fixes #1082 
## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
