### PR TITLE
Add WithFluxes to IsRefined check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1127]](https://github.com/parthenon-hpc-lab/parthenon/pull/1127) Add WithFluxes to IsRefined check
 - [[PR 1111]](https://github.com/parthenon-hpc-lab/parthenon/pull/1111) Fix undefined behavior due to bitshift of negative number in LogicalLocation
 - [[PR 1092]](https://github.com/parthenon-hpc-lab/parthenon/pull/1092) Updates to DataCollection and MeshData to remove requirement of predefining MeshBlockData
 - [[PR 1113]](https://github.com/parthenon-hpc-lab/parthenon/pull/1113) Prevent division by zero

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -54,7 +54,7 @@ void ProResCache_t::Initialize(int n_regions, StateDescriptor *pkg) {
 void ProResCache_t::RegisterRegionHost(int region, ProResInfo pri, Variable<Real> *v,
                                        StateDescriptor *pkg) {
   prores_info_h(region) = pri;
-  if (v->IsRefined()) {
+  if (v->HasRefinementOps()) {
     // var must be registered for refinement
     // note this condition means that each subset contains
     // both prolongation and restriction conditions. The

--- a/src/interface/metadata.cpp
+++ b/src/interface/metadata.cpp
@@ -126,7 +126,7 @@ Metadata::Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int>
   }
   // If variable is refined, set a default prolongation/restriction op
   // TODO(JMM): This is dangerous. See Issue #844.
-  if (IsRefined()) {
+  if (HasRefinementOps()) {
     refinement_funcs_ = ref_funcs_;
   }
 
@@ -253,7 +253,7 @@ bool Metadata::IsValid(bool throw_on_fail) const {
   }
 
   // Prolongation/restriction
-  if (IsRefined()) {
+  if (HasRefinementOps()) {
     if (refinement_funcs_.label().size() == 0) {
       valid = false;
       if (throw_on_fail) {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -448,7 +448,7 @@ class Metadata {
 
   // Returns true if this variable should do prolongation/restriction
   // and false otherwise.
-  bool IsRefined() const {
+  bool HasRefinementOps() const {
     return (IsSet(Independent) || IsSet(FillGhost) || IsSet(ForceRemeshComm) ||
             IsSet(GMGProlongate) || IsSet(GMGRestrict) || IsSet(Flux) ||
             IsSet(WithFluxes));
@@ -531,7 +531,7 @@ class Metadata {
             class InternalProlongationOp = refinement_ops::ProlongateInternalAverage>
   void RegisterRefinementOps() {
     PARTHENON_REQUIRE_THROWS(
-        IsRefined(),
+        HasRefinementOps(),
         "Variable must be registered for refinement to accept custom refinement ops");
     refinement_funcs_ =
         refinement::RefinementFunctions_t::RegisterOps<ProlongationOp, RestrictionOp,

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -450,7 +450,8 @@ class Metadata {
   // and false otherwise.
   bool IsRefined() const {
     return (IsSet(Independent) || IsSet(FillGhost) || IsSet(ForceRemeshComm) ||
-            IsSet(GMGProlongate) || IsSet(GMGRestrict) || IsSet(Flux));
+            IsSet(GMGProlongate) || IsSet(GMGRestrict) || IsSet(Flux) ||
+            IsSet(WithFluxes));
   }
 
   // Returns true if this variable is a coords var

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -62,7 +62,7 @@ using SBValFunc = std::function<void(std::shared_ptr<Swarm> &)>;
 /// IDs but they maybe could be? We should consider unifying that.
 struct RefinementFunctionMaps {
   void Register(const Metadata &m, std::string varname) {
-    if (m.IsRefined()) {
+    if (m.HasRefinementOps()) {
       const auto &funcs = m.GetRefinementFunctions();
       // Guard against uninitialized refinement functions by checking
       // if the label is the empty string.

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -107,7 +107,7 @@ class Variable {
   inline Metadata metadata() { return m_; }
 
   /// Refinement functions owned in metadata
-  inline bool IsRefined() const { return m_.IsRefined(); }
+  inline bool HasRefinementOps() const { return m_.HasRefinementOps(); }
   inline const refinement::RefinementFunctions_t &GetRefinementFunctions() const {
     return m_.GetRefinementFunctions();
   }

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -212,7 +212,7 @@ TEST_CASE("Metadata FlagCollection", "[Metadata]") {
 TEST_CASE("Refinement Information in Metadata", "[Metadata]") {
   GIVEN("A metadata struct with relevant flags set") {
     Metadata m({Metadata::Cell, Metadata::FillGhost});
-    THEN("It knows it's registered for refinement") { REQUIRE(m.IsRefined()); }
+    THEN("It knows it's registered for refinement") { REQUIRE(m.HasRefinementOps()); }
     THEN("It has the default Prolongation/Restriction ops") {
       const auto cell_funcs = parthenon::refinement::RefinementFunctions_t::RegisterOps<
           parthenon::refinement_ops::ProlongateSharedMinMod,


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
The fluxes associated with a field marked `Metadata::WithFluxes` must undergo flux correction with mesh refinement.  Parthenon cannot currently enroll custom PR ops on those fluxes if the associated field is marked `Metadata::WithFluxes`, but not `Metadata::Independent`, `Metadata::FillGhost`, or `Metadata::ForceRemeshComm`.  

This PR simply adds `WithFluxes` to the `IsRefined` check to circumvent this issue.  Technically, this is a bit slimy, because in the example above, the field itself does not undergo any custom-ops, only its associated fluxes, nevertheless, this appears to be the most expedient solution, and `IsRefined` should not actually be used when packing relevant fields needed for a particular refinement op (please check me on this one, though: https://github.com/search?q=repo%3Aparthenon-hpc-lab%2Fparthenon+isrefined&type=code).  If this is too dirty, please feel free to shoot down this PR.  

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
