### PR TITLE
Properly free swarm boundary MPI requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
-- [[PR1020]](https://github.com/parthenon-hpc-lab/parthenon/pull/1020) Add bi- and trilinear interpolation routines
+- [[PR 1084]](https://github.com/parthenon-hpc-lab/parthenon/pull/1084) Properly free swarm boundary MPI requests 
+- [[PR 1020]](https://github.com/parthenon-hpc-lab/parthenon/pull/1020) Add bi- and trilinear interpolation routines
 - [[PR 1026]](https://github.com/parthenon-hpc-lab/parthenon/pull/1026) Particle BCs without relocatable device code
 - [[PR 1037]](https://github.com/parthenon-hpc-lab/parthenon/pull/1037) Add SwarmPacks
 - [[PR 1068]](https://github.com/parthenon-hpc-lab/parthenon/pull/1068) Add ability to dump sparse pack contents as a string

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -645,7 +645,7 @@ void Swarm::ResetCommunication() {
   for (int n = 0; n < pmb->neighbors.size(); n++) {
     NeighborBlock &nb = pmb->neighbors[n];
     if (vbswarm->bd_var_.req_send[nb.bufid] != MPI_REQUEST_NULL) {
-      MPI_Request_Free(vbswarm->bd_var_.req_send[nb.bufid]);
+      MPI_Request_Free(&(vbswarm->bd_var_.req_send[nb.bufid]));
     }
   }
 #endif

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -645,7 +645,7 @@ void Swarm::ResetCommunication() {
   for (int n = 0; n < pmb->neighbors.size(); n++) {
     NeighborBlock &nb = pmb->neighbors[n];
     if (vbswarm->bd_var_.req_send[nb.bufid] != MPI_REQUEST_NULL) {
-      MPI_Request_Free(&(vbswarm->bd_var_.req_send[nb.bufid]));
+      MPI_Request_free(&(vbswarm->bd_var_.req_send[nb.bufid]));
     }
   }
 #endif

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -644,7 +644,9 @@ void Swarm::ResetCommunication() {
 #ifdef MPI_PARALLEL
   for (int n = 0; n < pmb->neighbors.size(); n++) {
     NeighborBlock &nb = pmb->neighbors[n];
-    vbswarm->bd_var_.req_send[nb.bufid] = MPI_REQUEST_NULL;
+    if (vbswarm->bd_var_.req_send[nb.bufid] != MPI_REQUEST_NULL) {
+      MPI_Request_Free(vbswarm->bd_var_.req_send[nb.bufid]);
+    }
   }
 #endif
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@pdmullen identified a bug in a downstream application using Parthenon particles where after a number of timesteps, MPI would fail internally. It turns out that Parthenon was not properly freeing MPI requests for swarms, but just setting its own variable to `null`. This is an easy fix, and solved the downstream issue. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
