### PR TITLE
Fix reading restarts due to hidden ghost var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1104]](https://github.com/parthenon-hpc-lab/parthenon/pull/1104) Fix reading restarts due to hidden ghost var
 - [[PR 1098]](https://github.com/parthenon-hpc-lab/parthenon/pull/1098) Move to symmetrized logical coordinates and fix SMR bug
 - [[PR 1095]](https://github.com/parthenon-hpc-lab/parthenon/pull/1095) Add missing include guards in hdf5 restart
 - [[PR 1093]](https://github.com/parthenon-hpc-lab/parthenon/pull/1093) Fix forest size for symmetry dimensions

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -132,8 +132,7 @@ class RestartReader {
   // perhaps belongs in a destructor?
   void Close();
 
-  // Does file have ghost cells?
-  int hasGhost;
+  [[nodiscard]] virtual int HasGhost() const = 0;
 };
 
 } // namespace parthenon

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -53,7 +53,7 @@ RestartReaderHDF5::RestartReaderHDF5(const char *filename) : filename_(filename)
   fh_ = H5F::FromHIDCheck(H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT));
   params_group_ = H5G::FromHIDCheck(H5Oopen(fh_, "Params", H5P_DEFAULT));
 
-  hasGhost = GetAttr<int>("Info", "IncludesGhost");
+  has_ghost = GetAttr<int>("Info", "IncludesGhost");
 #endif // ENABLE_HDF5
 }
 
@@ -224,7 +224,7 @@ void RestartReaderHDF5::ReadBlocks(const std::string &name, IndexRange range,
 
   offset[0] = static_cast<hsize_t>(range.s);
   count[0] = static_cast<hsize_t>(range.e - range.s + 1);
-  const IndexDomain domain = hasGhost ? IndexDomain::entire : IndexDomain::interior;
+  const IndexDomain domain = has_ghost != 0 ? IndexDomain::entire : IndexDomain::interior;
 
   // Currently supports versions 3 and 4.
   if (file_output_format_version >= HDF5::OUTPUT_VERSION_FORMAT - 1) {

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -245,8 +245,6 @@ void RestartReaderHDF5::ReadBlocks(const std::string &name, IndexRange range,
                            "Buffer (size " + std::to_string(dataVec.size()) +
                                ") is too small for dataset " + name + " (size " +
                                std::to_string(total_count) + ")");
-  PARTHENON_HDF5_CHECK(
-      H5Sselect_hyperslab(hdl.dataspace, H5S_SELECT_SET, offset, NULL, count, NULL));
 
   const H5S memspace = H5S::FromHIDCheck(H5Screate_simple(total_dim, count, NULL));
   PARTHENON_HDF5_CHECK(

--- a/src/outputs/restart_hdf5.hpp
+++ b/src/outputs/restart_hdf5.hpp
@@ -58,6 +58,8 @@ class RestartReaderHDF5 : public RestartReader {
   // Return output format version number. Return -1 if not existent.
   [[nodiscard]] int GetOutputFormatVersion() const override;
 
+  [[nodiscard]] int HasGhost() const override { return has_ghost; };
+
  private:
 #ifdef ENABLE_HDF5
   struct DatasetHandle {
@@ -227,6 +229,9 @@ class RestartReaderHDF5 : public RestartReader {
 
  private:
   const std::string filename_;
+
+  // Does file have ghost cells?
+  int has_ghost;
 
 #ifdef ENABLE_HDF5
   // Currently all restarts are HDF5 files

--- a/src/outputs/restart_hdf5.hpp
+++ b/src/outputs/restart_hdf5.hpp
@@ -225,9 +225,6 @@ class RestartReaderHDF5 : public RestartReader {
   // perhaps belongs in a destructor?
   void Close();
 
-  // Does file have ghost cells?
-  int hasGhost;
-
  private:
   const std::string filename_;
 

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -250,7 +250,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
   // Restart packages with information for blocks in ids from the restart file
   // Assumption: blocks are contiguous in restart file, may have to revisit this.
   const IndexDomain theDomain =
-      (resfile.hasGhost ? IndexDomain::entire : IndexDomain::interior);
+      (resfile.HasGhost() != 0 ? IndexDomain::entire : IndexDomain::interior);
   // Get block list and temp array size
   auto &mb = *(rm.block_list.front());
   int nb = rm.GetNumMeshBlocksThisRank(Globals::my_rank);
@@ -365,7 +365,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
       // we update the HDF5 infrastructure!
       if (file_output_format_ver >= HDF5::OUTPUT_VERSION_FORMAT - 1) {
         OutputUtils::PackOrUnpackVar(
-            v_info, resfile.hasGhost, index,
+            v_info, resfile.HasGhost() != 0, index,
             [&](auto index, int topo, int t, int u, int v, int k, int j, int i) {
               v_h(topo, t, u, v, k, j, i) = tmp[index];
             });


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

`hasGhost` was defined both in `restart.hpp` and `restart_hdf5.hpp`
We only set the value inside the constructor of the derived class but in the parthenon manager we work with the base class.
The latter actually set the data based on bounds defined by `hasGhosts` so it made a decision based on uninitialized data.
On Frontier I could reliably reproduce the issue (both with cray and amdclang/hip compilers), whereas on other machines/compilers `hasGhosts` was set by default/accident to `0` in the base class (though also rendering reading restarts with ghosts unusable in current develop).
Instead of just removing the duplicated declaration I decided to remove public variable entirely and go with a getter function.
I also get the data type to `int` for backwards compatibility and in case we eventually decide to do sth more with this rather than a bool check.


PS: With this (hopefully) last PR, we can finally restart/do some analysis with AthenaPK in sync with Parthenon `develop` again.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
