### PR TITLE
Enable `parthenon::par_reduce` for MD loops with Kokkos 1D Range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1130]](https://github.com/parthenon-hpc-lab/parthenon/pull/1130) Enable `parthenon::par_reduce` for MD loops with Kokkos 1D Range
 - [[PR 1099]](https://github.com/parthenon-hpc-lab/parthenon/pull/1099) Functionality for outputting task graphs in GraphViz format.
 - [[PR 1091]](https://github.com/parthenon-hpc-lab/parthenon/pull/1091) Add vector wave equation example.
 - [[PR 991]](https://github.com/parthenon-hpc-lab/parthenon/pull/991) Add fine fields.

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -268,13 +268,13 @@ auto MakeFlatFunctor(F &function, Args... args) {
 
 template <typename Function, typename R, typename T, typename Index, typename... FArgs>
 class FlatFunctor<Function, R (T::*)(Index, Index, Index, FArgs...) const> {
-  int NjNi, Nj, Ni, kl, jl, il;
+  int NjNi, Ni, kl, jl, il;
   Function function;
 
  public:
-  FlatFunctor(const Function _function, const int _NjNi, const int _Nj, const int _Ni,
-              const int _kl, const int _jl, const int _il)
-      : function(_function), NjNi(_NjNi), Nj(_Nj), Ni(_Ni), kl(_kl), jl(_jl), il(_il) {}
+  FlatFunctor(const Function _function, const int _NjNi, const int _Ni, const int _kl,
+              const int _jl, const int _il)
+      : function(_function), NjNi(_NjNi), Ni(_Ni), kl(_kl), jl(_jl), il(_il) {}
   KOKKOS_INLINE_FUNCTION
   void operator()(const int &idx, FArgs &&...fargs) const {
     int k = idx / NjNi;
@@ -300,7 +300,7 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
   const int NkNjNi = Nk * Nj * Ni;
   const int NjNi = Nj * Ni;
   kokkos_dispatch(tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
-                  MakeFlatFunctor(function, NjNi, Nj, Ni, kl, jl, il),
+                  MakeFlatFunctor(function, NjNi, Ni, kl, jl, il),
                   std::forward<Args>(args)...);
 }
 
@@ -394,14 +394,14 @@ inline void par_dispatch(LoopPatternSimdFor, const std::string &name,
 
 template <typename Function, typename R, typename T, typename Index, typename... FArgs>
 class FlatFunctor<Function, R (T::*)(Index, Index, Index, Index, FArgs...) const> {
-  int NkNjNi, NjNi, Nj, Ni, nl, kl, jl, il;
+  int NkNjNi, NjNi, Ni, nl, kl, jl, il;
   Function function;
 
  public:
-  FlatFunctor(const Function _function, const int _NkNjNi, const int _NjNi, const int _Nj,
-              const int _Ni, const int _nl, const int _kl, const int _jl, const int _il)
-      : function(_function), NkNjNi(_NkNjNi), NjNi(_NjNi), Nj(_Nj), Ni(_Ni), nl(_nl),
-        kl(_kl), jl(_jl), il(_il) {}
+  FlatFunctor(const Function _function, const int _NkNjNi, const int _NjNi, const int _Ni,
+              const int _nl, const int _kl, const int _jl, const int _il)
+      : function(_function), NkNjNi(_NkNjNi), NjNi(_NjNi), Ni(_Ni), nl(_nl), kl(_kl),
+        jl(_jl), il(_il) {}
   KOKKOS_INLINE_FUNCTION
   void operator()(const int &idx, FArgs &&...fargs) const {
     int n = idx / NkNjNi;
@@ -432,7 +432,7 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
   const int NkNjNi = Nk * Nj * Ni;
   const int NjNi = Nj * Ni;
   kokkos_dispatch(tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
-                  MakeFlatFunctor(function, NkNjNi, NjNi, Nj, Ni, nl, kl, jl, il),
+                  MakeFlatFunctor(function, NkNjNi, NjNi, Ni, nl, kl, jl, il),
                   std::forward<Args>(args)...);
 }
 

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -21,14 +21,12 @@
 #define KOKKOS_ABSTRACTION_HPP_
 
 #include <memory>
-#include <functional>
 #include <string>
 #include <type_traits>
 #include <utility>
 
 #include <Kokkos_Core.hpp>
 
-#include "Kokkos_Macros.hpp"
 #include "basic_types.hpp"
 #include "config.hpp"
 #include "parthenon_array_generic.hpp"
@@ -36,7 +34,6 @@
 #include "utils/instrument.hpp"
 #include "utils/multi_pointer.hpp"
 #include "utils/object_pool.hpp"
-
 
 namespace parthenon {
 
@@ -735,13 +732,8 @@ inline void par_dispatch(LoopPatternSimdFor, const std::string &name,
 
 template <typename Tag, typename... Args>
 inline void par_dispatch(const std::string &name, Args &&...args) {
-   if constexpr (std::is_same<Tag, dispatch_impl::ParallelForDispatch>::value) {
-     par_dispatch<Tag>(DEFAULT_LOOP_PATTERN, name, DevExecSpace(),
-                       std::forward<Args>(args)...);
-   } else {
-     par_dispatch<Tag>(loop_pattern_mdrange_tag, name, DevExecSpace(),
-                       std::forward<Args>(args)...);
-   }
+  par_dispatch<Tag>(DEFAULT_LOOP_PATTERN, name, DevExecSpace(),
+                    std::forward<Args>(args)...);
 }
 
 template <class... Args>

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -261,36 +261,42 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
                   function, std::forward<Args>(args)...);
 }
 
-template<typename> class Functor;
-
-template<typename R, typename T, typename... Args>
-class Functor<R(T::*)(const int, const int, const int, Args...) const>
-{
-   using F = std::function<R(const int, const int, const int, Args...)>;
-    F m_f;
-public:
-    Functor( F function, 
-          int _NjNi, int _Ni, int _kl, int _jl, int _il )
-       : m_f(function), NjNi(_NjNi), Ni(_Ni), kl(_kl), jl(_jl), il(_il)  {}
-    KOKKOS_INLINE_FUNCTION
-    void operator()(const int &idx, Args... args) const {
-        int k = idx / NjNi;
-        int j = (idx - k * NjNi) / Ni;
-        int i = idx - k * NjNi - j * Ni;
-        k += kl;
-        j += jl;
-        i += il;
-       m_f(k, j, i, std::forward<Args>(args)...);
-    }
-    int NjNi, Ni, kl, jl, il;
-};
+template<typename> class FlatFunctor;
 
 template<typename F>
-auto MakeFunctor(F &function, const int &NjNi, const int &Ni,
-                 const int &kl, const int &jl, const int &il) {
-   return Functor<decltype(&F::operator())>(function, NjNi, Ni, kl, jl, il);
+auto MakeFlatFunctor(F &function) {
+   return FlatFunctor<decltype(&F::operator())>();
 }
 
+template<typename R, typename T, typename... FArgs>
+class FlatFunctor<R(T::*)(const int, const int, const int, FArgs...) const>
+{
+   public:
+      FlatFunctor(){};
+      template <typename Tag, typename F, typename... Args>
+         inline void operator()(Tag tag, const std::string &name, 
+                                DevExecSpace exec_space, const int kl, const int ku,
+                                const int jl, const int ju, const int il, const int iu,
+                                const F &function, Args ...args) const {
+            const int Nk = ku - kl + 1;
+            const int Nj = ju - jl + 1;
+            const int Ni = iu - il + 1;
+            const int NkNjNi = Nk * Nj * Ni;
+            const int NjNi = Nj * Ni;
+            kokkos_dispatch(
+                  tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
+                  KOKKOS_LAMBDA(const int &idx, FArgs ...fargs) {
+                  int k = idx / NjNi;
+                  int j = (idx - k * NjNi) / Ni;
+                  int i = idx - k * NjNi - j * Ni;
+                  k += kl;
+                  j += jl;
+                  i += il;
+                  function(k, j, i, std::forward<FArgs>(fargs)...);
+                  },
+                  std::forward<Args>(args)...);
+         }
+};
 
 // 3D loop using Kokkos 1D Range
 template <typename Tag, typename Function, class... Args>
@@ -299,16 +305,8 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
              const int kl, const int ku, const int jl, const int ju, const int il,
              const int iu, const Function &function, Args &&...args) {
   Tag tag;
-  const int Nk = ku - kl + 1;
-  const int Nj = ju - jl + 1;
-  const int Ni = iu - il + 1;
-  const int NkNjNi = Nk * Nj * Ni;
-  const int NjNi = Nj * Ni;
-
-  kokkos_dispatch(
-      tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
-      MakeFunctor(function, NjNi, Ni, kl, jl, il),
-      std::forward<Args>(args)...);
+  const auto func = MakeFlatFunctor(function);
+  func(tag, name, exec_space, kl, ku, jl, ju, il, iu, function, std::forward<Args>(args)...);
 }
 
 // 3D loop using MDRange loops
@@ -399,6 +397,40 @@ inline void par_dispatch(LoopPatternSimdFor, const std::string &name,
         function(k, j, i);
 }
 
+template<typename R, typename T, typename... FArgs>
+class FlatFunctor<R(T::*)(const int, const int, const int, const int, FArgs...) const>
+{
+   public:
+      FlatFunctor(){};
+      template <typename Tag, typename F, typename... Args>
+         inline void operator()(Tag tag, const std::string &name, 
+                                DevExecSpace exec_space, const int nl, const int nu,
+                                const int kl, const int ku, const int jl, const int ju,
+                                const int il, const int iu, const F &function, Args ...args) const {
+            const int Nn = nu - nl + 1;
+            const int Nk = ku - kl + 1;
+            const int Nj = ju - jl + 1;
+            const int Ni = iu - il + 1;
+            const int NnNkNjNi = Nn * Nk * Nj * Ni;
+            const int NkNjNi = Nk * Nj * Ni;
+            const int NjNi = Nj * Ni;
+            kokkos_dispatch(
+                  tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
+                  KOKKOS_LAMBDA(const int &idx, FArgs ...fargs) {
+                  int n = idx / NkNjNi;
+                  int k = (idx - n * NkNjNi) / NjNi;
+                  int j = (idx - n * NkNjNi - k * NjNi) / Ni;
+                  int i = idx - n * NkNjNi - k * NjNi - j * Ni;
+                  n += nl;
+                  k += kl;
+                  j += jl;
+                  i += il;
+                  function(n, k, j, i, std::forward<FArgs>(fargs)...);
+                  },
+                  std::forward<Args>(args)...);
+         }
+};
+
 // 4D loop using Kokkos 1D Range
 template <typename Tag, typename Function, class... Args>
 inline typename std::enable_if<sizeof...(Args) <= 1, void>::type
@@ -407,27 +439,9 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
              const int ju, const int il, const int iu, const Function &function,
              Args &&...args) {
   Tag tag;
-  const int Nn = nu - nl + 1;
-  const int Nk = ku - kl + 1;
-  const int Nj = ju - jl + 1;
-  const int Ni = iu - il + 1;
-  const int NnNkNjNi = Nn * Nk * Nj * Ni;
-  const int NkNjNi = Nk * Nj * Ni;
-  const int NjNi = Nj * Ni;
-  kokkos_dispatch(
-      tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
-      KOKKOS_LAMBDA(const int &idx) {
-        int n = idx / NkNjNi;
-        int k = (idx - n * NkNjNi) / NjNi;
-        int j = (idx - n * NkNjNi - k * NjNi) / Ni;
-        int i = idx - n * NkNjNi - k * NjNi - j * Ni;
-        n += nl;
-        k += kl;
-        j += jl;
-        i += il;
-        function(n, k, j, i);
-      },
-      std::forward<Args>(args)...);
+  const auto func = MakeFlatFunctor(function);
+  func(tag, name, exec_space, nl, nu, kl, ku, jl, ju, il, iu,
+       function, std::forward<Args>(args)...);
 }
 
 // 4D loop using MDRange loops

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -258,50 +258,32 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
                   function, std::forward<Args>(args)...);
 }
 
-template <typename>
+template <typename, typename>
 class FlatFunctor;
 
-template <typename F>
-auto MakeFlatFunctor(F &function) {
-  return FlatFunctor<decltype(&F::operator())>();
+template <typename F, typename... Args>
+auto MakeFlatFunctor(F &function, Args... args) {
+  return FlatFunctor<F, decltype(&F::operator())>(function, std::forward<Args>(args)...);
 }
 
-template <typename... FArgs>
-struct FlatLoop3D {
-  FlatLoop3D() {}
-  template <typename Tag, typename F, typename... Args>
-  inline void operator()(Tag tag, const F &function, const std::string &name,
-                         DevExecSpace exec_space, const int kl, const int ku,
-                         const int jl, const int ju, const int il, const int iu,
-                         Args... args) const {
-    const int Nk = ku - kl + 1;
-    const int Nj = ju - jl + 1;
-    const int Ni = iu - il + 1;
-    const int NkNjNi = Nk * Nj * Ni;
-    const int NjNi = Nj * Ni;
-    kokkos_dispatch(
-        tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
-        KOKKOS_LAMBDA(const int &idx, FArgs... fargs) {
-          int k = idx / NjNi;
-          int j = (idx - k * NjNi) / Ni;
-          int i = idx - k * NjNi - j * Ni;
-          k += kl;
-          j += jl;
-          i += il;
-          function(k, j, i, std::forward<FArgs>(fargs)...);
-        },
-        std::forward<Args>(args)...);
-  }
-};
+template <typename Function, typename R, typename T, typename Index, typename... FArgs>
+class FlatFunctor<Function, R (T::*)(Index, Index, Index, FArgs...) const> {
+  int NjNi, Nj, Ni, kl, jl, il;
+  Function function;
 
-template <typename R, typename T, typename Index, typename... FArgs>
-class FlatFunctor<R (T::*)(Index, Index, Index, FArgs...) const> {
  public:
-  FlatFunctor() {}
-  template <typename Tag, typename F, typename... Args>
-  inline void operator()(Tag tag, const F &function, Args... args) const {
-    const FlatLoop3D<FArgs...> flat3D;
-    flat3D(tag, function, std::forward<Args>(args)...);
+  FlatFunctor(const Function _function, const int _NjNi, const int _Nj, const int _Ni,
+              const int _kl, const int _jl, const int _il)
+      : function(_function), NjNi(_NjNi), Nj(_Nj), Ni(_Ni), kl(_kl), jl(_jl), il(_il) {}
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int &idx, FArgs &&...fargs) const {
+    int k = idx / NjNi;
+    int j = (idx - k * NjNi) / Ni;
+    int i = idx - k * NjNi - j * Ni;
+    k += kl;
+    j += jl;
+    i += il;
+    function(k, j, i, std::forward<FArgs>(fargs)...);
   }
 };
 
@@ -312,9 +294,14 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
              const int kl, const int ku, const int jl, const int ju, const int il,
              const int iu, const Function &function, Args &&...args) {
   Tag tag;
-  const auto func = MakeFlatFunctor(function);
-  func(tag, function, name, exec_space, kl, ku, jl, ju, il, iu,
-       std::forward<Args>(args)...);
+  const int Nk = ku - kl + 1;
+  const int Nj = ju - jl + 1;
+  const int Ni = iu - il + 1;
+  const int NkNjNi = Nk * Nj * Ni;
+  const int NjNi = Nj * Ni;
+  kokkos_dispatch(tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
+                  MakeFlatFunctor(function, NjNi, Nj, Ni, kl, jl, il),
+                  std::forward<Args>(args)...);
 }
 
 // 3D loop using MDRange loops
@@ -405,46 +392,27 @@ inline void par_dispatch(LoopPatternSimdFor, const std::string &name,
         function(k, j, i);
 }
 
-template <typename... FArgs>
-struct FlatLoop4D {
-  FlatLoop4D() {}
-  template <typename Tag, typename F, typename... Args>
-  inline void operator()(Tag tag, const F &function, const std::string &name,
-                         DevExecSpace exec_space, const int nl, const int nu,
-                         const int kl, const int ku, const int jl, const int ju,
-                         const int il, const int iu, Args... args) const {
-    const int Nn = nu - nl + 1;
-    const int Nk = ku - kl + 1;
-    const int Nj = ju - jl + 1;
-    const int Ni = iu - il + 1;
-    const int NnNkNjNi = Nn * Nk * Nj * Ni;
-    const int NkNjNi = Nk * Nj * Ni;
-    const int NjNi = Nj * Ni;
-    kokkos_dispatch(
-        tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
-        KOKKOS_LAMBDA(const int &idx, FArgs... fargs) {
-          int n = idx / NkNjNi;
-          int k = (idx - n * NkNjNi) / NjNi;
-          int j = (idx - n * NkNjNi - k * NjNi) / Ni;
-          int i = idx - n * NkNjNi - k * NjNi - j * Ni;
-          n += nl;
-          k += kl;
-          j += jl;
-          i += il;
-          function(n, k, j, i, std::forward<FArgs>(fargs)...);
-        },
-        std::forward<Args>(args)...);
-  }
-};
+template <typename Function, typename R, typename T, typename Index, typename... FArgs>
+class FlatFunctor<Function, R (T::*)(Index, Index, Index, Index, FArgs...) const> {
+  int NkNjNi, NjNi, Nj, Ni, nl, kl, jl, il;
+  Function function;
 
-template <typename R, typename T, typename Index, typename... FArgs>
-class FlatFunctor<R (T::*)(Index, Index, Index, Index, FArgs...) const> {
  public:
-  FlatFunctor() {}
-  template <typename Tag, typename F, typename... Args>
-  inline void operator()(Tag tag, const F &function, Args... args) const {
-    const FlatLoop4D<FArgs...> flat4D;
-    flat4D(tag, function, std::forward<Args>(args)...);
+  FlatFunctor(const Function _function, const int _NkNjNi, const int _NjNi, const int _Nj,
+              const int _Ni, const int _nl, const int _kl, const int _jl, const int _il)
+      : function(_function), NkNjNi(_NkNjNi), NjNi(_NjNi), Nj(_Nj), Ni(_Ni), nl(_nl),
+        kl(_kl), jl(_jl), il(_il) {}
+  KOKKOS_INLINE_FUNCTION
+  void operator()(const int &idx, FArgs &&...fargs) const {
+    int n = idx / NkNjNi;
+    int k = (idx - n * NkNjNi) / NjNi;
+    int j = (idx - n * NkNjNi - k * NjNi) / Ni;
+    int i = idx - n * NkNjNi - k * NjNi - j * Ni;
+    n += nl;
+    k += kl;
+    j += jl;
+    i += il;
+    function(n, k, j, i, std::forward<FArgs>(fargs)...);
   }
 };
 
@@ -456,9 +424,16 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
              const int ju, const int il, const int iu, const Function &function,
              Args &&...args) {
   Tag tag;
-  const auto func = MakeFlatFunctor(function);
-  func(tag, function, name, exec_space, nl, nu, kl, ku, jl, ju, il, iu,
-       std::forward<Args>(args)...);
+  const int Nn = nu - nl + 1;
+  const int Nk = ku - kl + 1;
+  const int Nj = ju - jl + 1;
+  const int Ni = iu - il + 1;
+  const int NnNkNjNi = Nn * Nk * Nj * Ni;
+  const int NkNjNi = Nk * Nj * Ni;
+  const int NjNi = Nj * Ni;
+  kokkos_dispatch(tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
+                  MakeFlatFunctor(function, NkNjNi, NjNi, Nj, Ni, nl, kl, jl, il),
+                  std::forward<Args>(args)...);
 }
 
 // 4D loop using MDRange loops

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -294,19 +294,8 @@ struct FlatLoop3D {
   }
 };
 
-template <typename R, typename T, typename... FArgs>
-class FlatFunctor<R (T::*)(const int &, const int &, const int &, FArgs...) const> {
- public:
-  FlatFunctor() {}
-  template <typename Tag, typename F, typename... Args>
-  inline void operator()(Tag tag, const F &function, Args... args) const {
-    const FlatLoop3D<FArgs...> flat3D;
-    flat3D(tag, function, std::forward<Args>(args)...);
-  }
-};
-
-template <typename R, typename T, typename... FArgs>
-class FlatFunctor<R (T::*)(const int, const int, const int, FArgs...) const> {
+template <typename R, typename T, typename Index, typename... FArgs>
+class FlatFunctor<R (T::*)(Index, Index, Index, FArgs...) const> {
  public:
   FlatFunctor() {}
   template <typename Tag, typename F, typename... Args>
@@ -448,20 +437,8 @@ struct FlatLoop4D {
   }
 };
 
-template <typename R, typename T, typename... FArgs>
-class FlatFunctor<R (T::*)(const int, const int, const int, const int, FArgs...) const> {
- public:
-  FlatFunctor() {}
-  template <typename Tag, typename F, typename... Args>
-  inline void operator()(Tag tag, const F &function, Args... args) const {
-    const FlatLoop4D<FArgs...> flat4D;
-    flat4D(tag, function, std::forward<Args>(args)...);
-  }
-};
-
-template <typename R, typename T, typename... FArgs>
-class FlatFunctor<R (T::*)(const int &, const int &, const int &, const int &, FArgs...)
-                      const> {
+template <typename R, typename T, typename Index, typename... FArgs>
+class FlatFunctor<R (T::*)(Index, Index, Index, Index, FArgs...) const> {
  public:
   FlatFunctor() {}
   template <typename Tag, typename F, typename... Args>

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -268,7 +268,7 @@ auto MakeFlatFunctor(F &function) {
 
 template <typename... FArgs>
 struct FlatLoop3D {
-  FlatLoop3D() {};
+  FlatLoop3D() {}
   template <typename Tag, typename F, typename... Args>
   inline void operator()(Tag tag, const F &function, const std::string &name,
                          DevExecSpace exec_space, const int kl, const int ku,
@@ -297,10 +297,9 @@ struct FlatLoop3D {
 template <typename R, typename T, typename... FArgs>
 class FlatFunctor<R (T::*)(const int &, const int &, const int &, FArgs...) const> {
  public:
-  FlatFunctor() {};
+  FlatFunctor() {}
   template <typename Tag, typename F, typename... Args>
   inline void operator()(Tag tag, const F &function, Args... args) const {
-
     const FlatLoop3D<FArgs...> flat3D;
     flat3D(tag, function, std::forward<Args>(args)...);
   }
@@ -309,7 +308,7 @@ class FlatFunctor<R (T::*)(const int &, const int &, const int &, FArgs...) cons
 template <typename R, typename T, typename... FArgs>
 class FlatFunctor<R (T::*)(const int, const int, const int, FArgs...) const> {
  public:
-  FlatFunctor() {};
+  FlatFunctor() {}
   template <typename Tag, typename F, typename... Args>
   inline void operator()(Tag tag, const F &function, Args... args) const {
     const FlatLoop3D<FArgs...> flat3D;
@@ -419,7 +418,7 @@ inline void par_dispatch(LoopPatternSimdFor, const std::string &name,
 
 template <typename... FArgs>
 struct FlatLoop4D {
-  FlatLoop4D() {};
+  FlatLoop4D() {}
   template <typename Tag, typename F, typename... Args>
   inline void operator()(Tag tag, const F &function, const std::string &name,
                          DevExecSpace exec_space, const int nl, const int nu,
@@ -452,7 +451,7 @@ struct FlatLoop4D {
 template <typename R, typename T, typename... FArgs>
 class FlatFunctor<R (T::*)(const int, const int, const int, const int, FArgs...) const> {
  public:
-  FlatFunctor() {};
+  FlatFunctor() {}
   template <typename Tag, typename F, typename... Args>
   inline void operator()(Tag tag, const F &function, Args... args) const {
     const FlatLoop4D<FArgs...> flat4D;
@@ -464,7 +463,7 @@ template <typename R, typename T, typename... FArgs>
 class FlatFunctor<R (T::*)(const int &, const int &, const int &, const int &, FArgs...)
                       const> {
  public:
-  FlatFunctor() {};
+  FlatFunctor() {}
   template <typename Tag, typename F, typename... Args>
   inline void operator()(Tag tag, const F &function, Args... args) const {
     const FlatLoop4D<FArgs...> flat4D;

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -258,64 +258,63 @@ par_dispatch(LoopPatternMDRange, const std::string &name, DevExecSpace exec_spac
                   function, std::forward<Args>(args)...);
 }
 
-template<typename> class FlatFunctor;
+template <typename>
+class FlatFunctor;
 
-template<typename F>
+template <typename F>
 auto MakeFlatFunctor(F &function) {
-   return FlatFunctor<decltype(&F::operator())>();
+  return FlatFunctor<decltype(&F::operator())>();
 }
 
-template<typename... FArgs>
+template <typename... FArgs>
 struct FlatLoop3D {
-   FlatLoop3D(){};
-   template <typename Tag, typename F, typename... Args>
-      inline void operator()(Tag tag, const F &function, const std::string &name, 
-            DevExecSpace exec_space, const int kl, const int ku,
-            const int jl, const int ju, const int il, const int iu,
-             Args ...args) const {
-         const int Nk = ku - kl + 1;
-         const int Nj = ju - jl + 1;
-         const int Ni = iu - il + 1;
-         const int NkNjNi = Nk * Nj * Ni;
-         const int NjNi = Nj * Ni;
-         kokkos_dispatch(
-               tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
-               KOKKOS_LAMBDA(const int &idx, FArgs ...fargs) {
-               int k = idx / NjNi;
-               int j = (idx - k * NjNi) / Ni;
-               int i = idx - k * NjNi - j * Ni;
-               k += kl;
-               j += jl;
-               i += il;
-               function(k, j, i, std::forward<FArgs>(fargs)...);
-               },
-               std::forward<Args>(args)...);
-      }
+  FlatLoop3D() {};
+  template <typename Tag, typename F, typename... Args>
+  inline void operator()(Tag tag, const F &function, const std::string &name,
+                         DevExecSpace exec_space, const int kl, const int ku,
+                         const int jl, const int ju, const int il, const int iu,
+                         Args... args) const {
+    const int Nk = ku - kl + 1;
+    const int Nj = ju - jl + 1;
+    const int Ni = iu - il + 1;
+    const int NkNjNi = Nk * Nj * Ni;
+    const int NjNi = Nj * Ni;
+    kokkos_dispatch(
+        tag, name, Kokkos::RangePolicy<>(exec_space, 0, NkNjNi),
+        KOKKOS_LAMBDA(const int &idx, FArgs... fargs) {
+          int k = idx / NjNi;
+          int j = (idx - k * NjNi) / Ni;
+          int i = idx - k * NjNi - j * Ni;
+          k += kl;
+          j += jl;
+          i += il;
+          function(k, j, i, std::forward<FArgs>(fargs)...);
+        },
+        std::forward<Args>(args)...);
+  }
 };
 
-template<typename R, typename T, typename... FArgs>
-class FlatFunctor<R(T::*)(const int &, const int &, const int &, FArgs...) const>
-{
-   public:
-      FlatFunctor(){};
-      template <typename Tag, typename F, typename... Args>
-         inline void operator()(Tag tag, const F &function, Args ...args) const {
+template <typename R, typename T, typename... FArgs>
+class FlatFunctor<R (T::*)(const int &, const int &, const int &, FArgs...) const> {
+ public:
+  FlatFunctor() {};
+  template <typename Tag, typename F, typename... Args>
+  inline void operator()(Tag tag, const F &function, Args... args) const {
 
-            const FlatLoop3D<FArgs...> flat3D;
-            flat3D(tag, function, std::forward<Args>(args)...);
-         }
+    const FlatLoop3D<FArgs...> flat3D;
+    flat3D(tag, function, std::forward<Args>(args)...);
+  }
 };
 
-template<typename R, typename T, typename... FArgs>
-class FlatFunctor<R(T::*)(const int, const int, const int, FArgs...) const>
-{
-   public:
-      FlatFunctor(){};
-      template <typename Tag, typename F, typename... Args>
-         inline void operator()(Tag tag, const F &function, Args ...args) const {
-            const FlatLoop3D<FArgs...> flat3D;
-            flat3D(tag, function, std::forward<Args>(args)...);
-         }
+template <typename R, typename T, typename... FArgs>
+class FlatFunctor<R (T::*)(const int, const int, const int, FArgs...) const> {
+ public:
+  FlatFunctor() {};
+  template <typename Tag, typename F, typename... Args>
+  inline void operator()(Tag tag, const F &function, Args... args) const {
+    const FlatLoop3D<FArgs...> flat3D;
+    flat3D(tag, function, std::forward<Args>(args)...);
+  }
 };
 
 // 3D loop using Kokkos 1D Range
@@ -326,7 +325,8 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
              const int iu, const Function &function, Args &&...args) {
   Tag tag;
   const auto func = MakeFlatFunctor(function);
-  func(tag, function, name, exec_space, kl, ku, jl, ju, il, iu, std::forward<Args>(args)...);
+  func(tag, function, name, exec_space, kl, ku, jl, ju, il, iu,
+       std::forward<Args>(args)...);
 }
 
 // 3D loop using MDRange loops
@@ -417,60 +417,59 @@ inline void par_dispatch(LoopPatternSimdFor, const std::string &name,
         function(k, j, i);
 }
 
-template<typename... FArgs>
+template <typename... FArgs>
 struct FlatLoop4D {
-   FlatLoop4D(){};
-   template <typename Tag, typename F, typename... Args>
-      inline void operator()(Tag tag, const F &function, const std::string &name, 
-                             DevExecSpace exec_space, const int nl, const int nu,
-                             const int kl, const int ku, const int jl, const int ju,
-                             const int il, const int iu,  Args ...args) const {
-            const int Nn = nu - nl + 1;
-            const int Nk = ku - kl + 1;
-            const int Nj = ju - jl + 1;
-            const int Ni = iu - il + 1;
-            const int NnNkNjNi = Nn * Nk * Nj * Ni;
-            const int NkNjNi = Nk * Nj * Ni;
-            const int NjNi = Nj * Ni;
-            kokkos_dispatch(
-                  tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
-                  KOKKOS_LAMBDA(const int &idx, FArgs ...fargs) {
-                  int n = idx / NkNjNi;
-                  int k = (idx - n * NkNjNi) / NjNi;
-                  int j = (idx - n * NkNjNi - k * NjNi) / Ni;
-                  int i = idx - n * NkNjNi - k * NjNi - j * Ni;
-                  n += nl;
-                  k += kl;
-                  j += jl;
-                  i += il;
-                  function(n, k, j, i, std::forward<FArgs>(fargs)...);
-                  },
-                  std::forward<Args>(args)...);
-      }
+  FlatLoop4D() {};
+  template <typename Tag, typename F, typename... Args>
+  inline void operator()(Tag tag, const F &function, const std::string &name,
+                         DevExecSpace exec_space, const int nl, const int nu,
+                         const int kl, const int ku, const int jl, const int ju,
+                         const int il, const int iu, Args... args) const {
+    const int Nn = nu - nl + 1;
+    const int Nk = ku - kl + 1;
+    const int Nj = ju - jl + 1;
+    const int Ni = iu - il + 1;
+    const int NnNkNjNi = Nn * Nk * Nj * Ni;
+    const int NkNjNi = Nk * Nj * Ni;
+    const int NjNi = Nj * Ni;
+    kokkos_dispatch(
+        tag, name, Kokkos::RangePolicy<>(exec_space, 0, NnNkNjNi),
+        KOKKOS_LAMBDA(const int &idx, FArgs... fargs) {
+          int n = idx / NkNjNi;
+          int k = (idx - n * NkNjNi) / NjNi;
+          int j = (idx - n * NkNjNi - k * NjNi) / Ni;
+          int i = idx - n * NkNjNi - k * NjNi - j * Ni;
+          n += nl;
+          k += kl;
+          j += jl;
+          i += il;
+          function(n, k, j, i, std::forward<FArgs>(fargs)...);
+        },
+        std::forward<Args>(args)...);
+  }
 };
 
-template<typename R, typename T, typename... FArgs>
-class FlatFunctor<R(T::*)(const int, const int, const int, const int, FArgs...) const>
-{
-   public:
-      FlatFunctor(){};
-      template <typename Tag, typename F, typename... Args>
-         inline void operator()(Tag tag, const F &function, Args ...args) const {
-            const FlatLoop4D<FArgs...> flat4D;
-            flat4D(tag, function, std::forward<Args>(args)...);
-         }
+template <typename R, typename T, typename... FArgs>
+class FlatFunctor<R (T::*)(const int, const int, const int, const int, FArgs...) const> {
+ public:
+  FlatFunctor() {};
+  template <typename Tag, typename F, typename... Args>
+  inline void operator()(Tag tag, const F &function, Args... args) const {
+    const FlatLoop4D<FArgs...> flat4D;
+    flat4D(tag, function, std::forward<Args>(args)...);
+  }
 };
 
-template<typename R, typename T, typename... FArgs>
-class FlatFunctor<R(T::*)(const int &, const int &, const int &, const int &, FArgs...) const>
-{
-   public:
-      FlatFunctor(){};
-      template <typename Tag, typename F, typename... Args>
-         inline void operator()(Tag tag, const F &function, Args ...args) const {
-            const FlatLoop4D<FArgs...> flat4D;
-            flat4D(tag, function, std::forward<Args>(args)...);
-         }
+template <typename R, typename T, typename... FArgs>
+class FlatFunctor<R (T::*)(const int &, const int &, const int &, const int &, FArgs...)
+                      const> {
+ public:
+  FlatFunctor() {};
+  template <typename Tag, typename F, typename... Args>
+  inline void operator()(Tag tag, const F &function, Args... args) const {
+    const FlatLoop4D<FArgs...> flat4D;
+    flat4D(tag, function, std::forward<Args>(args)...);
+  }
 };
 
 // 4D loop using Kokkos 1D Range
@@ -483,7 +482,7 @@ par_dispatch(LoopPatternFlatRange, const std::string &name, DevExecSpace exec_sp
   Tag tag;
   const auto func = MakeFlatFunctor(function);
   func(tag, function, name, exec_space, nl, nu, kl, ku, jl, ju, il, iu,
-        std::forward<Args>(args)...);
+       std::forward<Args>(args)...);
 }
 
 // 4D loop using MDRange loops

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -568,10 +568,14 @@ TEST_CASE("Parallel reduce", "[par_reduce]") {
   SECTION("3D loops") {
   REQUIRE(test_wrapper_reduce_3d(parthenon::loop_pattern_flatrange_tag,
                                  default_exec_space) == true);
+  REQUIRE(test_wrapper_reduce_3d(parthenon::loop_pattern_mdrange_tag,
+                                 default_exec_space) == true);
   }
 
   SECTION("4D loops") {
   REQUIRE(test_wrapper_reduce_4d(parthenon::loop_pattern_flatrange_tag,
+                                 default_exec_space) == true);
+  REQUIRE(test_wrapper_reduce_4d(parthenon::loop_pattern_mdrange_tag,
                                  default_exec_space) == true);
   }
 }

--- a/tst/unit/kokkos_abstraction.cpp
+++ b/tst/unit/kokkos_abstraction.cpp
@@ -506,76 +506,79 @@ bool test_wrapper_reduce_3d(T loop_pattern, DevExecSpace exec_space) {
   parthenon::ParArray3D<int> buffer("Testing buffer", N, N, N);
   // Initialize data
   parthenon::par_for(
-      loop_pattern, "Initialize parallel reduce array", exec_space, 0, N-1, 0, N-1, 0, N-1,
-      KOKKOS_LAMBDA(const int k, const int j, const int i) { buffer(k,j,i) = i+j+k; });
+      loop_pattern, "Initialize parallel reduce array", exec_space, 0, N - 1, 0, N - 1, 0,
+      N - 1, KOKKOS_LAMBDA(const int k, const int j, const int i) {
+        buffer(k, j, i) = i + j + k;
+      });
   int tot = 0;
   for (int k = 0; k < N; ++k) {
-     for (int j = 0; j < N; ++j) {
-        for (int i = 0; i < N; ++i) {
-          tot += i+j+k;
-        }
-     }
+    for (int j = 0; j < N; ++j) {
+      for (int i = 0; i < N; ++i) {
+        tot += i + j + k;
+      }
+    }
   }
   int test_tot = 0;
   parthenon::par_reduce(
-      loop_pattern, "Sum via par reduce", exec_space,
-      0, N-1, 0, N-1, 0, N-1,
-      KOKKOS_LAMBDA(const int k, const int j, const int i, int &t) {
-         t += i+j+k; 
-      }, Kokkos::Sum<int>(test_tot));
+      loop_pattern, "Sum via par reduce", exec_space, 0, N - 1, 0, N - 1, 0, N - 1,
+      KOKKOS_LAMBDA(const int k, const int j, const int i, int &t) { t += i + j + k; },
+      Kokkos::Sum<int>(test_tot));
   return tot == test_tot;
 }
 
 template <class T>
 bool test_wrapper_reduce_4d(T loop_pattern, DevExecSpace exec_space) {
-   constexpr int N = 10;
-   parthenon::ParArray4D<int> buffer("Testing buffer", N, N, N, N);
-   // Initialize data
-   parthenon::par_for(
-         loop_pattern, "Initialize parallel reduce array", exec_space, 0, N-1, 0, N-1, 0, N-1, 0, N-1,
-         KOKKOS_LAMBDA(const int n, const int k, const int j, const int i) { buffer(n,k,j,i) = i+j+k+n; });
-   int tot = 0;
-   for (int n = 0; n < N; ++n) {
-      for (int k = 0; k < N; ++k) {
-         for (int j = 0; j < N; ++j) {
-            for (int i = 0; i < N; ++i) {
-               tot += i+j+k+n;
-            }
-         }
+  constexpr int N = 10;
+  parthenon::ParArray4D<int> buffer("Testing buffer", N, N, N, N);
+  // Initialize data
+  parthenon::par_for(
+      loop_pattern, "Initialize parallel reduce array", exec_space, 0, N - 1, 0, N - 1, 0,
+      N - 1, 0, N - 1, KOKKOS_LAMBDA(const int n, const int k, const int j, const int i) {
+        buffer(n, k, j, i) = i + j + k + n;
+      });
+  int tot = 0;
+  for (int n = 0; n < N; ++n) {
+    for (int k = 0; k < N; ++k) {
+      for (int j = 0; j < N; ++j) {
+        for (int i = 0; i < N; ++i) {
+          tot += i + j + k + n;
+        }
       }
-   }
+    }
+  }
   int test_tot = 0;
   parthenon::par_reduce(
-      loop_pattern, "Sum via par reduce", exec_space,
-      0, N-1, 0, N-1, 0, N-1, 0, N-1,
+      loop_pattern, "Sum via par reduce", exec_space, 0, N - 1, 0, N - 1, 0, N - 1, 0,
+      N - 1,
       KOKKOS_LAMBDA(const int n, const int k, const int j, const int i, int &t) {
-         t += i+j+k+n; 
-      }, Kokkos::Sum<int>(test_tot));
+        t += i + j + k + n;
+      },
+      Kokkos::Sum<int>(test_tot));
   return tot == test_tot;
 }
 
 TEST_CASE("Parallel reduce", "[par_reduce]") {
   auto default_exec_space = DevExecSpace();
   SECTION("1D loops") {
-  REQUIRE(test_wrapper_reduce_1d(parthenon::loop_pattern_flatrange_tag,
-                                 default_exec_space) == true);
-  if constexpr (std::is_same<DevExecSpace, Kokkos::Serial>::value) {
-    REQUIRE(test_wrapper_reduce_1d(parthenon::loop_pattern_simdfor_tag,
+    REQUIRE(test_wrapper_reduce_1d(parthenon::loop_pattern_flatrange_tag,
                                    default_exec_space) == true);
-  }
+    if constexpr (std::is_same<DevExecSpace, Kokkos::Serial>::value) {
+      REQUIRE(test_wrapper_reduce_1d(parthenon::loop_pattern_simdfor_tag,
+                                     default_exec_space) == true);
+    }
   }
 
   SECTION("3D loops") {
-  REQUIRE(test_wrapper_reduce_3d(parthenon::loop_pattern_flatrange_tag,
-                                 default_exec_space) == true);
-  REQUIRE(test_wrapper_reduce_3d(parthenon::loop_pattern_mdrange_tag,
-                                 default_exec_space) == true);
+    REQUIRE(test_wrapper_reduce_3d(parthenon::loop_pattern_flatrange_tag,
+                                   default_exec_space) == true);
+    REQUIRE(test_wrapper_reduce_3d(parthenon::loop_pattern_mdrange_tag,
+                                   default_exec_space) == true);
   }
 
   SECTION("4D loops") {
-  REQUIRE(test_wrapper_reduce_4d(parthenon::loop_pattern_flatrange_tag,
-                                 default_exec_space) == true);
-  REQUIRE(test_wrapper_reduce_4d(parthenon::loop_pattern_mdrange_tag,
-                                 default_exec_space) == true);
+    REQUIRE(test_wrapper_reduce_4d(parthenon::loop_pattern_flatrange_tag,
+                                   default_exec_space) == true);
+    REQUIRE(test_wrapper_reduce_4d(parthenon::loop_pattern_mdrange_tag,
+                                   default_exec_space) == true);
   }
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->
Replaces `KOKKOS_LAMBDA`s with templated functors in `par_dispatch(LoopPatternFlatRange, ...)` that deduce the signature of the provided `function` to allow for extra arguments used in reductions.

Makes it possible to use `par_reduce(DEFAULT_LOOP_PATTERN, ..)` & `par_reduce(name, ...)` 


<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
