### PR TITLE
Small Bugfix: Fix an issue outputting >4GB single variables per rank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1146]](https://github.com/parthenon-hpc-lab/parthenon/pull/1146) Fix an issue outputting >4GB single variables per rank
 - [[PR 1132]](https://github.com/parthenon-hpc-lab/parthenon/pull/1132) Fix regional dependencies for iterative task lists and make solvers work for arbirtrary MeshData partitioning
 - [[PR 1139]](https://github.com/parthenon-hpc-lab/parthenon/pull/1139) only add --expt-relaxed-constexpr for COMPILE_LANGUAGE:CXX
 - [[PR 1131]](https://github.com/parthenon-hpc-lab/parthenon/pull/1131) Make deallocation of fine and sparse fields work

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -76,8 +76,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   // HDF5 structures
   // Also writes companion xdmf file
 
-  const int max_blocks_global = pm->nbtotal;
-  const int num_blocks_local = static_cast<int>(pm->block_list.size());
+  const size_t max_blocks_global = pm->nbtotal;
+  const size_t num_blocks_local = static_cast<int>(pm->block_list.size());
 
   const IndexDomain theDomain =
       (output_params.include_ghost_zones ? IndexDomain::entire : IndexDomain::interior);
@@ -301,9 +301,9 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   std::vector<int> sparse_dealloc_count(num_blocks_local * num_sparse);
 
   // allocate space for largest size variable
-  int varSize_max = 0;
+  size_t varSize_max = 0;
   for (auto &vinfo : all_vars_info) {
-    const int varSize = vinfo.Size();
+    const size_t varSize = vinfo.Size();
     varSize_max = std::max(varSize_max, varSize);
   }
 

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -77,7 +77,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
   // Also writes companion xdmf file
 
   const size_t max_blocks_global = pm->nbtotal;
-  const size_t num_blocks_local = static_cast<int>(pm->block_list.size());
+  const size_t num_blocks_local = pm->block_list.size();
 
   const IndexDomain theDomain =
       (output_params.include_ghost_zones ? IndexDomain::entire : IndexDomain::interior);


### PR DESCRIPTION
`parthenon_hdf5.cpp` allocates a `std::vector` cache of the largest per-block variable size times the number of blocks.  However, both numbers are declared as `int`s, so when they are multiplied it overflows when outputting a variable of total size >4GB from a single MPI rank.

Oddly, this raises the following tangentially-related error:
```
terminate called after throwing an instance of 'std::length_error'
  what():  cannot create std::vector larger than max_size()
```

There are various ways of fixing this, but I chose the easy one.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
