### PR TITLE
Fix forest size for symmetry dimensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1093]](https://github.com/parthenon-hpc-lab/parthenon/pull/1093) Fix forest size for symmetry dimensions
 - [[PR 1089]](https://github.com/parthenon-hpc-lab/parthenon/pull/1089) Fix loading restart files without derefinement counter
 - [[PR 1079]](https://github.com/parthenon-hpc-lab/parthenon/pull/1079) Address XDMF/Visit Issues
 - [[PR 1088]](https://github.com/parthenon-hpc-lab/parthenon/pull/1088) Correctly fill fluxes for non-cell variables in SparsePacks

--- a/src/mesh/forest/forest.cpp
+++ b/src/mesh/forest/forest.cpp
@@ -75,11 +75,18 @@ Forest Forest::HyperRectangular(RegionSize mesh_size, RegionSize block_size,
   for (auto dir : {X1DIR, X2DIR, X3DIR}) {
     if (mesh_size.symmetry(dir)) {
       nblock[dir - 1] = 1;
+      // Symmetry directions have just a single zone for
+      // both the mesh and for each block
+      max_common_power2_divisor = 1;
       continue;
     }
     // Add error checking
     ndim = dir;
     nblock[dir - 1] = mesh_size.nx(dir) / block_size.nx(dir);
+    PARTHENON_REQUIRE(mesh_size.nx(dir) % block_size.nx(dir) == 0,
+                      "Block size is not evenly divisible into the base mesh size.");
+    PARTHENON_REQUIRE(nblock[dir - 1] > 0,
+                      "Must have a mesh that has a block size greater than one.");
     max_common_power2_divisor =
         std::min(max_common_power2_divisor, MaximumPowerOf2Divisor(nblock[dir - 1]));
   }


### PR DESCRIPTION
## PR Summary
This PR fixes a bug in the hyper rectangular forest generation routine.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
