### PR TITLE
result_of -> invoke_result

### DIFF
--- a/src/tasks/thread_pool.hpp
+++ b/src/tasks/thread_pool.hpp
@@ -151,7 +151,7 @@ class ThreadPool {
 
   template <typename F, class... Args>
   void enqueue(F &&f, Args &&...args) {
-    using return_t = typename std::result_of<F(Args...)>::type;
+    using return_t = typename std::invoke_result_t<F, Args...>;
     auto task = std::make_shared<std::packaged_task<return_t()>>(
         [=, func = std::forward<F>(f)] { return func(std::forward<Args>(args)...); });
     // If we're listing Prathenon "Tasks" (all current uses) keep the returns


### PR DESCRIPTION
Remove deprecated `std::result_of`. 

Fixes #1008 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
