### PR TITLE
[WIP] Take ownership of `Param`s

### DIFF
--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -49,28 +49,28 @@ class Params {
   ///
   /// Throws an error if the key is already in use
   template <typename T>
-  void Add(const std::string &key, T &value, Mutability mutability) {
+  void Add(const std::string &key, T &&object, Mutability mutability) {
     PARTHENON_REQUIRE_THROWS(!(hasKey(key)), "Key " + key + " already exists");
-    myParams_[key] = std::unique_ptr<Params::base_t>(std::move(value));
-    myTypes_.emplace(make_pair(key, std::type_index(typeid(value))));
+    myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(std::move(object)));
+    myTypes_.emplace(make_pair(key, std::type_index(typeid(object))));
     myMutable_[key] = mutability;
   }
   template <typename T>
-  void Add(const std::string &key, T &&value, bool is_mutable = false) {
-    Add(key, std::forward<T>(value), static_cast<Mutability>(is_mutable));
+  void Add(const std::string &key, T &&object, bool is_mutable = false) {
+    Add(key, std::forward<T>(object), static_cast<Mutability>(is_mutable));
   }
 
   /// Updates existing object
   /// Throws an error if the key is not already in use
   template <typename T>
-  void Update(const std::string &key, T &value) {
+  void Update(const std::string &key, T &&object) {
     PARTHENON_REQUIRE_THROWS((hasKey(key)), "Key " + key + "missing.");
     // immutable casts to false all others cast to true
     PARTHENON_REQUIRE_THROWS(static_cast<bool>(myMutable_.at(key)),
                              "Parameter " + key + " must be marked as mutable");
     PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
                              "WRONG TYPE FOR KEY '" + key + "'");
-    myParams_[key] = std::unique_ptr<Params::base_t>(std::move(value));
+    myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(std::move(object)));
   }
 
   void reset() {
@@ -197,7 +197,7 @@ class Params {
   template <typename T>
   struct object_t : base_t {
     std::unique_ptr<T> pValue;
-    explicit object_t(T val) : pValue(std::make_unique<T>(val)) {}
+    explicit object_t(T &&obj) : pValue(std::make_unique<T>(obj)) {}
     ~object_t() = default;
     const void *address() { return reinterpret_cast<void *>(pValue.get()); }
   };

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -49,28 +49,28 @@ class Params {
   ///
   /// Throws an error if the key is already in use
   template <typename T>
-  void Add(const std::string &key, T value, Mutability mutability) {
+  void Add(const std::string &key, T &value, Mutability mutability) {
     PARTHENON_REQUIRE_THROWS(!(hasKey(key)), "Key " + key + " already exists");
-    myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
+    myParams_[key] = std::unique_ptr<Params::base_t>(std::move(value));
     myTypes_.emplace(make_pair(key, std::type_index(typeid(value))));
     myMutable_[key] = mutability;
   }
   template <typename T>
-  void Add(const std::string &key, T value, bool is_mutable = false) {
-    Add(key, value, static_cast<Mutability>(is_mutable));
+  void Add(const std::string &key, T &&value, bool is_mutable = false) {
+    Add(key, std::forward<T>(value), static_cast<Mutability>(is_mutable));
   }
 
   /// Updates existing object
   /// Throws an error if the key is not already in use
   template <typename T>
-  void Update(const std::string &key, T value) {
+  void Update(const std::string &key, T &value) {
     PARTHENON_REQUIRE_THROWS((hasKey(key)), "Key " + key + "missing.");
     // immutable casts to false all others cast to true
     PARTHENON_REQUIRE_THROWS(static_cast<bool>(myMutable_.at(key)),
                              "Parameter " + key + " must be marked as mutable");
     PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
                              "WRONG TYPE FOR KEY '" + key + "'");
-    myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
+    myParams_[key] = std::unique_ptr<Params::base_t>(std::move(value));
   }
 
   void reset() {

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -123,18 +123,18 @@ class StateDescriptor {
   }
 
   template <typename T>
-  void AddParam(const std::string &key, T value, Params::Mutability mutability) {
-    params_.Add<T>(key, value, mutability);
+  void AddParam(const std::string &key, T &&object, Params::Mutability mutability) {
+    params_.Add<T>(key, std::forward<T>(object), mutability);
   }
 
   template <typename T>
-  void AddParam(const std::string &key, T value, bool is_mutable = false) {
-    params_.Add<T>(key, value, is_mutable);
+  void AddParam(const std::string &key, T &&object, bool is_mutable = false) {
+    params_.Add<T>(key, std::forward<T>(object), is_mutable);
   }
 
   template <typename T>
-  void UpdateParam(const std::string &key, T value) {
-    params_.Update<T>(key, value);
+  void UpdateParam(const std::string &key, T &&object) {
+    params_.Update<T>(key, std::forward<T>(object));
   }
 
   template <typename T>
@@ -150,8 +150,8 @@ class StateDescriptor {
   // Set (if not set) and get simultaneously.
   // infers type correctly.
   template <typename T>
-  const T &Param(const std::string &key, T value) const {
-    return params_.Get(key, value);
+  const T &Param(const std::string &key, T &&object) const {
+    return params_.Get(key, std::forward<T>(object));
   }
 
   const std::type_index &ParamType(const std::string &key) const {


### PR DESCRIPTION
## PR Summary

When `Param`s are created or updated, it takes ownership of the object passed with `std::move`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [x] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
