### PR TITLE
Fix restaring from files not containing the derefinement counter (from #1073)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1089]](https://github.com/parthenon-hpc-lab/parthenon/pull/1089) Fix loading restart files without derefinement counter
 - [[PR 1083]](https://github.com/parthenon-hpc-lab/parthenon/pull/1083) Correctly fill VariableFluxPack for edge fluxes in 2D
 - [[PR 1087]](https://github.com/parthenon-hpc-lab/parthenon/pull/1087) Make sure InnerLoopPatternTVR is resolved on device properly when it is the default loop pattern
 - [[PR 1071]](https://github.com/parthenon-hpc-lab/parthenon/pull/1070) Fix bug in static mesh refinement related to redefinition of Mesh::root_level

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -285,7 +285,8 @@ def compare_metadata(f0, f1, quiet=False, one=False, check_input=False, tol=1.0e
             for key in f0.fid[var].keys():
                 if var == "Blocks" and key == "loc.level-gid-lid-cnghost-gflag":
                     continue  # depends on number of MPI ranks and distribution of blocks among ranks
-
+                if var == "Blocks" and key == "derefinement_count":
+                    continue  # Gold files have not been updated to include derefinement_count
                 # Compare raw data of these variables
                 val0 = f0.fid[var][key]
                 val1 = f1.fid[var][key]

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -604,11 +604,12 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   // files works.
   auto NumIDsAndFlags_in_file = NumIDsAndFlags;
   if (locLevelGidLidCnghostGflag.size() / nbtotal == 5) {
+    NumIDsAndFlags_in_file = 5;
+  } else {
     PARTHENON_REQUIRE_THROWS(locLevelGidLidCnghostGflag.size() / nbtotal ==
                                  NumIDsAndFlags,
                              "Trying to restart with an unexpected number of entries. "
                              "Did NumIDsAndFlags change?");
-    NumIDsAndFlags_in_file = 5;
   }
   for (int i = 0; i < nbtotal; i++) {
     loclist[i] = LogicalLocation(locLevelGidLidCnghostGflag[NumIDsAndFlags_in_file * i],

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -598,21 +598,8 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
   auto lx123 = mesh_info.lx123;
   auto locLevelGidLidCnghostGflag = mesh_info.level_gid_lid_cnghost_gflag;
   current_level = -1;
-  // Ugly fix to adjust to the change the number of component for each block when the
-  // deallocation counter was introduced
-  // (https://github.com/parthenon-hpc-lab/parthenon/pull/1073) so that restarting older
-  // files works.
-  auto NumIDsAndFlags_in_file = NumIDsAndFlags;
-  if (locLevelGidLidCnghostGflag.size() / nbtotal == 5) {
-    NumIDsAndFlags_in_file = 5;
-  } else {
-    PARTHENON_REQUIRE_THROWS(locLevelGidLidCnghostGflag.size() / nbtotal ==
-                                 NumIDsAndFlags,
-                             "Trying to restart with an unexpected number of entries. "
-                             "Did NumIDsAndFlags change?");
-  }
   for (int i = 0; i < nbtotal; i++) {
-    loclist[i] = LogicalLocation(locLevelGidLidCnghostGflag[NumIDsAndFlags_in_file * i],
+    loclist[i] = LogicalLocation(locLevelGidLidCnghostGflag[NumIDsAndFlags * i],
                                  lx123[3 * i], lx123[3 * i + 1], lx123[3 * i + 2]);
   }
 
@@ -705,14 +692,8 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
     block_list[i - nbs] =
         MeshBlock::Make(i, i - nbs, loclist[i], block_size, block_bcs, this, pin, app_in,
                         packages, resolved_packages, gflag, costlist[i]);
-    if (block_list[i - nbs]->pmr) {
-      // NumIDsAndFlags == 5 is a "older" format that did not contain the derefinement
-      // count so it's set to 0 (which was the previous default behavior)
-      block_list[i - nbs]->pmr->DerefinementCount() =
-          NumIDsAndFlags_in_file == 5
-              ? 0
-              : locLevelGidLidCnghostGflag[NumIDsAndFlags * i + 5];
-    }
+    if (block_list[i - nbs]->pmr)
+      block_list[i - nbs]->pmr->DerefinementCount() = mesh_info.derefinement_count[i];
   }
   BuildGMGBlockLists(pin, app_in);
   SetMeshBlockNeighbors(GridIdentifier::leaf(), block_list, ranklist);

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -232,15 +232,21 @@ std::vector<int64_t> ComputeLocs(Mesh *pm) {
 
 std::vector<int> ComputeIDsAndFlags(Mesh *pm) {
   return FlattenBlockInfo<int>(
-      pm, 6, [=](MeshBlock *pmb, std::vector<int> &data, int &i) {
+      pm, 5, [=](MeshBlock *pmb, std::vector<int> &data, int &i) {
         auto loc = pmb->pmy_mesh->Forest().GetLegacyTreeLocation(pmb->loc);
         data[i++] = loc.level();
         data[i++] = pmb->gid;
         data[i++] = pmb->lid;
         data[i++] = pmb->cnghost;
         data[i++] = pmb->gflag;
-        data[i++] = pmb->pmr ? pmb->pmr->DerefinementCount() : 0;
       });
+}
+
+std::vector<int> ComputeDerefinementCount(Mesh *pm) {
+  return FlattenBlockInfo<int>(pm, 1,
+                               [=](MeshBlock *pmb, std::vector<int> &data, int &i) {
+                                 data[i++] = pmb->pmr ? pmb->pmr->DerefinementCount() : 0;
+                               });
 }
 
 // TODO(JMM): I could make this use the other loop

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -338,6 +338,7 @@ void ComputeCoords(Mesh *pm, bool face, const IndexRange &ib, const IndexRange &
 std::vector<Real> ComputeXminBlocks(Mesh *pm);
 std::vector<int64_t> ComputeLocs(Mesh *pm);
 std::vector<int> ComputeIDsAndFlags(Mesh *pm);
+std::vector<int> ComputeDerefinementCount(Mesh *pm);
 
 // TODO(JMM): Potentially unsafe if MPI_UNSIGNED_LONG_LONG isn't a size_t
 // however I think it's probably safe to assume we'll be on systems

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -603,6 +603,16 @@ void PHDF5Output::WriteBlocksMetadata_(Mesh *pm, hid_t file, const HDF5::H5P &pl
     HDF5Write2D(gBlocks, "loc.level-gid-lid-cnghost-gflag", tmpID.data(), &loc_offset[0],
                 &loc_cnt[0], &glob_cnt[0], pl);
   }
+
+  {
+    // derefinement count
+    hsize_t loc_cnt[2] = {num_blocks_local, 1};
+    hsize_t glob_cnt[2] = {max_blocks_global, 1};
+    std::vector<int> tmpID = OutputUtils::ComputeDerefinementCount(pm);
+    HDF5Write2D(gBlocks, "derefinement_count", tmpID.data(), &loc_offset[0], &loc_cnt[0],
+                &glob_cnt[0], pl);
+  }
+
   Kokkos::Profiling::popRegion(); // write block metadata
 }
 

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -37,7 +37,7 @@ class Param;
 
 // If this number changes, the logic for reading previously written restart files in
 // mesh.cpp needs to be adjusted.
-constexpr int NumIDsAndFlags{6};
+constexpr int NumIDsAndFlags{5};
 
 class RestartReader {
  public:
@@ -91,6 +91,7 @@ class RestartReader {
     std::vector<Real> grid_dim;
     std::vector<int64_t> lx123;
     std::vector<int> level_gid_lid_cnghost_gflag; // what's this?!
+    std::vector<int> derefinement_count;
   };
   [[nodiscard]] virtual MeshInfo GetMeshInfo() const = 0;
 

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -35,6 +35,8 @@ namespace parthenon {
 class Mesh;
 class Param;
 
+// If this number changes, the logic for reading previously written restart files in
+// mesh.cpp needs to be adjusted.
 constexpr int NumIDsAndFlags{6};
 
 class RestartReader {

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -138,10 +138,12 @@ RestartReaderHDF5::MeshInfo RestartReaderHDF5::GetMeshInfo() const {
     mesh_info.derefinement_count = ReadDataset<int>("/Blocks/derefinement_count");
   } catch (const std::runtime_error &e) {
     // File does not contain this dataset, so must be older. Set to default value of zero
-    PARTHENON_WARN(
-        "Restarting from an HDF5 file that doesn't contain /Blocks/derefinement_count. \n"
-        "If you are running with AMR, this may cause restarts to not be bitwise exact \n"
-        "with simulations that are run without restarting.");
+    if (Globals::my_rank == 0)
+      PARTHENON_WARN("Restarting from an HDF5 file that doesn't contain "
+                     "/Blocks/derefinement_count. \n"
+                     "If you are running with AMR, this may cause restarts to not be "
+                     "bitwise exact \n"
+                     "with simulations that are run without restarting.");
     mesh_info.derefinement_count = std::vector<int>(mesh_info.nbtotal, 0);
   }
   return mesh_info;

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -134,6 +134,12 @@ RestartReaderHDF5::MeshInfo RestartReaderHDF5::GetMeshInfo() const {
   mesh_info.level_gid_lid_cnghost_gflag =
       ReadDataset<int>("/Blocks/loc.level-gid-lid-cnghost-gflag");
 
+  try {
+    mesh_info.derefinement_count = ReadDataset<int>("/Blocks/derefinement_count");
+  } catch (const std::runtime_error &e) {
+    // File does not contain this dataset, so must be older. Set to default value of zero
+    mesh_info.derefinement_count = std::vector<int>(mesh_info.nbtotal, 0);
+  }
   return mesh_info;
 }
 

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -138,6 +138,10 @@ RestartReaderHDF5::MeshInfo RestartReaderHDF5::GetMeshInfo() const {
     mesh_info.derefinement_count = ReadDataset<int>("/Blocks/derefinement_count");
   } catch (const std::runtime_error &e) {
     // File does not contain this dataset, so must be older. Set to default value of zero
+    PARTHENON_WARN(
+        "Restarting from an HDF5 file that doesn't contain /Blocks/derefinement_count. \n"
+        "If you are running with AMR, this may cause restarts to not be bitwise exact \n"
+        "with simulations that are run without restarting.");
     mesh_info.derefinement_count = std::vector<int>(mesh_info.nbtotal, 0);
   }
   return mesh_info;

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -134,16 +134,18 @@ RestartReaderHDF5::MeshInfo RestartReaderHDF5::GetMeshInfo() const {
   mesh_info.level_gid_lid_cnghost_gflag =
       ReadDataset<int>("/Blocks/loc.level-gid-lid-cnghost-gflag");
 
-  try {
+  auto status =
+      PARTHENON_HDF5_CHECK(H5Lexists(fh_, "Blocks/derefinement_count", H5P_DEFAULT));
+  if (status > 0) {
     mesh_info.derefinement_count = ReadDataset<int>("/Blocks/derefinement_count");
-  } catch (const std::runtime_error &e) {
+  } else {
     // File does not contain this dataset, so must be older. Set to default value of zero
-    if (Globals::my_rank == 0)
+    if (Globals::my_rank == 0 && (GetAttr<int>("Info", "Multilevel") != 0))
       PARTHENON_WARN("Restarting from an HDF5 file that doesn't contain "
                      "/Blocks/derefinement_count. \n"
-                     "If you are running with AMR, this may cause restarts to not be "
+                     "  If you are running with AMR, this may cause restarts to not be "
                      "bitwise exact \n"
-                     "with simulations that are run without restarting.");
+                     "  with simulations that are run without restarting.");
     mesh_info.derefinement_count = std::vector<int>(mesh_info.nbtotal, 0);
   }
   return mesh_info;

--- a/tst/regression/test_suites/restart/parthinput.restart
+++ b/tst/regression/test_suites/restart/parthinput.restart
@@ -39,9 +39,6 @@ x3max = 1
 ix3_bc = periodic
 ox3_bc = periodic
 
-derefine_count = 999999 # disable this since derefinement counter resets on
-                        # restart and thus leads to different results
-
 <parthenon/meshblock>
 nx1 = 16
 nx2 = 16


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In https://github.com/parthenon-hpc-lab/parthenon/pull/1073 the per-block derefinement counter was stored in restart files (and restored on restarts).
This changes the number of entries in the flattened `loc.level-gid-lid-cnghost-gflag` vector (from 5 per block to 6 per block).
If one currently restarts with from an older file this is not taken into account and logical locations (and potentially more are off).
I came across this because of a 
```
### PARTHENON ERROR
  Message:     Somehow didn't find a tree.
  File:        /project/project_465000552/env/src/athenapk/external/parthenon/src/mesh/forest/forest.hpp
  Line number: 128
Somehow didn't find a tree.
```
on restart.

Effectively, this renders restart any older file impossible/erroneous right now.
The proposed fix is not necessarily super-clean but it circumvents bumping the output format version (and introducing similar logic anyway).
But if there's a different/cleaner solution, I'm also open to suggestions.

Note, that this still doesn't fully fix a restart problem I'm tracking down (also in context of reviewing #1055) but it fixes the error above.
It might also be that the restart I'm trying to fix are broken because I used some Parthenon version in between that didn't contain all the mesh/tree related bugfixes that went in over the past weeks.
I'm still investigating, but I'm fairly sure that this PR and the proposed fix are necessary no matter what.


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
