### PR TITLE
Refactor `MeshBlock` Partitioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1119]](https://github.com/parthenon-hpc-lab/parthenon/pull/1119) Formalize MeshData partitioning.
 - [[PR 1099]](https://github.com/parthenon-hpc-lab/parthenon/pull/1099) Functionality for outputting task graphs in GraphViz format.
 - [[PR 1091]](https://github.com/parthenon-hpc-lab/parthenon/pull/1091) Add vector wave equation example.
 - [[PR 991]](https://github.com/parthenon-hpc-lab/parthenon/pull/991) Add fine fields.

--- a/example/advection/advection_driver.cpp
+++ b/example/advection/advection_driver.cpp
@@ -62,7 +62,7 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
   const Real dt = integrator->dt;
   const auto &stage_name = integrator->stage_name;
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   int num_partitions = partitions.size();
   // note that task within this region that contains one tasklist per pack
   // could still be executed in parallel

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -118,14 +118,15 @@ TaskCollection PiDriver::MakeTaskCollection(T &blocks) {
   using calculate_pi::ComputeArea;
   TaskCollection tc;
 
-  const int num_partitions = pmesh->DefaultNumPartitions();
+  auto partitions = pmesh->GetBlockPartitions();
+  const int num_partitions = partitions.size();
   ParArrayHost<Real> areas("areas", num_partitions);
   TaskRegion &async_region = tc.AddRegion(num_partitions);
   {
     // asynchronous region where area is computed per partition
     for (int i = 0; i < num_partitions; i++) {
       TaskID none(0);
-      auto &md = pmesh->mesh_data.GetOrAdd("base", i);
+      auto &md = pmesh->mesh_data.Add("base", partitions[i]);
       auto get_area = async_region[i].AddTask(none, ComputeArea, md, areas, i);
     }
   }

--- a/example/calculate_pi/pi_driver.cpp
+++ b/example/calculate_pi/pi_driver.cpp
@@ -118,7 +118,7 @@ TaskCollection PiDriver::MakeTaskCollection(T &blocks) {
   using calculate_pi::ComputeArea;
   TaskCollection tc;
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   const int num_partitions = partitions.size();
   ParArrayHost<Real> areas("areas", num_partitions);
   TaskRegion &async_region = tc.AddRegion(num_partitions);

--- a/example/fine_advection/advection_driver.cpp
+++ b/example/fine_advection/advection_driver.cpp
@@ -78,7 +78,7 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
   const Real beta = integrator->beta[stage - 1];
   const Real dt = integrator->dt;
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   TaskRegion &single_tasklist_per_pack_region = tc.AddRegion(partitions.size());
 
   for (int i = 0; i < partitions.size(); i++) {

--- a/example/fine_advection/advection_driver.cpp
+++ b/example/fine_advection/advection_driver.cpp
@@ -78,15 +78,15 @@ TaskCollection AdvectionDriver::MakeTaskCollection(BlockList_t &blocks, const in
   const Real beta = integrator->beta[stage - 1];
   const Real dt = integrator->dt;
 
-  const int num_partitions = pmesh->DefaultNumPartitions();
-  TaskRegion &single_tasklist_per_pack_region = tc.AddRegion(num_partitions);
+  auto partitions = pmesh->GetBlockPartitions();
+  TaskRegion &single_tasklist_per_pack_region = tc.AddRegion(partitions.size());
 
-  for (int i = 0; i < num_partitions; i++) {
+  for (int i = 0; i < partitions.size(); i++) {
     auto &tl = single_tasklist_per_pack_region[i];
-    auto &mbase = pmesh->mesh_data.GetOrAdd("base", i);
-    auto &mc0 = pmesh->mesh_data.GetOrAdd(stage_name[stage - 1], i);
-    auto &mc1 = pmesh->mesh_data.GetOrAdd(stage_name[stage], i);
-    auto &mdudt = pmesh->mesh_data.GetOrAdd("dUdt", i);
+    auto &mbase = pmesh->mesh_data.Add("base", partitions[i]);
+    auto &mc0 = pmesh->mesh_data.Add(stage_name[stage - 1], mbase);
+    auto &mc1 = pmesh->mesh_data.Add(stage_name[stage], mbase);
+    auto &mdudt = pmesh->mesh_data.Add("dUdt", mbase);
 
     auto start_send = tl.AddTask(none, parthenon::StartReceiveBoundaryBuffers, mc1);
     auto start_flxcor = tl.AddTask(none, parthenon::StartReceiveFluxCorrections, mc0);

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -288,7 +288,7 @@ TaskCollection ParticleDriver::MakeParticlesUpdateTaskCollection() const {
   TaskID none(0);
   const BlockList_t &blocks = pmesh->block_list;
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   const int num_partitions = partitions.size();
   const int num_task_lists_executed_independently = blocks.size();
 

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -288,7 +288,8 @@ TaskCollection ParticleDriver::MakeParticlesUpdateTaskCollection() const {
   TaskID none(0);
   const BlockList_t &blocks = pmesh->block_list;
 
-  const int num_partitions = pmesh->DefaultNumPartitions();
+  auto partitions = pmesh->GetBlockPartitions();
+  const int num_partitions = partitions.size();
   const int num_task_lists_executed_independently = blocks.size();
 
   TaskRegion &sync_region0 = tc.AddRegion(1);
@@ -304,7 +305,7 @@ TaskCollection ParticleDriver::MakeParticlesUpdateTaskCollection() const {
   TaskRegion &tr = tc.AddRegion(num_partitions);
   for (int i = 0; i < num_partitions; i++) {
     auto &tl = tr[i];
-    auto &base = pmesh->mesh_data.GetOrAdd("base", i);
+    auto &base = pmesh->mesh_data.Add("base", partitions[i]);
     auto transport = tl.AddTask(none, TransportParticles, base.get(), &integrator);
   }
 

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -429,7 +429,7 @@ TaskCollection ParticleDriver::MakeTaskCollection(BlockList_t &blocks, int stage
     auto advect_flux = tl.AddTask(none, tracers_example::CalculateFluxes, sc0.get());
   }
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   const int num_partitions = partitions.size();
   // note that task within this region that contains one tasklist per pack
   // could still be executed in parallel

--- a/example/particle_tracers/particle_tracers.cpp
+++ b/example/particle_tracers/particle_tracers.cpp
@@ -429,16 +429,17 @@ TaskCollection ParticleDriver::MakeTaskCollection(BlockList_t &blocks, int stage
     auto advect_flux = tl.AddTask(none, tracers_example::CalculateFluxes, sc0.get());
   }
 
-  const int num_partitions = pmesh->DefaultNumPartitions();
+  auto partitions = pmesh->GetBlockPartitions();
+  const int num_partitions = partitions.size();
   // note that task within this region that contains one tasklist per pack
   // could still be executed in parallel
   TaskRegion &single_tasklist_per_pack_region = tc.AddRegion(num_partitions);
   for (int i = 0; i < num_partitions; i++) {
     auto &tl = single_tasklist_per_pack_region[i];
-    auto &mbase = pmesh->mesh_data.GetOrAdd("base", i);
-    auto &mc0 = pmesh->mesh_data.GetOrAdd(stage_name[stage - 1], i);
-    auto &mc1 = pmesh->mesh_data.GetOrAdd(stage_name[stage], i);
-    auto &mdudt = pmesh->mesh_data.GetOrAdd("dUdt", i);
+    auto &mbase = pmesh->mesh_data.Add("base", partitions[i]);
+    auto &mc0 = pmesh->mesh_data.Add(stage_name[stage - 1], mbase);
+    auto &mc1 = pmesh->mesh_data.Add(stage_name[stage], mbase);
+    auto &mdudt = pmesh->mesh_data.Add("dUdt", mbase);
 
     const auto any = parthenon::BoundaryType::any;
 

--- a/example/poisson/poisson_driver.cpp
+++ b/example/poisson/poisson_driver.cpp
@@ -55,7 +55,7 @@ TaskCollection PoissonDriver::MakeTaskCollection(BlockList_t &blocks) {
   auto fail_flag = pkg->Param<bool>("fail_without_convergence");
   auto warn_flag = pkg->Param<bool>("warn_without_convergence");
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   const int num_partitions = partitions.size();
   TaskRegion &solver_region = tc.AddRegion(num_partitions);
 

--- a/example/poisson/poisson_driver.cpp
+++ b/example/poisson/poisson_driver.cpp
@@ -55,7 +55,8 @@ TaskCollection PoissonDriver::MakeTaskCollection(BlockList_t &blocks) {
   auto fail_flag = pkg->Param<bool>("fail_without_convergence");
   auto warn_flag = pkg->Param<bool>("warn_without_convergence");
 
-  const int num_partitions = pmesh->DefaultNumPartitions();
+  auto partitions = pmesh->GetBlockPartitions();
+  const int num_partitions = partitions.size();
   TaskRegion &solver_region = tc.AddRegion(num_partitions);
 
   // setup some reductions
@@ -72,8 +73,8 @@ TaskCollection PoissonDriver::MakeTaskCollection(BlockList_t &blocks) {
       pkg->MutableParam<AllReduce<HostArray1D<Real>>>("view_reduce");
   for (int i = 0; i < num_partitions; i++) {
     // make/get a mesh_data container for the state
-    auto &md = pmesh->mesh_data.GetOrAdd("base", i);
-    auto &mdelta = pmesh->mesh_data.GetOrAdd("delta", i);
+    auto &md = pmesh->mesh_data.Add("base", partitions[i]);
+    auto &mdelta = pmesh->mesh_data.Add("delta", md);
 
     TaskList &tl = solver_region[i];
 

--- a/example/poisson_gmg/poisson_driver.cpp
+++ b/example/poisson_gmg/poisson_driver.cpp
@@ -77,7 +77,7 @@ TaskCollection PoissonDriver::MakeTaskCollection(BlockList_t &blocks) {
       pkg->MutableParam<parthenon::solvers::BiCGSTABSolver<u, rhs, PoissonEquation>>(
           "MGBiCGSTABsolver");
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   const int num_partitions = partitions.size();
   TaskRegion &region = tc.AddRegion(num_partitions);
   for (int i = 0; i < num_partitions; ++i) {

--- a/example/poisson_gmg/poisson_driver.cpp
+++ b/example/poisson_gmg/poisson_driver.cpp
@@ -77,11 +77,12 @@ TaskCollection PoissonDriver::MakeTaskCollection(BlockList_t &blocks) {
       pkg->MutableParam<parthenon::solvers::BiCGSTABSolver<u, rhs, PoissonEquation>>(
           "MGBiCGSTABsolver");
 
-  const int num_partitions = pmesh->DefaultNumPartitions();
+  auto partitions = pmesh->GetBlockPartitions();
+  const int num_partitions = partitions.size();
   TaskRegion &region = tc.AddRegion(num_partitions);
   for (int i = 0; i < num_partitions; ++i) {
     TaskList &tl = region[i];
-    auto &md = pmesh->mesh_data.GetOrAdd("base", i);
+    auto &md = pmesh->mesh_data.Add("base", partitions[i]);
 
     // Possibly set rhs <- A.u_exact for a given u_exact so that the exact solution is
     // known when we solve A.u = rhs

--- a/example/sparse_advection/sparse_advection_driver.cpp
+++ b/example/sparse_advection/sparse_advection_driver.cpp
@@ -83,7 +83,7 @@ TaskCollection SparseAdvectionDriver::MakeTaskCollection(BlockList_t &blocks,
         tl.AddTask(none, TF(sparse_advection_package::CalculateFluxes), sc0);
   }
 
-  auto partitions = pmesh->GetBlockPartitions();
+  auto partitions = pmesh->GetDefaultBlockPartitions();
   const int num_partitions = partitions.size();
   // note that task within this region that contains one tasklist per pack
   // could still be executed in parallel

--- a/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
+++ b/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
@@ -64,7 +64,7 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
 
   // sample number of iterations task
   {
-    auto partitions = pmesh->GetBlockPartitions();
+    auto partitions = pmesh->GetDefaultBlockPartitions();
     const int num_partitions = partitions.size();
     TaskRegion &async_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
@@ -115,7 +115,7 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
   {
     const Real beta = integrator->beta[stage - 1];
     const Real dt = integrator->dt;
-    auto partitions = pmesh->GetBlockPartitions();
+    auto partitions = pmesh->GetDefaultBlockPartitions();
     const int num_partitions = partitions.size();
 
     // note that task within this region that contains one tasklist per pack

--- a/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
+++ b/example/stochastic_subgrid/stochastic_subgrid_driver.cpp
@@ -64,10 +64,11 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
 
   // sample number of iterations task
   {
-    const int num_partitions = pmesh->DefaultNumPartitions();
+    auto partitions = pmesh->GetBlockPartitions();
+    const int num_partitions = partitions.size();
     TaskRegion &async_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
-      auto &md = pmesh->mesh_data.GetOrAdd("base", i);
+      auto &md = pmesh->mesh_data.Add("base", partitions[i]);
       async_region[i].AddTask(none, ComputeNumIter, md, pmesh->packages);
     }
   }
@@ -114,17 +115,18 @@ TaskCollection StochasticSubgridDriver::MakeTaskCollection(BlockList_t &blocks,
   {
     const Real beta = integrator->beta[stage - 1];
     const Real dt = integrator->dt;
-    const int num_partitions = pmesh->DefaultNumPartitions();
+    auto partitions = pmesh->GetBlockPartitions();
+    const int num_partitions = partitions.size();
 
     // note that task within this region that contains one tasklist per pack
     // could still be executed in parallel
     TaskRegion &single_tasklist_per_pack_region = tc.AddRegion(num_partitions);
     for (int i = 0; i < num_partitions; i++) {
       auto &tl = single_tasklist_per_pack_region[i];
-      auto &mbase = pmesh->mesh_data.GetOrAdd("base", i);
-      auto &mc0 = pmesh->mesh_data.GetOrAdd(stage_name[stage - 1], i);
-      auto &mc1 = pmesh->mesh_data.GetOrAdd(stage_name[stage], i);
-      auto &mdudt = pmesh->mesh_data.GetOrAdd("dUdt", i);
+      auto &mbase = pmesh->mesh_data.Add("base", partitions[i]);
+      auto &mc0 = pmesh->mesh_data.Add(stage_name[stage - 1], mbase);
+      auto &mc1 = pmesh->mesh_data.Add(stage_name[stage], mbase);
+      auto &mdudt = pmesh->mesh_data.Add("dUdt", mbase);
 
       const auto any = parthenon::BoundaryType::any;
 

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -77,7 +77,7 @@ enum class BoundaryType : int {
   gmg_prolongate_recv
 };
 
-enum class GridType { none, leaf, two_level_composite, single_level_with_internal };
+enum class GridType : int { none, leaf, two_level_composite, single_level_with_internal };
 struct GridIdentifier {
   GridType type = GridType::none;
   int logical_level = 0;
@@ -87,6 +87,11 @@ struct GridIdentifier {
     return GridIdentifier{GridType::two_level_composite, level};
   }
 };
+// Add a comparator so we can store in std::map
+inline bool operator<(const GridIdentifier &lhs, const GridIdentifier &rhs) {
+  if (lhs.type != rhs.type) return lhs.type < rhs.type;
+  return lhs.logical_level < rhs.logical_level;
+}
 
 constexpr bool IsSender(BoundaryType btype) {
   if (btype == BoundaryType::flxcor_recv) return false;

--- a/src/bvals/comms/build_boundary_buffers.cpp
+++ b/src/bvals/comms/build_boundary_buffers.cpp
@@ -107,8 +107,6 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
 }
 } // namespace
 
-// pmesh->boundary_comm_map.clear() after every remesh
-// in InitializeBlockTimeStepsAndBoundaries()
 TaskStatus BuildBoundaryBuffers(std::shared_ptr<MeshData<Real>> &md) {
   PARTHENON_INSTRUMENT
   Mesh *pmesh = md->GetMeshPointer();

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -105,11 +105,10 @@ void InitializeBufferCache(std::shared_ptr<MeshData<Real>> &md, COMM_MAP *comm_m
   std::for_each(std::begin(key_order), std::end(key_order), [&](auto &t) {
     if (comm_map->count(std::get<2>(t)) == 0) {
       auto key = std::get<2>(t);
-      PARTHENON_FAIL(std::string("Asking for buffer that doesn't exist")
-                     + " (sender: " + std::to_string(std::get<0>(key)) 
-                     + ", receiver: " + std::to_string(std::get<1>(key))
-                     + ", var: " + std::get<2>(key)
-                     + ", location: " + std::to_string(std::get<3>(key)) + ")");
+      PARTHENON_FAIL(std::string("Asking for buffer that doesn't exist") +
+                     " (sender: " + std::to_string(std::get<0>(key)) + ", receiver: " +
+                     std::to_string(std::get<1>(key)) + ", var: " + std::get<2>(key) +
+                     ", location: " + std::to_string(std::get<3>(key)) + ")");
     }
     pcache->buf_vec.push_back(&((*comm_map)[std::get<2>(t)]));
     (pcache->idx_vec)[std::get<1>(t)] = buff_idx++;

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -104,7 +104,12 @@ void InitializeBufferCache(std::shared_ptr<MeshData<Real>> &md, COMM_MAP *comm_m
   pcache->idx_vec = std::vector<std::size_t>(key_order.size());
   std::for_each(std::begin(key_order), std::end(key_order), [&](auto &t) {
     if (comm_map->count(std::get<2>(t)) == 0) {
-      PARTHENON_FAIL("Asking for buffer that doesn't exist");
+      auto key = std::get<2>(t);
+      PARTHENON_FAIL(std::string("Asking for buffer that doesn't exist")
+                     + " (sender: " + std::to_string(std::get<0>(key)) 
+                     + ", receiver: " + std::to_string(std::get<1>(key))
+                     + ", var: " + std::get<2>(key)
+                     + ", location: " + std::to_string(std::get<3>(key)) + ")");
     }
     pcache->buf_vec.push_back(&((*comm_map)[std::get<2>(t)]));
     (pcache->idx_vec)[std::get<1>(t)] = buff_idx++;

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -196,7 +196,7 @@ void EvolutionDriver::InitializeBlockTimeSteps() {
   // calculate the first time step using Mesh function
   for (auto &partition : pmesh->GetBlockPartitions()) {
     auto &mbase = pmesh->mesh_data.Add("base", partition);
-    Update::EstimateTimestep(mbase.get())
+    Update::EstimateTimestep(mbase.get());
   }
 }
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -194,7 +194,7 @@ void EvolutionDriver::InitializeBlockTimeSteps() {
     Update::EstimateTimestep(pmb->meshblock_data.Get().get());
   }
   // calculate the first time step using Mesh function
-  for (auto &partition : pmesh->GetBlockPartitions()) {
+  for (auto &partition : pmesh->GetDefaultBlockPartitions()) {
     auto &mbase = pmesh->mesh_data.Add("base", partition);
     Update::EstimateTimestep(mbase.get());
   }

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -90,7 +90,7 @@ class EvolutionDriver : public Driver {
   void PostExecute(DriverStatus status) override;
 
  private:
-  void InitializeBlockTimeStepsAndBoundaries();
+  void InitializeBlockTimeSteps();
 };
 
 namespace DriverUtils {

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -23,7 +23,8 @@
 namespace parthenon {
 
 template <typename T>
-std::string DataCollection<T>::GetKey(const std::string &stage_label, const std::shared_ptr<BlockListPartition> &in) { 
+std::string DataCollection<T>::GetKey(const std::string &stage_label,
+                                      const std::shared_ptr<BlockListPartition> &in) {
   auto key = stage_label;
   for (const auto &pmb : in->block_list)
     key += "_" + std::to_string(pmb->gid);
@@ -31,7 +32,8 @@ std::string DataCollection<T>::GetKey(const std::string &stage_label, const std:
 }
 
 template <typename T>
-std::string DataCollection<T>::GetKey(const std::string &stage_label, const std::shared_ptr<MeshData<Real>> &in) { 
+std::string DataCollection<T>::GetKey(const std::string &stage_label,
+                                      const std::shared_ptr<MeshData<Real>> &in) {
   auto key = stage_label;
   for (const auto &pmbd : in->GetAllBlockData())
     key += "_" + std::to_string(pmbd->GetBlockPointer()->gid);

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -26,6 +26,8 @@ template <typename T>
 std::string DataCollection<T>::GetKey(const std::string &stage_label,
                                       const std::shared_ptr<BlockListPartition> &in) {
   auto key = stage_label;
+  if (in->grid.type == GridType::two_level_composite)
+    key = key + "_gmg-" + std::to_string(in->grid.logical_level);
   for (const auto &pmb : in->block_list)
     key += "_" + std::to_string(pmb->gid);
   return key;
@@ -35,6 +37,8 @@ template <typename T>
 std::string DataCollection<T>::GetKey(const std::string &stage_label,
                                       const std::shared_ptr<MeshData<Real>> &in) {
   auto key = stage_label;
+  if (in->grid.type == GridType::two_level_composite)
+    key = key + "_gmg-" + std::to_string(in->grid.logical_level);
   for (const auto &pmbd : in->GetAllBlockData())
     key += "_" + std::to_string(pmbd->GetBlockPointer()->gid);
   return key;

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -45,15 +45,16 @@ std::shared_ptr<MeshData<Real>> &
 DataCollection<MeshData<Real>>::GetOrAdd(const std::string &mbd_label,
                                          const int &partition_id) {
   return Add(mbd_label,
-             pmy_mesh_->GetBlockPartitions(GridIdentifier::leaf())[partition_id]);
+             pmy_mesh_->GetDefaultBlockPartitions(GridIdentifier::leaf())[partition_id]);
 }
 
 template <>
 std::shared_ptr<MeshData<Real>> &
 DataCollection<MeshData<Real>>::GetOrAdd(int gmg_level, const std::string &mbd_label,
                                          const int &partition_id) {
-  return Add(mbd_label, pmy_mesh_->GetBlockPartitions(GridIdentifier::two_level_composite(
-                            gmg_level))[partition_id]);
+  return Add(mbd_label,
+             pmy_mesh_->GetDefaultBlockPartitions(
+                 GridIdentifier::two_level_composite(gmg_level))[partition_id]);
 }
 
 template class DataCollection<MeshData<Real>>;

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -34,41 +34,16 @@ std::shared_ptr<T> &DataCollection<T>::Add(const std::string &label) {
 
 template <>
 std::shared_ptr<MeshData<Real>> &
-DataCollection<MeshData<Real>>::GetOrAdd_impl(const std::string &mbd_label,
-                                              const int &partition_id,
-                                              const std::optional<int> gmg_level) {
-  std::string label = GetKey(mbd_label, partition_id, gmg_level);
-  auto it = containers_.find(label);
-  if (it == containers_.end()) {
-    // TODO(someone) add caching of partitions to Mesh at some point
-    const int pack_size = pmy_mesh_->DefaultPackSize();
-    auto &block_list =
-        gmg_level ? pmy_mesh_->gmg_block_lists[*gmg_level] : pmy_mesh_->block_list;
-    auto partitions = partition::ToSizeN(block_list, pack_size);
-    // Account for possibly empty block_list
-    if (partitions.size() == 0) partitions = std::vector<BlockList_t>(1);
-    for (auto i = 0; i < partitions.size(); i++) {
-      std::string md_label = GetKey(mbd_label, partition_id, gmg_level);
-      containers_[md_label] = std::make_shared<MeshData<Real>>(mbd_label);
-      containers_[md_label]->Initialize(partitions[i], pmy_mesh_, gmg_level);
-      containers_[md_label]->partition = i;
-    }
-  }
-  return containers_[label];
-}
-
-template <>
-std::shared_ptr<MeshData<Real>> &
 DataCollection<MeshData<Real>>::GetOrAdd(const std::string &mbd_label,
                                          const int &partition_id) {
-  return GetOrAdd_impl(mbd_label, partition_id, {});
+  return Add(mbd_label, pmy_mesh_->GetBlockPartitions(GridIdentifier::leaf())[partition_id]);
 }
 
 template <>
 std::shared_ptr<MeshData<Real>> &
 DataCollection<MeshData<Real>>::GetOrAdd(int gmg_level, const std::string &mbd_label,
                                          const int &partition_id) {
-  return GetOrAdd_impl(mbd_label, partition_id, gmg_level);
+  return Add(mbd_label, pmy_mesh_->GetBlockPartitions(GridIdentifier::two_level_composite(gmg_level))[partition_id]);
 }
 
 template class DataCollection<MeshData<Real>>;

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -36,14 +36,16 @@ template <>
 std::shared_ptr<MeshData<Real>> &
 DataCollection<MeshData<Real>>::GetOrAdd(const std::string &mbd_label,
                                          const int &partition_id) {
-  return Add(mbd_label, pmy_mesh_->GetBlockPartitions(GridIdentifier::leaf())[partition_id]);
+  return Add(mbd_label,
+             pmy_mesh_->GetBlockPartitions(GridIdentifier::leaf())[partition_id]);
 }
 
 template <>
 std::shared_ptr<MeshData<Real>> &
 DataCollection<MeshData<Real>>::GetOrAdd(int gmg_level, const std::string &mbd_label,
                                          const int &partition_id) {
-  return Add(mbd_label, pmy_mesh_->GetBlockPartitions(GridIdentifier::two_level_composite(gmg_level))[partition_id]);
+  return Add(mbd_label, pmy_mesh_->GetBlockPartitions(GridIdentifier::two_level_composite(
+                            gmg_level))[partition_id]);
 }
 
 template class DataCollection<MeshData<Real>>;

--- a/src/interface/data_collection.cpp
+++ b/src/interface/data_collection.cpp
@@ -17,19 +17,25 @@
 #include "interface/mesh_data.hpp"
 #include "interface/meshblock_data.hpp"
 #include "mesh/mesh.hpp"
+#include "mesh/meshblock.hpp"
 #include "utils/partition_stl_containers.hpp"
 
 namespace parthenon {
 
 template <typename T>
-std::shared_ptr<T> &DataCollection<T>::Add(const std::string &label) {
-  // error check for duplicate names
-  auto it = containers_.find(label);
-  if (it != containers_.end()) {
-    return it->second;
-  }
-  containers_[label] = std::make_shared<T>();
-  return containers_[label];
+std::string DataCollection<T>::GetKey(const std::string &stage_label, const std::shared_ptr<BlockListPartition> &in) { 
+  auto key = stage_label;
+  for (const auto &pmb : in->block_list)
+    key += "_" + std::to_string(pmb->gid);
+  return key;
+}
+
+template <typename T>
+std::string DataCollection<T>::GetKey(const std::string &stage_label, const std::shared_ptr<MeshData<Real>> &in) { 
+  auto key = stage_label;
+  for (const auto &pmbd : in->GetAllBlockData())
+    key += "_" + std::to_string(pmbd->GetBlockPointer()->gid);
+  return key;
 }
 
 template <>

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -116,8 +116,10 @@ class DataCollection {
   }
 
  private:
-  std::string GetKey(const std::string &stage_label, const std::shared_ptr<BlockListPartition> &in); 
-  std::string GetKey(const std::string &stage_label, const std::shared_ptr<MeshData<Real>> &in);
+  std::string GetKey(const std::string &stage_label,
+                     const std::shared_ptr<BlockListPartition> &in);
+  std::string GetKey(const std::string &stage_label,
+                     const std::shared_ptr<MeshData<Real>> &in);
   template <class U>
   std::string GetKey(const std::string &stage_label, const std::shared_ptr<U> &in) {
     return stage_label;

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -87,13 +87,14 @@ class DataCollection {
   auto &Stages() { return containers_; }
   const auto &Stages() const { return containers_; }
 
-  std::shared_ptr<T> &Get(const std::string &label = "base") {
+  std::shared_ptr<T> &Get(const std::string &label) {
     auto it = containers_.find(label);
     if (it == containers_.end()) {
       throw std::runtime_error("Container " + label + " does not exist in collection.");
     }
     return it->second;
   }
+  std::shared_ptr<T> &Get() { return Get("base"); }
   const std::shared_ptr<T> &Get() const { return Get("base"); }
 
   void Set(const std::string &name, std::shared_ptr<T> &d) { containers_[name] = d; }

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -95,7 +95,7 @@ class DataCollection {
     return it->second;
   }
   std::shared_ptr<T> &Get() { return Get("base"); }
-  const std::shared_ptr<T> &Get() const { return Get("base"); }
+  const std::shared_ptr<T> &Get() const { return containers_.at("base"); }
 
   void Set(const std::string &name, std::shared_ptr<T> &d) { containers_[name] = d; }
 

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -94,6 +94,7 @@ class DataCollection {
     }
     return it->second;
   }
+  const std::shared_ptr<T> &Get() const { return Get("base"); }
 
   void Set(const std::string &name, std::shared_ptr<T> &d) { containers_[name] = d; }
 
@@ -115,17 +116,11 @@ class DataCollection {
   }
 
  private:
+  std::string GetKey(const std::string &stage_label, const std::shared_ptr<BlockListPartition> &in); 
+  std::string GetKey(const std::string &stage_label, const std::shared_ptr<MeshData<Real>> &in);
   template <class U>
   std::string GetKey(const std::string &stage_label, const std::shared_ptr<U> &in) {
-    if constexpr (std::is_same_v<U, MeshData<Real>> ||
-                  std::is_same_v<U, BlockListPartition>) {
-      std::string key = stage_label + "_part-" + std::to_string(in->partition);
-      if (in->grid.type == GridType::two_level_composite)
-        key = key + "_gmg-" + std::to_string(in->grid.logical_level);
-      return key;
-    } else {
-      return stage_label;
-    }
+    return stage_label;
   }
 
   Mesh *pmy_mesh_;

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -110,7 +110,8 @@ class DataCollection {
   void PurgeNonBase() {
     auto c = containers_.begin();
     while (c != containers_.end()) {
-      if (c->first != "base") {
+      // Remove anything that doesn't contain the label base
+      if (c->first.find("base") == std::string::npos) {
         c = containers_.erase(c);
       } else {
         ++c;

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -107,8 +107,7 @@ class DataCollection {
   void PurgeNonBase() {
     auto c = containers_.begin();
     while (c != containers_.end()) {
-      // Remove anything that doesn't contain the label base
-      if (c->first.find("base") == std::string::npos) {
+      if (c->first != "base") {
         c = containers_.erase(c);
       } else {
         ++c;

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -83,16 +83,11 @@ class DataCollection {
                                  const std::vector<ID_t> &fields = {}) {
     return Add(label, src, fields, true);
   }
-  // TODO(LFR): Is this method used anywhere? Should insertion of empty containers be
-  // allowed?
-  std::shared_ptr<T> &Add(const std::string &label);
 
   auto &Stages() { return containers_; }
   const auto &Stages() const { return containers_; }
 
-  std::shared_ptr<T> &Get() { return containers_.at("base"); }
-  const std::shared_ptr<T> &Get() const { return containers_.at("base"); }
-  std::shared_ptr<T> &Get(const std::string &label) {
+  std::shared_ptr<T> &Get(const std::string &label = "base") {
     auto it = containers_.find(label);
     if (it == containers_.end()) {
       throw std::runtime_error("Container " + label + " does not exist in collection.");

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -83,7 +83,8 @@ class DataCollection {
                                  const std::vector<ID_t> &fields = {}) {
     return Add(label, src, fields, true);
   }
-  // TODO(LFR): Is this method used anywhere? Should insertion of empty containers be allowed?
+  // TODO(LFR): Is this method used anywhere? Should insertion of empty containers be
+  // allowed?
   std::shared_ptr<T> &Add(const std::string &label);
 
   auto &Stages() { return containers_; }
@@ -100,7 +101,7 @@ class DataCollection {
   }
 
   void Set(const std::string &name, std::shared_ptr<T> &d) { containers_[name] = d; }
-  
+
   // Legacy methods that are specific to MeshData
   std::shared_ptr<T> &GetOrAdd(const std::string &mbd_label, const int &partition_id);
   std::shared_ptr<T> &GetOrAdd(int gmg_level, const std::string &mbd_label,
@@ -120,7 +121,8 @@ class DataCollection {
  private:
   template <class U>
   std::string GetKey(const std::string &stage_label, const std::shared_ptr<U> &in) {
-    if constexpr (std::is_same_v<U, MeshData<Real>> || std::is_same_v<U, BlockListPartition>) {
+    if constexpr (std::is_same_v<U, MeshData<Real>> ||
+                  std::is_same_v<U, BlockListPartition>) {
       std::string key = stage_label + "_part-" + std::to_string(in->partition);
       if (in->grid.type == GridType::two_level_composite)
         key = key + "_gmg-" + std::to_string(in->grid.logical_level);

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -32,10 +32,10 @@ void MeshData<T>::Initialize(BlockList_t blocks, Mesh *pmesh,
   }
 }
 
-// This method is basically here to get around the forward 
+// This method is basically here to get around the forward
 // declaration of Mesh in the mesh_data.hpp
 template <typename T>
-void MeshData<T>::SetMeshProperties(Mesh *pmesh) { 
+void MeshData<T>::SetMeshProperties(Mesh *pmesh) {
   pmy_mesh_ = pmesh;
   ndim_ = pmesh == nullptr ? 0 : pmesh->ndim;
 }

--- a/src/interface/mesh_data.cpp
+++ b/src/interface/mesh_data.cpp
@@ -17,12 +17,11 @@
 namespace parthenon {
 
 template <typename T>
-void MeshData<T>::Initialize(BlockList_t blocks, Mesh *pmesh, int ndim,
+void MeshData<T>::Initialize(BlockList_t blocks, Mesh *pmesh,
                              std::optional<int> gmg_level) {
   const int nblocks = blocks.size();
-  ndim_ = ndim;
   block_data_.resize(nblocks);
-  SetMeshPointer(pmesh);
+  SetMeshProperties(pmesh);
   for (int i = 0; i < nblocks; i++) {
     block_data_[i] = blocks[i]->meshblock_data.Add(stage_name_, blocks[i]);
   }
@@ -33,19 +32,12 @@ void MeshData<T>::Initialize(BlockList_t blocks, Mesh *pmesh, int ndim,
   }
 }
 
+// This method is basically here to get around the forward 
+// declaration of Mesh in the mesh_data.hpp
 template <typename T>
-void MeshData<T>::Initialize(BlockList_t blocks, Mesh *pmesh,
-                             std::optional<int> gmg_level) {
-  int ndim;
-  if (pmesh != nullptr) {
-    ndim = pmesh->ndim;
-  }
-  Initialize(blocks, pmesh, ndim, gmg_level);
-}
-
-template <typename T>
-bool MeshData<T>::BlockDataIsWholeRank_() const {
-  return block_data_.size() == (pmy_mesh_->block_list).size();
+void MeshData<T>::SetMeshProperties(Mesh *pmesh) { 
+  pmy_mesh_ = pmesh;
+  ndim_ = pmesh == nullptr ? 0 : pmesh->ndim;
 }
 
 template class MeshData<Real>;

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -250,7 +250,7 @@ class MeshData {
         shallow == false,
         "Can't shallow copy when the source is not another MeshData object.");
     SetMeshProperties(part->pmesh);
-    auto &bl = part->block_list; 
+    auto &bl = part->block_list;
     block_data_.resize(bl.size());
     for (int i = 0; i < bl.size(); ++i)
       block_data_[i] = bl[i]->meshblock_data.Add(stage_name_, bl[i], vars);

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -254,8 +254,9 @@ class MeshData {
     if (part->grid.type == GridType::leaf) {
       Initialize(part->block_list, part->pmesh, {});
     } else {
-      Initialize(part->block_list, part->pmesh, part->grid.logical_level);
+      Initialize(part->block_list, part->pmesh, std::optional<int>{part->grid.logical_level});
     }
+    partition = part->partition;
   }
 
   void Initialize(BlockList_t blocks, Mesh *pmesh, int ndim,
@@ -281,6 +282,7 @@ class MeshData {
     // modifying DataCollection::GetOrAdd. In the future we should
     // make that "just work (tm)."
     grid = src->grid;
+    partition = src->partition;
     // PARTHENON_REQUIRE((grid.type == GridType::two_level_composite) ||
     //                       src->BlockDataIsWholeRank_(),
     //                   "Add may only be called on all blocks on a rank");

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -287,6 +287,11 @@ class MeshData {
     assert(n >= 0 && n < block_data_.size());
     return block_data_[n];
   }
+  
+  const auto &GetAllBlockData() const {
+    return block_data_;
+  }
+
 
   void SetAllVariablesToInitialized() {
     std::for_each(block_data_.begin(), block_data_.end(),

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -258,7 +258,6 @@ class MeshData {
     partition = part->partition;
   }
 
-
   template <typename ID_t>
   void Initialize(std::shared_ptr<MeshData<T>> src, const std::vector<ID_t> &vars,
                   const bool shallow) {
@@ -276,7 +275,7 @@ class MeshData {
     grid = src->grid;
     partition = src->partition;
   }
-  
+
   void Initialize(BlockList_t blocks, Mesh *pmesh, std::optional<int> gmg_level = {});
 
   const std::shared_ptr<MeshBlockData<T>> &GetBlockData(int n) const {

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -258,7 +258,6 @@ class MeshData {
     partition = part->partition;
   }
 
-  void Initialize(BlockList_t blocks, Mesh *pmesh, std::optional<int> gmg_level = {});
 
   template <typename ID_t>
   void Initialize(std::shared_ptr<MeshData<T>> src, const std::vector<ID_t> &vars,
@@ -277,6 +276,8 @@ class MeshData {
     grid = src->grid;
     partition = src->partition;
   }
+  
+  void Initialize(BlockList_t blocks, Mesh *pmesh, std::optional<int> gmg_level = {});
 
   const std::shared_ptr<MeshBlockData<T>> &GetBlockData(int n) const {
     assert(n >= 0 && n < block_data_.size());

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -243,6 +243,19 @@ class MeshData {
     }
   }
 
+  template <typename ID_t> 
+  void Initialize(const std::shared_ptr<BlockListPartition> &part,
+                  const std::vector<ID_t> &vars,
+                  const bool shallow) { 
+    PARTHENON_REQUIRE(shallow == false, "Can't shallow copy when the source is not another MeshData object.");
+    PARTHENON_REQUIRE(vars.size() == 0, "Non-copy initialization not implemented for variable subsets."); 
+    if (part->grid.type == GridType::leaf) {
+      Initialize(part->block_list, part->pmesh, {});
+    } else {
+      Initialize(part->block_list, part->pmesh, part->grid.logical_level); 
+    }
+  }
+
   void Initialize(BlockList_t blocks, Mesh *pmesh, int ndim,
                   std::optional<int> gmg_level = {});
   void Initialize(BlockList_t blocks, Mesh *pmesh, std::optional<int> gmg_level = {});
@@ -266,9 +279,9 @@ class MeshData {
     // modifying DataCollection::GetOrAdd. In the future we should
     // make that "just work (tm)."
     grid = src->grid;
-    PARTHENON_REQUIRE((grid.type == GridType::two_level_composite) ||
-                          src->BlockDataIsWholeRank_(),
-                      "Add may only be called on all blocks on a rank");
+    //PARTHENON_REQUIRE((grid.type == GridType::two_level_composite) ||
+    //                      src->BlockDataIsWholeRank_(),
+    //                  "Add may only be called on all blocks on a rank");
     for (int i = 0; i < nblocks; ++i) {
       auto pmbd = src->GetBlockData(i);
       block_data_[i] = pmbd->GetBlockSharedPointer()->meshblock_data.Add(

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -243,16 +243,18 @@ class MeshData {
     }
   }
 
-  template <typename ID_t> 
+  template <typename ID_t>
   void Initialize(const std::shared_ptr<BlockListPartition> &part,
-                  const std::vector<ID_t> &vars,
-                  const bool shallow) { 
-    PARTHENON_REQUIRE(shallow == false, "Can't shallow copy when the source is not another MeshData object.");
-    PARTHENON_REQUIRE(vars.size() == 0, "Non-copy initialization not implemented for variable subsets."); 
+                  const std::vector<ID_t> &vars, const bool shallow) {
+    PARTHENON_REQUIRE(
+        shallow == false,
+        "Can't shallow copy when the source is not another MeshData object.");
+    PARTHENON_REQUIRE(vars.size() == 0,
+                      "Non-copy initialization not implemented for variable subsets.");
     if (part->grid.type == GridType::leaf) {
       Initialize(part->block_list, part->pmesh, {});
     } else {
-      Initialize(part->block_list, part->pmesh, part->grid.logical_level); 
+      Initialize(part->block_list, part->pmesh, part->grid.logical_level);
     }
   }
 
@@ -279,9 +281,9 @@ class MeshData {
     // modifying DataCollection::GetOrAdd. In the future we should
     // make that "just work (tm)."
     grid = src->grid;
-    //PARTHENON_REQUIRE((grid.type == GridType::two_level_composite) ||
-    //                      src->BlockDataIsWholeRank_(),
-    //                  "Add may only be called on all blocks on a rank");
+    // PARTHENON_REQUIRE((grid.type == GridType::two_level_composite) ||
+    //                       src->BlockDataIsWholeRank_(),
+    //                   "Add may only be called on all blocks on a rank");
     for (int i = 0; i < nblocks; ++i) {
       auto pmbd = src->GetBlockData(i);
       block_data_[i] = pmbd->GetBlockSharedPointer()->meshblock_data.Add(

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -287,11 +287,8 @@ class MeshData {
     assert(n >= 0 && n < block_data_.size());
     return block_data_[n];
   }
-  
-  const auto &GetAllBlockData() const {
-    return block_data_;
-  }
 
+  const auto &GetAllBlockData() const { return block_data_; }
 
   void SetAllVariablesToInitialized() {
     std::for_each(block_data_.begin(), block_data_.end(),

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -243,8 +243,8 @@ void Swarm::setPoolMax(const std::int64_t nmax_pool) {
   // Eliminate any cached SwarmPacks, as they will need to be rebuilt following setPoolMax
   pmb->meshblock_data.Get()->ClearSwarmCaches();
   pm->mesh_data.Get("base")->ClearSwarmCaches();
-  for (int i = 0; i < pm->DefaultNumPartitions(); i++) {
-    pm->mesh_data.GetOrAdd("base", i)->ClearSwarmCaches();
+  for (auto &partition : pm->GetBlockPartitions()) {
+    pm->mesh_data.Add("base", partition)->ClearSwarmCaches();
   }
 }
 

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -243,7 +243,7 @@ void Swarm::setPoolMax(const std::int64_t nmax_pool) {
   // Eliminate any cached SwarmPacks, as they will need to be rebuilt following setPoolMax
   pmb->meshblock_data.Get()->ClearSwarmCaches();
   pm->mesh_data.Get("base")->ClearSwarmCaches();
-  for (auto &partition : pm->GetBlockPartitions()) {
+  for (auto &partition : pm->GetDefaultBlockPartitions()) {
     pm->mesh_data.Add("base", partition)->ClearSwarmCaches();
   }
 }

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -968,8 +968,8 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       SetGMGNeighbors();
       BuildTagMapAndBoundaryBuffers();
       std::string noncc = "mesh_internal_noncc";
-      for (int i = 0; i < DefaultNumPartitions(); ++i) {
-        auto &md = mesh_data.GetOrAdd("base", i);
+      for (auto &partition : GetBlockPartitions()) {
+        auto &md = mesh_data.Add("base", partition);
         auto &md_noncc = mesh_data.AddShallow(noncc, md, noncc_names);
       }
 

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -969,7 +969,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
       SetGMGNeighbors();
       BuildTagMapAndBoundaryBuffers();
       std::string noncc = "mesh_internal_noncc";
-      for (auto &partition : GetBlockPartitions()) {
+      for (auto &partition : GetDefaultBlockPartitions()) {
         auto &md = mesh_data.Add("base", partition);
         auto &md_noncc = mesh_data.AddShallow(noncc, md, noncc_names);
       }

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -997,6 +997,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     FillDerived();
 
     // Initialize the "base" MeshData object
+    // TODO(LFR): Is this necessary? Do we every pull out the entire mesh MeshData?
     mesh_data.Get()->Initialize(block_list, this);
   } // AMR Recv and unpack data
 

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -997,7 +997,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     FillDerived();
 
     // Initialize the "base" MeshData object
-    // TODO(LFR): Is this necessary? Do we every pull out the entire mesh MeshData?
+    // TODO(LFR): Is this necessary? Do we ever pull out the entire mesh MeshData?
     mesh_data.Get()->Initialize(block_list, this);
   } // AMR Recv and unpack data
 

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -834,6 +834,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
     block_list[n - nbs]->gid = n;
     block_list[n - nbs]->lid = n - nbs;
   }
+  BuildBlockPartitions(GridIdentifier::leaf());
 
   // Receive the data and load into MeshBlocks
   { // AMR Recv and unpack data

--- a/src/mesh/mesh-gmg.cpp
+++ b/src/mesh/mesh-gmg.cpp
@@ -113,12 +113,7 @@ void Mesh::BuildGMGBlockLists(ParameterInput *pin, ApplicationInput *app_in) {
   gmg_min_logical_level_ = gmg_min_level;
   for (int level = gmg_min_level; level <= current_level; ++level) {
     gmg_block_lists[level] = BlockList_t();
-    gmg_mesh_data[level] = DataCollection<MeshData<Real>>();
   }
-
-  // Create MeshData objects for GMG
-  for (auto &[l, mdc] : gmg_mesh_data)
-    mdc.SetMeshPointer(this);
 
   // Fill/create gmg block lists based on this ranks block list
   for (auto &pmb : block_list) {

--- a/src/mesh/mesh-gmg.cpp
+++ b/src/mesh/mesh-gmg.cpp
@@ -149,6 +149,7 @@ void Mesh::BuildGMGBlockLists(ParameterInput *pin, ApplicationInput *app_in) {
   // Sort the gmg block lists by gid
   for (auto &[level, bl] : gmg_block_lists) {
     std::sort(bl.begin(), bl.end(), [](auto &a, auto &b) { return a->gid < b->gid; });
+    BuildBlockPartitions(GridIdentifier::two_level_composite(level));
   }
 }
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -316,6 +316,7 @@ void Mesh::BuildBlockList(ParameterInput *pin, ApplicationInput *app_in,
 
   // Output MeshBlock list and quit (mesh test only); do not create meshes
   if (mesh_test > 0) {
+    BuildBlockPartitions(GridIdentifier::leaf());
     if (Globals::my_rank == 0) OutputMeshStructure(ndim);
     return;
   }

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -366,6 +366,9 @@ void Mesh::BuildBlockPartitions(GridIdentifier grid) {
   auto partition_blocklists = partition::ToSizeN(
       grid.type == GridType::leaf ? block_list : gmg_block_lists[grid.logical_level],
       DefaultPackSize());
+  // Account for possibly empty block_list
+  if (partition_blocklists.size() == 0)
+    partition_blocklists = std::vector<BlockList_t>(1);
   std::vector<std::shared_ptr<BlockListPartition>> out;
   int id = 0;
   for (auto &part_bl : partition_blocklists)

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -806,9 +806,9 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
       // Call Mesh ProblemGenerator
       if (ProblemGenerator != nullptr) {
-        // PARTHENON_REQUIRE(num_partitions == 1,
-        //                   "Mesh ProblemGenerator requires parthenon/mesh/pack_size=-1 "
-        //                   "during first initialization.");
+        PARTHENON_REQUIRE(num_partitions == 1,
+                          "Mesh ProblemGenerator requires parthenon/mesh/pack_size=-1 "
+                          "during first initialization.");
         for (auto &partition : GetBlockPartitions(GridIdentifier::leaf())) {
           auto &md = mesh_data.Add("base", partition);
           ProblemGenerator(this, pin, md.get());

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -826,12 +826,10 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
       // Call Mesh PostInitialization
       if (PostInitialization != nullptr) {
-        PARTHENON_REQUIRE(num_partitions == 1,
-                          "Mesh PostInitialization requires parthenon/mesh/pack_size=-1 "
-                          "during first initialization.");
-
-        auto &md = mesh_data.Add("base", GetDefaultBlockPartitions()[0]);
-        PostInitialization(this, pin, md.get());
+        for (auto &partition : GetDefaultBlockPartitions(GridIdentifier::leaf())) {
+          auto &md = mesh_data.Add("base", partition);
+          PostInitialization(this, pin, md.get());
+        }
         // Call individual MeshBlock PostInitialization
       } else {
         for (int i = 0; i < nmb; ++i) {

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -806,9 +806,6 @@ void Mesh::Initialize(bool init_problem, ParameterInput *pin, ApplicationInput *
 
       // Call Mesh ProblemGenerator
       if (ProblemGenerator != nullptr) {
-        PARTHENON_REQUIRE(num_partitions == 1,
-                          "Mesh ProblemGenerator requires parthenon/mesh/pack_size=-1 "
-                          "during first initialization.");
         for (auto &partition : GetBlockPartitions(GridIdentifier::leaf())) {
           auto &md = mesh_data.Add("base", partition);
           ProblemGenerator(this, pin, md.get());

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -612,7 +612,6 @@ void Mesh::ApplyUserWorkBeforeRestartOutput(Mesh *mesh, ParameterInput *pin,
 }
 
 void Mesh::BuildTagMapAndBoundaryBuffers() {
-  printf("Building boundary information %i\n", multigrid);
   const int num_partitions = DefaultNumPartitions();
   const int nmb = GetNumMeshBlocksThisRank(Globals::my_rank);
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -147,10 +147,13 @@ class Mesh {
     return partition::partition_impl::IntCeil(block_list.size(), DefaultPackSize());
   }
 
-  std::vector<std::shared_ptr<BlockListPartition>> GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
-    auto partition_blocklists = partition::ToSizeN(grid.type == GridType::leaf ? block_list : gmg_block_lists[grid.logical_level], DefaultPackSize());
-    std::vector<std::shared_ptr<BlockListPartition>> out; 
-    int id = 0; 
+  std::vector<std::shared_ptr<BlockListPartition>>
+  GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
+    auto partition_blocklists = partition::ToSizeN(
+        grid.type == GridType::leaf ? block_list : gmg_block_lists[grid.logical_level],
+        DefaultPackSize());
+    std::vector<std::shared_ptr<BlockListPartition>> out;
+    int id = 0;
     for (auto &part_bl : partition_blocklists)
       out.emplace_back(std::make_shared<BlockListPartition>(id++, grid, part_bl, this));
     return out;

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -147,16 +147,9 @@ class Mesh {
     return partition::partition_impl::IntCeil(block_list.size(), DefaultPackSize());
   }
 
-  std::vector<std::shared_ptr<BlockListPartition>>
+  std::vector<std::shared_ptr<BlockListPartition>> &
   GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
-    auto partition_blocklists = partition::ToSizeN(
-        grid.type == GridType::leaf ? block_list : gmg_block_lists[grid.logical_level],
-        DefaultPackSize());
-    std::vector<std::shared_ptr<BlockListPartition>> out;
-    int id = 0;
-    for (auto &part_bl : partition_blocklists)
-      out.emplace_back(std::make_shared<BlockListPartition>(id++, grid, part_bl, this));
-    return out;
+    return block_partitions_.at(grid);
   }
 
   // step 7: create new MeshBlock list (same MPI rank but diff level: create new block)
@@ -342,6 +335,10 @@ class Mesh {
   void CommunicateBoundaries(std::string md_name = "base");
   void PreCommFillDerived();
   void FillDerived();
+
+  void BuildBlockPartitions(GridIdentifier grid);
+  std::map<GridIdentifier, std::vector<std::shared_ptr<BlockListPartition>>>
+      block_partitions_;
 };
 
 } // namespace parthenon

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -149,10 +149,6 @@ class Mesh {
 
   std::vector<std::shared_ptr<BlockListPartition>> &
   GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
-    if (block_partitions_.count(grid) == 0) {
-      PARTHENON_WARN("Adding empty partitions, should only happen in tests.");
-      block_partitions_[grid] = std::vector<std::shared_ptr<BlockListPartition>>();
-    }
     return block_partitions_.at(grid);
   }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -146,6 +146,16 @@ class Mesh {
   int DefaultNumPartitions() {
     return partition::partition_impl::IntCeil(block_list.size(), DefaultPackSize());
   }
+
+  std::vector<std::shared_ptr<BlockListPartition>> GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
+    auto partition_blocklists = partition::ToSizeN(grid.type == GridType::leaf ? block_list : gmg_block_lists[grid.logical_level], DefaultPackSize());
+    std::vector<std::shared_ptr<BlockListPartition>> out; 
+    int id = 0; 
+    for (auto &part_bl : partition_blocklists)
+      out.emplace_back(std::make_shared<BlockListPartition>(id++, grid, part_bl, this));
+    return out;
+  }
+
   // step 7: create new MeshBlock list (same MPI rank but diff level: create new block)
   // Moved here given Cuda/nvcc restriction:
   // "error: The enclosing parent function ("...")

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -147,7 +147,7 @@ class Mesh {
   }
 
   const std::vector<std::shared_ptr<BlockListPartition>> &
-  GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) const {
+  GetDefaultBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) const {
     return block_partitions_.at(grid);
   }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -146,8 +146,8 @@ class Mesh {
     return partition::partition_impl::IntCeil(block_list.size(), DefaultPackSize());
   }
 
-  std::vector<std::shared_ptr<BlockListPartition>> &
-  GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
+  const std::vector<std::shared_ptr<BlockListPartition>> &
+  GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) const {
     return block_partitions_.at(grid);
   }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -128,7 +128,6 @@ class Mesh {
   DataCollection<MeshData<Real>> mesh_data;
 
   std::map<int, BlockList_t> gmg_block_lists;
-  std::map<int, DataCollection<MeshData<Real>>> gmg_mesh_data;
   int GetGMGMaxLevel() const { return current_level; }
   int GetGMGMinLevel() const { return gmg_min_logical_level_; }
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -149,6 +149,10 @@ class Mesh {
 
   std::vector<std::shared_ptr<BlockListPartition>> &
   GetBlockPartitions(GridIdentifier grid = GridIdentifier::leaf()) {
+    if (block_partitions_.count(grid) == 0) {
+      PARTHENON_WARN("Adding empty partitions, should only happen in tests.");
+      block_partitions_[grid] = std::vector<std::shared_ptr<BlockListPartition>>();
+    }
     return block_partitions_.at(grid);
   }
 

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -461,8 +461,8 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
 using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;
 
 struct BlockListPartition {
-  BlockListPartition(int p, GridIdentifier g, const BlockList_t &bl, Mesh* pm) : 
-      partition{p}, grid{g}, block_list{bl}, pmesh{pm}{}
+  BlockListPartition(int p, GridIdentifier g, const BlockList_t &bl, Mesh *pm)
+      : partition{p}, grid{g}, block_list{bl}, pmesh{pm} {}
   int partition;
   GridIdentifier grid;
   BlockList_t block_list;

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -460,6 +460,15 @@ class MeshBlock : public std::enable_shared_from_this<MeshBlock> {
 
 using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;
 
+struct BlockListPartition {
+  BlockListPartition(int p, GridIdentifier g, const BlockList_t &bl, Mesh* pm) : 
+      partition{p}, grid{g}, block_list{bl}, pmesh{pm}{}
+  int partition;
+  GridIdentifier grid;
+  BlockList_t block_list;
+  Mesh *pmesh;
+};
+
 } // namespace parthenon
 
 #endif // MESH_MESHBLOCK_HPP_

--- a/src/mesh/meshblock.hpp
+++ b/src/mesh/meshblock.hpp
@@ -463,9 +463,9 @@ using BlockList_t = std::vector<std::shared_ptr<MeshBlock>>;
 struct BlockListPartition {
   BlockListPartition(int p, GridIdentifier g, const BlockList_t &bl, Mesh *pm)
       : partition{p}, grid{g}, block_list{bl}, pmesh{pm} {}
-  int partition;
-  GridIdentifier grid;
-  BlockList_t block_list;
+  const int partition;
+  const GridIdentifier grid;
+  const BlockList_t block_list;
   Mesh *pmesh;
 };
 

--- a/src/outputs/histogram.cpp
+++ b/src/outputs/histogram.cpp
@@ -257,10 +257,8 @@ void Histogram::CalcHist(Mesh *pm) {
   // https://github.com/kokkos/kokkos/issues/6363
   Kokkos::deep_copy(result, 0);
 
-  const int num_partitions = pm->DefaultNumPartitions();
-
-  for (int p = 0; p < num_partitions; p++) {
-    auto &md = pm->mesh_data.GetOrAdd("base", p);
+  for (auto partition : pm->GetBlockPartitions()) {
+    auto &md = pm->mesh_data.Add("base", partition);
 
     const auto x_var_pack_string = x_var_type == VarType::Var
                                        ? std::vector<std::string>{x_var_name_}

--- a/src/outputs/histogram.cpp
+++ b/src/outputs/histogram.cpp
@@ -257,7 +257,7 @@ void Histogram::CalcHist(Mesh *pm) {
   // https://github.com/kokkos/kokkos/issues/6363
   Kokkos::deep_copy(result, 0);
 
-  for (auto partition : pm->GetBlockPartitions()) {
+  for (auto partition : pm->GetDefaultBlockPartitions()) {
     auto &md = pm->mesh_data.Add("base", partition);
 
     const auto x_var_pack_string = x_var_type == VarType::Var

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -317,7 +317,7 @@ class MGSolver {
     auto partitions =
         pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
     if (partition >= partitions.size()) return dependence;
-    auto &md = pmesh->gmg_mesh_data[level].Add("base", partitions[partition]);
+    auto &md = pmesh->mesh_data.Add("base", partitions[partition]);
 
     auto task_out = dependence;
     if (level < max_level) {
@@ -366,11 +366,9 @@ class MGSolver {
     auto partitions =
         pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
     if (partition >= partitions.size()) return dependence;
-    auto &md = pmesh->gmg_mesh_data[level].Add("base", partitions[partition]);
-    std::string label =
-        "mg_comm_" + std::to_string(level) + "_" + std::to_string(partition);
-    auto &md_comm = pmesh->gmg_mesh_data[level].AddShallow(
-        label, md, std::vector<std::string>{u::name(), res_err::name()});
+    auto &md = pmesh->mesh_data.Add("base", partitions[partition]);
+    auto &md_comm = pmesh->mesh_data.AddShallow(
+        "mg_comm", md, std::vector<std::string>{u::name(), res_err::name()});
 
     // 0. Receive residual from coarser level if there is one
     auto set_from_finer = dependence;

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -112,8 +112,7 @@ class MGSolver {
     auto mg_finest = AddLinearOperatorTasks(itl, none, partition, pmesh);
 
     auto partitions = pmesh->GetBlockPartitions(GridIdentifier::leaf());
-    if (partition >= partitions.size()) 
-      return dependence;
+    if (partition >= partitions.size()) return dependence;
     auto &md = pmesh->mesh_data.Add("base", partitions[partition]);
     auto comm = AddBoundaryExchangeTasks<BoundaryType::any>(mg_finest, itl, md,
                                                             pmesh->multilevel);
@@ -314,10 +313,10 @@ class MGSolver {
     using namespace utils;
 
     bool multilevel = (level != min_level);
-    
-    auto partitions = pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
-    if (partition >= partitions.size()) 
-      return dependence;
+
+    auto partitions =
+        pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
+    if (partition >= partitions.size()) return dependence;
     auto &md = pmesh->gmg_mesh_data[level].Add("base", partitions[partition]);
 
     auto task_out = dependence;
@@ -364,9 +363,9 @@ class MGSolver {
 
     bool multilevel = (level != min_level);
 
-    auto partitions = pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
-    if (partition >= partitions.size()) 
-      return dependence;
+    auto partitions =
+        pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
+    if (partition >= partitions.size()) return dependence;
     auto &md = pmesh->gmg_mesh_data[level].Add("base", partitions[partition]);
     std::string label =
         "mg_comm_" + std::to_string(level) + "_" + std::to_string(partition);

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -124,7 +124,7 @@ class MGSolver {
         &iter_counter);
     auto mg_finest = AddLinearOperatorTasks(itl, none, partition, pmesh);
 
-    auto partitions = pmesh->GetBlockPartitions(GridIdentifier::leaf());
+    auto partitions = pmesh->GetDefaultBlockPartitions(GridIdentifier::leaf());
     if (partition >= partitions.size()) return dependence;
     auto &md = pmesh->mesh_data.Add("base", partitions[partition]);
     auto comm = AddBoundaryExchangeTasks<BoundaryType::any>(mg_finest, itl, md,
@@ -328,7 +328,7 @@ class MGSolver {
     bool multilevel = (level != min_level);
 
     auto partitions =
-        pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
+        pmesh->GetDefaultBlockPartitions(GridIdentifier::two_level_composite(level));
     if (partition >= partitions.size()) return dependence;
     auto &md = pmesh->mesh_data.Add("base", partitions[partition]);
 
@@ -377,7 +377,7 @@ class MGSolver {
     bool multilevel = (level != min_level);
 
     auto partitions =
-        pmesh->GetBlockPartitions(GridIdentifier::two_level_composite(level));
+        pmesh->GetDefaultBlockPartitions(GridIdentifier::two_level_composite(level));
     if (partition >= partitions.size()) return dependence;
     auto &md = pmesh->mesh_data.Add("base", partitions[partition]);
     auto &md_comm = pmesh->mesh_data.AddShallow(


### PR DESCRIPTION
## PR Summary
This PR adds an object `BlockListPartition` that stores a `BlockList_t` and a little more information about a partition of blocks. We then have the analogy `BlockListPartition` is to `MeshData` as `MeshBlock` is to `MeshBlockData`. Then instead of doing block list partitioning inside of `DataCollection`, partitioning is moved to `Mesh` (which at least to me is a more reasonable location for this to live) and methods for getting the partitions are added to `Mesh`. `MeshData` gains an `Initialize` method that takes a `BlockListPartition`. As a result, all incarnations of `DataCollection<MeshData>::Add` are made to "just work" for `MeshData` when it is passed either another `MeshData` object or a `BlockListPartition` object. `DataCollection<MeshData>::GetOrAdd` is deprecated (although still available, it just calls `Add` internally). I have also removed `GetOrAdd` from Parthenon internals and from the examples.

This nearly gets us to working multigrid for multiple partitions, aside from the task bug described in #1125 (at least I hope).

This should close issue #1097.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
