### PR TITLE
Add `GetPackDimension` to `StateDescriptor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1148]](https://github.com/parthenon-hpc-lab/parthenon/pull/1148) Add `GetPackDimension` to `StateDescriptor` for calculating pack sizes before `Mesh` initialization
 - [[PR 1140]](https://github.com/parthenon-hpc-lab/parthenon/pull/1140) Allow for relative convergence tolerance in BiCGSTAB solver.
 - [[PR 1047]](https://github.com/parthenon-hpc-lab/parthenon/pull/1047) General three- and four-valent 2D forests w/ arbitrary orientations.
 - [[PR 1130]](https://github.com/parthenon-hpc-lab/parthenon/pull/1130) Enable `parthenon::par_reduce` for MD loops with Kokkos 1D Range

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -566,4 +566,37 @@ StateDescriptor::GetVariableNames(const Metadata::FlagCollection &flags) {
   return GetVariableNames({}, flags, {});
 }
 
+// Get the total length of this StateDescriptor's variables when packed
+int StateDescriptor::GetPackDimension(const std::vector<std::string> &req_names,
+                                      const Metadata::FlagCollection &flags,
+                                      const std::vector<int> &sparse_ids) {
+  std::vector<std::string> names = GetVariableNames(req_names, flags, sparse_ids);
+  int nvar = 0;
+  for (auto name : names) {
+    const auto &meta = metadataMap_[VarID(name)];
+    int var_len = 0;
+    if (meta.Shape().size() < 1) {
+      var_len = 1;
+    } else {
+      var_len = meta.Shape()[0];
+    }
+    nvar += var_len;
+  }
+  return nvar;
+}
+int StateDescriptor::GetPackDimension(const std::vector<std::string> &req_names,
+                                      const std::vector<int> &sparse_ids) {
+  return GetPackDimension(req_names, Metadata::FlagCollection(), sparse_ids);
+}
+int StateDescriptor::GetPackDimension(const Metadata::FlagCollection &flags,
+                                      const std::vector<int> &sparse_ids) {
+  return GetPackDimension({}, flags, sparse_ids);
+}
+int StateDescriptor::GetPackDimension(const std::vector<std::string> &req_names) {
+  return GetPackDimension(req_names, Metadata::FlagCollection(), {});
+}
+int StateDescriptor::GetPackDimension(const Metadata::FlagCollection &flags) {
+  return GetPackDimension({}, flags, {});
+}
+
 } // namespace parthenon

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -577,8 +577,14 @@ int StateDescriptor::GetPackDimension(const std::vector<std::string> &req_names,
     int var_len = 0;
     if (meta.Shape().size() < 1) {
       var_len = 1;
-    } else {
+    } else if (meta.Shape().size() == 1) {
       var_len = meta.Shape()[0];
+    } else if (meta.Shape().size() == 2) {
+      var_len = meta.Shape()[0] * meta.Shape()[1];
+    } else if (meta.Shape().size() == 3) {
+      var_len = meta.Shape()[0] * meta.Shape()[1] * meta.Shape()[2];
+    } else {
+      PARTHENON_THROW("Computing total lengths of tensors of rank >3 is not supported!");
     }
     nvar += var_len;
   }

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -276,6 +276,16 @@ class StateDescriptor {
   std::vector<std::string> GetVariableNames(const std::vector<std::string> &req_names);
   std::vector<std::string> GetVariableNames(const Metadata::FlagCollection &flags);
 
+  int GetPackDimension(const std::vector<std::string> &req_names,
+                       const Metadata::FlagCollection &flags,
+                       const std::vector<int> &sparse_ids);
+  int GetPackDimension(const std::vector<std::string> &req_names,
+                       const std::vector<int> &sparse_ids);
+  int GetPackDimension(const Metadata::FlagCollection &flags,
+                       const std::vector<int> &sparse_ids);
+  int GetPackDimension(const std::vector<std::string> &req_names);
+  int GetPackDimension(const Metadata::FlagCollection &flags);
+
   std::size_t
   RefinementFuncID(const refinement::RefinementFunctions_t &funcs) const noexcept {
     return refinementFuncMaps_.funcs_to_ids.at(funcs);

--- a/tst/unit/test_state_descriptor.cpp
+++ b/tst/unit/test_state_descriptor.cpp
@@ -121,6 +121,22 @@ TEST_CASE("Test Associate in StateDescriptor", "[StateDescriptor]") {
   }
 }
 
+TEST_CASE("Test GetPackDimension in StateDescriptor", "[StateDescriptor]") {
+  GIVEN("Some flags and state descriptors") {
+    StateDescriptor state("state");
+    WHEN("We add some fields with various shapes and total size") {
+      state.AddField("foo", Metadata(std::vector<MetadataFlag>{}, std::vector<int>{4}));
+      state.AddField("bar",
+                     Metadata(std::vector<MetadataFlag>{}, std::vector<int>{4, 4}));
+      state.AddField("baz",
+                     Metadata(std::vector<MetadataFlag>{}, std::vector<int>{4, 4, 4}));
+      THEN("The total length is identified correctly") {
+        REQUIRE(state.GetPackDimension(Metadata::GetUserFlag("state")) == 84);
+      }
+    }
+  }
+}
+
 TEST_CASE("Test dependency resolution in StateDescriptor", "[StateDescriptor]") {
   GIVEN("Some empty state descriptors and metadata") {
     // metadata


### PR DESCRIPTION
Sometimes when initializing a package, you want to know how many variables another package has declared (e.g., a `Flux` package might need the total number of `WithFluxes` variables declared so far).  The `Mesh` doesn't exist yet, so you have to ask the other packages directly, and have them tally up variable lists.  Thus, `GetPackDimension`.

This is the last of the patches I've been carrying in KHARMA's version of Parthenon vs. `develop`.  It works for my purposes downstream, ~~but I'm pretty sure it would fail for `Overridable` variables and maybe other corner cases.  Happy to try to make it more robust if it seems useful, or keep it downstream if no one else needs this kind of info at package init time (or maybe there's some cleaner way to get it? Create a temporary `resolved_state` or something?)~~

I've checked and these functions work fine for the `StateDescriptor` returned by `CreateResolvedStateDescriptor`, which I think already resolves any `Overridable` variables down to a single entry each.  So, if anyone else needs this sort of crazy thing, the code in here at least has a decent chance of being robust for whatever use case they're throwing at it.  Since I think the overall function has a chance of being broadly useful, I'm going to remove WIP, add a changelog entry, and ask for reviews/opinions.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
