### PR TITLE
Add `par_reduce_inner` functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1147]](https://github.com/parthenon-hpc-lab/parthenon/pull/1147) Add `par_reduce_inner` functions
 - [[PR 1140]](https://github.com/parthenon-hpc-lab/parthenon/pull/1140) Allow for relative convergence tolerance in BiCGSTAB solver.
 - [[PR 1047]](https://github.com/parthenon-hpc-lab/parthenon/pull/1047) General three- and four-valent 2D forests w/ arbitrary orientations.
 - [[PR 1130]](https://github.com/parthenon-hpc-lab/parthenon/pull/1130) Enable `parthenon::par_reduce` for MD loops with Kokkos 1D Range

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -979,9 +979,9 @@ KOKKOS_FORCEINLINE_FUNCTION void par_for_inner(team_mbr_t team_member, Args &&..
 // Inner reduction loops
 template <typename Function, typename T>
 KOKKOS_FORCEINLINE_FUNCTION void
-par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int jl,
-                 const int ju, const int il, const int iu, const Function &function,
-                 T reduction) {
+par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int kl, const int ku,
+                 const int jl, const int ju, const int il, const int iu,
+                 const Function &function, T reduction) {
   const int Nk = ku - kl + 1;
   const int Nj = ju - jl + 1;
   const int Ni = iu - il + 1;
@@ -1003,8 +1003,8 @@ par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int j
 
 template <typename Function, typename T>
 KOKKOS_FORCEINLINE_FUNCTION void
-par_reduce_inner(team_mbr_t team_member, const int jl, const int ju, const int il,
-                 const int iu, const Function &function, T reduction) {
+par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int jl, const int ju,
+                 const int il, const int iu, const Function &function, T reduction) {
   const int Nj = ju - jl + 1;
   const int Ni = iu - il + 1;
   const int NjNi = Nj * Ni;
@@ -1021,9 +1021,9 @@ par_reduce_inner(team_mbr_t team_member, const int jl, const int ju, const int i
 }
 
 template <typename Function, typename T>
-KOKKOS_FORCEINLINE_FUNCTION void par_reduce_inner(team_mbr_t team_member, const int il,
-                                                  const int iu, const Function &function,
-                                                  T reduction) {
+KOKKOS_FORCEINLINE_FUNCTION void
+par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int il, const int iu,
+                 const Function &function, T reduction) {
   const int Ni = iu - il + 1;
   Kokkos::parallel_reduce(
       Kokkos::TeamThreadRange(team_member, Ni),

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -1003,9 +1003,8 @@ par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int j
 
 template <typename Function, typename T>
 KOKKOS_FORCEINLINE_FUNCTION void
-par_reduce_inner(team_mbr_t team_member, const int jl,
-                 const int ju, const int il, const int iu, const Function &function,
-                 T reduction) {
+par_reduce_inner(team_mbr_t team_member, const int jl, const int ju, const int il,
+                 const int iu, const Function &function, T reduction) {
   const int Nj = ju - jl + 1;
   const int Ni = iu - il + 1;
   const int NjNi = Nj * Ni;
@@ -1022,9 +1021,9 @@ par_reduce_inner(team_mbr_t team_member, const int jl,
 }
 
 template <typename Function, typename T>
-KOKKOS_FORCEINLINE_FUNCTION void
-par_reduce_inner(team_mbr_t team_member, const int il, const int iu, const Function &function,
-                 T reduction) {
+KOKKOS_FORCEINLINE_FUNCTION void par_reduce_inner(team_mbr_t team_member, const int il,
+                                                  const int iu, const Function &function,
+                                                  T reduction) {
   const int Ni = iu - il + 1;
   Kokkos::parallel_reduce(
       Kokkos::TeamThreadRange(team_member, Ni),

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -976,6 +976,66 @@ KOKKOS_FORCEINLINE_FUNCTION void par_for_inner(team_mbr_t team_member, Args &&..
   par_for_inner(DEFAULT_INNER_LOOP_PATTERN, team_member, std::forward<Args>(args)...);
 }
 
+// Inner reduction loops
+template <typename Function, typename T>
+KOKKOS_FORCEINLINE_FUNCTION void
+par_reduce_inner(team_mbr_t team_member, const int kl, const int ku, const int jl,
+                 const int ju, const int il, const int iu, const Function &function,
+                 T reduction) {
+  const int Nk = ku - kl + 1;
+  const int Nj = ju - jl + 1;
+  const int Ni = iu - il + 1;
+  const int NkNjNi = Nk * Nj * Ni;
+  const int NjNi = Nj * Ni;
+  Kokkos::parallel_reduce(
+      Kokkos::TeamThreadRange(team_member, NkNjNi),
+      [&](const int &idx, typename T::value_type &lreduce) {
+        int k = idx / NjNi;
+        int j = (idx - k * NjNi) / Ni;
+        int i = idx - k * NjNi - j * Ni;
+        k += kl;
+        j += jl;
+        i += il;
+        function(k, j, i, lreduce);
+      },
+      reduction);
+}
+
+template <typename Function, typename T>
+KOKKOS_FORCEINLINE_FUNCTION void
+par_reduce_inner(team_mbr_t team_member, const int jl,
+                 const int ju, const int il, const int iu, const Function &function,
+                 T reduction) {
+  const int Nj = ju - jl + 1;
+  const int Ni = iu - il + 1;
+  const int NjNi = Nj * Ni;
+  Kokkos::parallel_reduce(
+      Kokkos::TeamThreadRange(team_member, NjNi),
+      [&](const int &idx, typename T::value_type &lreduce) {
+        int j = idx / Ni;
+        int i = idx - j * Ni;
+        j += jl;
+        i += il;
+        function(j, i, lreduce);
+      },
+      reduction);
+}
+
+template <typename Function, typename T>
+KOKKOS_FORCEINLINE_FUNCTION void
+par_reduce_inner(team_mbr_t team_member, const int il, const int iu, const Function &function,
+                 T reduction) {
+  const int Ni = iu - il + 1;
+  Kokkos::parallel_reduce(
+      Kokkos::TeamThreadRange(team_member, Ni),
+      [&](const int &idx, typename T::value_type &lreduce) {
+        int i = idx;
+        i += il;
+        function(i, lreduce);
+      },
+      reduction);
+}
+
 // reused from kokoks/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
 // commit a0d011fb30022362c61b3bb000ae3de6906cb6a7
 template <class ExecSpace>


### PR DESCRIPTION
All credit for these to @pdmullen!  I will fix bugs if they come up though.

At some point @pdmullen sent me some implementations of inner loops for performing reductions, i.e. `par_for_inner` but for `par_reduce`.  This is useful if reducing to a vector, replacing values with an average, etc.

I am using the 1D variant in production happily, but haven't needed the 2D and 3D versions yet -- it seems difficult to believe they're incorrect though.  I'm poking them upstream as a part of reducing the changeset between KHARMA's parthenon and `develop`, which is now quite small!

It might be useful to have a unit test for these, which I can add soon.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
