### PR TITLE
Small Bugfix: Remove `shared_ptr` cycle in `Tree`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1112]](https://github.com/parthenon-hpc-lab/parthenon/pull/1112) Remove shared_ptr cycle in forest::Tree
 - [[PR 1104]](https://github.com/parthenon-hpc-lab/parthenon/pull/1104) Fix reading restarts due to hidden ghost var
 - [[PR 1098]](https://github.com/parthenon-hpc-lab/parthenon/pull/1098) Move to symmetrized logical coordinates and fix SMR bug
 - [[PR 1095]](https://github.com/parthenon-hpc-lab/parthenon/pull/1095) Add missing include guards in hdf5 restart

--- a/src/mesh/forest/tree.cpp
+++ b/src/mesh/forest/tree.cpp
@@ -323,7 +323,7 @@ Tree::GetBlockBCs(const LogicalLocation &loc) const {
 void Tree::AddNeighborTree(CellCentOffsets offset, std::shared_ptr<Tree> neighbor_tree,
                            RelativeOrientation orient, const bool periodic) {
   int location_idx = offset.GetIdx();
-  neighbors[location_idx].insert({neighbor_tree, orient});
+  neighbors[location_idx].insert({neighbor_tree.get(), orient});
   BoundaryFace fidx = offset.Face();
 
   if (fidx >= 0)

--- a/src/mesh/forest/tree.hpp
+++ b/src/mesh/forest/tree.hpp
@@ -54,7 +54,7 @@ class Tree : public std::enable_shared_from_this<Tree> {
     RelativeOrientation orient;
     orient.use_offset = true;
     orient.offset = {0, 0, 0};
-    ptree->neighbors[13].insert({ptree, orient});
+    ptree->neighbors[13].insert({ptree.get(), orient});
     return ptree;
   }
 
@@ -117,8 +117,7 @@ class Tree : public std::enable_shared_from_this<Tree> {
   // multiple neighbors generally, we keep a map at each neighbor location from
   // the tree sptr to the relative logical coordinate orientation of the neighbor
   // block.
-  std::array<std::unordered_map<std::shared_ptr<Tree>, RelativeOrientation>, 27>
-      neighbors;
+  std::array<std::unordered_map<Tree *, RelativeOrientation>, 27> neighbors;
 
   std::array<BoundaryFlag, BOUNDARY_NFACES> boundary_conditions;
 


### PR DESCRIPTION
## PR Summary

This PR removes a memory leak caused by a closed `shared_ptr` cycle in `forest::Tree` by switching the neighbor pointers from `shared_ptr` to non-owning raw pointers. This probably had limited effect since the forest is only destroyed at the very end of the process. I found this using `-DENABLE_ASAN=On`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
