### PR TITLE
Custom refinement ops propagated to fluxes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1100]](https://github.com/parthenon-hpc-lab/parthenon/pull/1100) Custom refinement ops propagated to fluxes
 - [[PR 1090]](https://github.com/parthenon-hpc-lab/parthenon/pull/1090) SMR with swarms
 - [[PR 1079]](https://github.com/parthenon-hpc-lab/parthenon/pull/1079) Address XDMF/Visit Issues
 - [[PR 1084]](https://github.com/parthenon-hpc-lab/parthenon/pull/1084) Properly free swarm boundary MPI requests

--- a/doc/sphinx/src/interface/refinement_operations.rst
+++ b/doc/sphinx/src/interface/refinement_operations.rst
@@ -110,3 +110,10 @@ You must register both prolongation and restriction together. You may,
 however, use the default Parthenon structs if desired. Then any variable
 registered with this metadata object will use your custom prolongation
 and restriction operations.
+
+When a variable with custom operations is enrolled and marked
+``Metadata::WithFluxes``, the resulting flux variables that are created will
+also have the same custom operations enrolled. In general the custom operations
+will need to be different for the variable and for its fluxes; these can be
+distinguished inside the custom operations by referring to the
+``TopologicalElement`` template parameter.

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -126,10 +126,8 @@ Metadata::Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int>
   }
   // If variable is refined, set a default prolongation/restriction op
   // TODO(JMM): This is dangerous. See Issue #844.
-  printf("Is refined? %i\n", static_cast<int>(IsRefined()));
   if (IsRefined()) {
     refinement_funcs_ = ref_funcs_;
-    printf("label size? %i\n", refinement_funcs_.label().size());
   }
 
   // check if all flag constraints are satisfied, throw if not

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -126,8 +126,10 @@ Metadata::Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int>
   }
   // If variable is refined, set a default prolongation/restriction op
   // TODO(JMM): This is dangerous. See Issue #844.
+  printf("Is refined? %i\n", static_cast<int>(IsRefined()));
   if (IsRefined()) {
     refinement_funcs_ = ref_funcs_;
+    printf("label size? %i\n", refinement_funcs_.label().size());
   }
 
   // check if all flag constraints are satisfied, throw if not

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -281,11 +281,20 @@ bool StateDescriptor::AddFieldImpl(const VarID &vid, const Metadata &m_in,
         mFlags.push_back(Metadata::Edge);
       else if (m.IsSet(Metadata::Edge))
         mFlags.push_back(Metadata::Node);
-      Metadata mf(mFlags, m.Shape());
+
+      Metadata mf;
+      if (m.GetRefinementFunctions().label().size() > 0) {
+        // Propagate custom refinement ops to flux field
+        mf = Metadata(mFlags, m.Shape(), std::vector<std::string>(), std::string(),
+                      m.GetRefinementFunctions());
+      } else {
+        mf = Metadata(mFlags, m.Shape());
+      }
       auto fId = VarID{internal_fluxname + internal_varname_seperator + vid.base_name,
                        vid.sparse_id};
       AddFieldImpl(fId, mf, control_vid);
       m.SetFluxName(fId.label());
+      refinementFuncMaps_.Register(mf, fId.label());
     }
     metadataMap_.insert({vid, m});
     refinementFuncMaps_.Register(m, vid.label());

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -294,7 +294,6 @@ bool StateDescriptor::AddFieldImpl(const VarID &vid, const Metadata &m_in,
                        vid.sparse_id};
       AddFieldImpl(fId, mf, control_vid);
       m.SetFluxName(fId.label());
-      refinementFuncMaps_.Register(mf, fId.label());
     }
     metadataMap_.insert({vid, m});
     refinementFuncMaps_.Register(m, vid.label());


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

Custom refinement operations enrolled in variable metadata were not being propagated to flux fields if `WithFluxes` was active. This PR addresses that.

Note that in this model the refinement operations will need to be able to distinguish between the field and the flux field, presumably by branching based on the `TopologicalElement`. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
