### PR TITLE
[trivial] create inner loop pattern tag manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1087]](https://github.com/parthenon-hpc-lab/parthenon/pull/1087) Make sure InnerLoopPatternTVR is resolved on device properly when it is the default loop pattern
 - [[PR 1071]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Fix bug in static mesh refinement related to redefinition of Mesh::root_level
 - [[PR 1073]](https://github.com/parthenon-hpc-lab/parthenon/pull/1073) Fix bug in AMR and sparse restarts
 - [[PR 1070]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Correctly exclude flux vars from searches by default

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ else()
 endif()
 
 if (${PAR_LOOP_INNER_LAYOUT} STREQUAL "TVR_INNER_LOOP")
-  set(PAR_LOOP_INNER_LAYOUT_TAG InnerLoopPatternTVR())
+  set(PAR_LOOP_INNER_LAYOUT_TAG "InnerLoopPatternTVR()")
 elseif (${PAR_LOOP_INNER_LAYOUT} STREQUAL "SIMDFOR_INNER_LOOP")
   set(PAR_LOOP_INNER_LAYOUT_TAG inner_loop_pattern_simdfor_tag)
 else()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,7 +78,7 @@ else()
 endif()
 
 if (${PAR_LOOP_INNER_LAYOUT} STREQUAL "TVR_INNER_LOOP")
-  set(PAR_LOOP_INNER_LAYOUT_TAG inner_loop_pattern_tvr_tag)
+  set(PAR_LOOP_INNER_LAYOUT_TAG InnerLoopPatternTVR())
 elseif (${PAR_LOOP_INNER_LAYOUT} STREQUAL "SIMDFOR_INNER_LOOP")
   set(PAR_LOOP_INNER_LAYOUT_TAG inner_loop_pattern_simdfor_tag)
 else()


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

My "automatic" loop pattern fix in PR #1078 had an unexpected effect. Inner loop pattern tags, on some builds in riot, are now not being properly resolved on device. I think this is related to #321 and #319, though I'm not sure why `constexpr` isn't sufficient to make the tags get captured. The trivial solution, implemented here, is to just make the macro call the tag constructor manually. This only needs to be done for `InnerLoopPatternTVR`.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
