### PR TITLE
Small: Fix NumPy 2.0 test script breakage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 - [[PR 1031]](https://github.com/parthenon-hpc-lab/parthenon/pull/1031) Fix bug in non-cell centered AMR
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1116]](https://github.com/parthenon-hpc-lab/parthenon/pull/1116) Fix NumPy 2.0 test script breakage
 - [[PR 1055]](https://github.com/parthenon-hpc-lab/parthenon/pull/1055) Refactor mesh constructors
 - [[PR 1066]](https://github.com/parthenon-hpc-lab/parthenon/pull/1066) Re-introduce default loop patterns and exec spaces
 - [[PR 1064]](https://github.com/parthenon-hpc-lab/parthenon/pull/1064) Forbid erroneous edge case when adding MeshData on a partition

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -648,11 +648,11 @@ class phdf:
         if flatten:
             nblocks = vShape[0]
             if self.varTopology[variable] == "None":
-                remaining_size = np.product(vShape[1:])
+                remaining_size = np.prod(vShape[1:])
                 return self.varData[variable].reshape(nblocks, remaining_size)
             else:
                 preserved_shape = vShape[:-3]
-                remaining_size = np.product(vShape[-3:])
+                remaining_size = np.prod(vShape[-3:])
                 return self.varData[variable].reshape(*preserved_shape, remaining_size)
 
         if self.IncludesGhost and interior:


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This fixes the test script breakage due to NumPy 2.0 API changes (https://numpy.org/devdocs/numpy_2_0_migration_guide.html#numpy-2-0-migration-guide)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
