### PR TITLE
WIP: Bugfix: Remove `shared_ptr` cycle in `Tree`

### DIFF
--- a/src/mesh/forest/tree.hpp
+++ b/src/mesh/forest/tree.hpp
@@ -54,7 +54,8 @@ class Tree : public std::enable_shared_from_this<Tree> {
     RelativeOrientation orient;
     orient.use_offset = true;
     orient.offset = {0, 0, 0};
-    ptree->neighbors[13].insert({ptree, orient});
+    ptree->neighbors[13].push_back(
+        std::pair<std::weak_ptr<Tree>, RelativeOrientation>{ptree, orient});
     return ptree;
   }
 
@@ -117,7 +118,7 @@ class Tree : public std::enable_shared_from_this<Tree> {
   // multiple neighbors generally, we keep a map at each neighbor location from
   // the tree sptr to the relative logical coordinate orientation of the neighbor
   // block.
-  std::array<std::unordered_map<std::shared_ptr<Tree>, RelativeOrientation>, 27>
+  std::array<std::vector<std::pair<std::weak_ptr<Tree>, RelativeOrientation>>, 27>
       neighbors;
 
   std::array<BoundaryFlag, BOUNDARY_NFACES> boundary_conditions;


### PR DESCRIPTION
## PR Summary
This PR removes a memory leak caused by a closed `shared_ptr` cycle in `forest::Tree` by switching the neighbor pointers from `shared_ptr` to `weak_ptr`. This probably had limited effect since the forest is only destroyed at the very end of the process.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
