### PR TITLE
Add cycle and nbtotal to hst

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1128]](https://github.com/parthenon-hpc-lab/parthenon/pull/1128) Add cycle and nbtotal to hst
 - [[PR 1099]](https://github.com/parthenon-hpc-lab/parthenon/pull/1099) Functionality for outputting task graphs in GraphViz format.
 - [[PR 1091]](https://github.com/parthenon-hpc-lab/parthenon/pull/1091) Add vector wave equation example.
 - [[PR 991]](https://github.com/parthenon-hpc-lab/parthenon/pull/991) Add fine fields.
@@ -71,6 +72,7 @@
 - [[PR 1108]](https://github.com/parthenon-hpc-lab/parthenon/pull/1108) Remove NaN payload tags infrastructure
 
 ### Incompatibilities (i.e. breaking changes)
+- [[PR 1128]](https://github.com/parthenon-hpc-lab/parthenon/pull/1128) Add cycle and nbtotal to hst
 - [[PR 1108]](https://github.com/parthenon-hpc-lab/parthenon/pull/1108) Remove NaN payload tags infrastructure
 - [[PR 1026]](https://github.com/parthenon-hpc-lab/parthenon/pull/1026) Particle BCs without relocatable device code
 - [[PR 1037]](https://github.com/parthenon-hpc-lab/parthenon/pull/1037) Add SwarmPacks

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # ========================================================================================
-# (C) (or copyright) 2023. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2024. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/benchmarks/burgers/burgers_diff.py
+++ b/benchmarks/burgers/burgers_diff.py
@@ -21,7 +21,7 @@ parser = ArgumentParser(
     description="Compute difference between two history solvers parthenon VIBE",
 )
 parser.add_argument("file1", type=str, help="First file in diff")
-parser.add_argument("file2", type=str, help="Second fiel in diff")
+parser.add_argument("file2", type=str, help="Second file in diff")
 parser.add_argument(
     "-t", "--tolerance", type=float, default=1e-8, help="Relative tolerance for diff"
 )
@@ -54,4 +54,4 @@ def compare_files(file1, file2, tolerance, print_results=True):
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    sys.exit(compare_files(args.file1, args.file1, args.tolerance, True))
+    sys.exit(compare_files(args.file1, args.file2, args.tolerance, True))

--- a/benchmarks/burgers/burgers_package.cpp
+++ b/benchmarks/burgers/burgers_package.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/benchmarks/burgers/burgers_package.cpp
+++ b/benchmarks/burgers/burgers_package.cpp
@@ -132,7 +132,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     hst_vars.emplace_back(HstSum, ReduceMass, "MS Mass " + std::to_string(i_octant));
     i_octant++;
   }
-  hst_vars.emplace_back(HstSum, MeshCountHistory, "Meshblock count");
   pkg->AddParam(parthenon::hist_param_key, hst_vars);
 
   pkg->EstimateTimestepMesh = EstimateTimestepMesh;
@@ -438,7 +437,5 @@ Real MassHistory(MeshData<Real> *md, const Real x1min, const Real x1max, const R
       Kokkos::Sum<Real>(result));
   return result;
 }
-
-Real MeshCountHistory(MeshData<Real> *md) { return md->NumBlocks(); }
 
 } // namespace burgers_package

--- a/benchmarks/burgers/burgers_package.hpp
+++ b/benchmarks/burgers/burgers_package.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/benchmarks/burgers/burgers_package.hpp
+++ b/benchmarks/burgers/burgers_package.hpp
@@ -27,7 +27,6 @@ Real EstimateTimestepMesh(MeshData<Real> *md);
 TaskStatus CalculateFluxes(MeshData<Real> *md);
 Real MassHistory(MeshData<Real> *md, const Real x1min, const Real x1max, const Real x2min,
                  const Real x2max, const Real x3min, const Real x3max);
-Real MeshCountHistory(MeshData<Real> *md);
 
 // compute the hll flux for Burgers' equation
 KOKKOS_INLINE_FUNCTION

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -176,6 +176,8 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       std::fprintf(pfile, "#  History data\n"); // descriptor is first line
       std::fprintf(pfile, "# [%d]=time     ", iout++);
       std::fprintf(pfile, "[%d]=dt       ", iout++);
+      std::fprintf(pfile, "[%d]=ncycle   ", iout++);
+      std::fprintf(pfile, "[%d]=nbtotal  ", iout++);
       for (auto &op : ops) {
         for (auto &label : labels[op]) {
           std::fprintf(pfile, "[%d]=%-8s ", iout++, label.c_str());
@@ -187,6 +189,8 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     // write history variables
     std::fprintf(pfile, output_params.data_format.c_str(), tm->time);
     std::fprintf(pfile, output_params.data_format.c_str(), tm->dt);
+    std::fprintf(pfile, "%12d  ", tm->ncycle);
+    std::fprintf(pfile, "%12d", pm->nbtotal);
     for (auto &op : ops) {
       for (auto &result : results[op]) {
         std::fprintf(pfile, output_params.data_format.c_str(), result);

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -176,7 +176,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       std::fprintf(pfile, "#  History data\n"); // descriptor is first line
       std::fprintf(pfile, "# [%d]=time     ", iout++);
       std::fprintf(pfile, "[%d]=dt       ", iout++);
-      std::fprintf(pfile, "[%d]=ncycle   ", iout++);
+      std::fprintf(pfile, "[%d]=cycle    ", iout++);
       std::fprintf(pfile, "[%d]=nbtotal  ", iout++);
       for (auto &op : ops) {
         for (auto &label : labels[op]) {

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -174,13 +174,13 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     if (output_params.file_number == 0) {
       int iout = 1;
       std::fprintf(pfile, "#  History data\n"); // descriptor is first line
-      std::fprintf(pfile, "# [%d]=time     ", iout++);
-      std::fprintf(pfile, "[%d]=dt       ", iout++);
-      std::fprintf(pfile, "[%d]=cycle    ", iout++);
-      std::fprintf(pfile, "[%d]=nbtotal  ", iout++);
+      std::fprintf(pfile, "# [%d]=time    ", iout++);
+      std::fprintf(pfile, " [%d]=dt      ", iout++);
+      std::fprintf(pfile, " [%d]=cycle   ", iout++);
+      std::fprintf(pfile, " [%d]=nbtotal ", iout++);
       for (auto &op : ops) {
         for (auto &label : labels[op]) {
-          std::fprintf(pfile, "[%d]=%-8s ", iout++, label.c_str());
+          std::fprintf(pfile, " [%d]=%-8s", iout++, label.c_str());
         }
       }
       std::fprintf(pfile, "\n"); // terminate line
@@ -189,8 +189,8 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     // write history variables
     std::fprintf(pfile, output_params.data_format.c_str(), tm->time);
     std::fprintf(pfile, output_params.data_format.c_str(), tm->dt);
-    std::fprintf(pfile, "%12d  ", tm->ncycle);
-    std::fprintf(pfile, "%12d", pm->nbtotal);
+    std::fprintf(pfile, " %12d", tm->ncycle);
+    std::fprintf(pfile, " %12d", pm->nbtotal);
     for (auto &op : ops) {
       for (auto &result : results[op]) {
         std::fprintf(pfile, output_params.data_format.c_str(), result);

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -1,9 +1,9 @@
 # ========================================================================================
 # Parthenon performance portable AMR framework
-# Copyright(C) 2020-2023 The Parthenon collaboration
+# Copyright(C) 2020-2024 The Parthenon collaboration
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -124,7 +124,7 @@ class TestCase(utils.test_case.TestCaseAbs):
         ref_results = [
             ["time", 1.0, 1.0],
             ["dt", 1.75781e-03, 3.12500e-03],
-            ["ncycle", 5.69000e02, 2.14000e02],
+            ["cycle", 5.69000e02, 2.14000e02],
             ["nbtotal", 1.30000e02, 2.04000e02],
             ["total_advected", 7.06177e-02, 1.39160e-02],
             ["advected_powers_0", 7.06177e-02, 1.39160e-02],

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -124,6 +124,8 @@ class TestCase(utils.test_case.TestCaseAbs):
         ref_results = [
             ["time", 1.0, 1.0],
             ["dt", 1.75781e-03, 3.12500e-03],
+            ["ncycle", 5.69000e02, 2.14000e02],
+            ["nbtotal", 1.30000e02, 2.04000e02],
             ["total_advected", 7.06177e-02, 1.39160e-02],
             ["advected_powers_0", 7.06177e-02, 1.39160e-02],
             ["advected_powers_1", 3.88112e-02, 2.59597e-03],
@@ -141,7 +143,7 @@ class TestCase(utils.test_case.TestCaseAbs):
                 f.readline()
                 header = f.readline()[1:].split()
                 for i, val in enumerate(ref_results):
-                    col_label = header[i].strip()[4:]
+                    col_label = (header[i].strip()).split("=", 1)[1]
                     if col_label != val[0]:
                         print(
                             "Wrong",

--- a/tst/unit/test_metadata.cpp
+++ b/tst/unit/test_metadata.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
This PR adds the cycle and total number of MeshBlocks to the history file output.  If we choose to merge this one, please merge it after #1127.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] Change is breaking (API, behavior, ...)
  - [x] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [x] PR is marked as breaking
  - [x] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
