### PR TITLE
[Breaking change][WIP] Disallow accessing mutable param by value

### DIFF
--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -82,6 +82,9 @@ class Params {
   template <typename T>
   const T &Get(const std::string &key) const {
     auto typed_ptr = GetTypedPointer_<T>(key);
+    // require that param is NOT mutable
+    PARTHENON_REQUIRE_THROWS(!static_cast<bool>(myMutable_.at(key)),
+                             "Parameter " + key + " must be NOT marked as mutable");
     return *typed_ptr->pValue;
   }
 


### PR DESCRIPTION
## PR Summary

Throw an exception if a mutable parameter is accessed by value.

This means that mutable parameters must be accessed with `StateDescriptor::MutableParam` and non-mutable parameters must be accessed with `StateDescriptor::Param`. This helps to avoid bugs in downstream application codes due to accidental use of `pkg->Param` with mutable params.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [x] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
