### PR TITLE
Reduce memory consumption for buffer pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1150]](https://github.com/parthenon-hpc-lab/parthenon/pull/1150) Reduce memory consumption for buffer pool
+- [[PR 1146]](https://github.com/parthenon-hpc-lab/parthenon/pull/1146) Fix an issue outputting >4GB single variables per rank
 - [[PR 1152]](https://github.com/parthenon-hpc-lab/parthenon/pull/1152) Fix memory leak in task graph outputs related to `abi::__cxa_demangle`
 - [[PR 1146]](https://github.com/parthenon-hpc-lab/parthenon/pull/1146) Fix an issue outputting >4GB single variables per rank
 - [[PR 1144]](https://github.com/parthenon-hpc-lab/parthenon/pull/1144) Fix some restarts w/non-CC fields

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -332,7 +332,7 @@ BndInfo BndInfo::GetSetBndInfo(MeshBlock *pmb, const NeighborBlock &nb,
     out.buf_allocated = false;
   } else {
     printf("%i [rank: %i] -> %i [rank: %i] (Set %s) is in state %i.\n", nb.gid, nb.rank,
-           pmb->gid, Globals::my_rank, v->label().c_str(), buf_state);
+           pmb->gid, Globals::my_rank, v->label().c_str(), static_cast<int>(buf_state));
     PARTHENON_FAIL("Buffer should be in a received state.");
   }
   return out;

--- a/src/bvals/comms/build_boundary_buffers.cpp
+++ b/src/bvals/comms/build_boundary_buffers.cpp
@@ -53,10 +53,11 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
     int buf_size = GetBufferSize(pmb, nb, v);
     if (pmb->gid == nb.gid && nb.offsets.IsCell()) buf_size = 0;
 
-    if (v->IsAllocated()) {
-      nbufs[buf_size] += 1; // relying on value init of int to 0 for initial entry
-    }
+    nbufs[buf_size] += 1; // relying on value init of int to 0 for initial entry
+    std::cerr << "\nnbufs[" << buf_size << "] += 1, which is now " << nbufs[buf_size];
   });
+
+  std::cerr << "\nbefore nbufs.size = " << nbufs.size();
 
   ForEachBoundary<BTYPE>(md, [&](auto pmb, sp_mbd_t /*rc*/, nb_t &nb, const sp_cv_t v) {
     // Calculate the required size of the buffer for this boundary
@@ -66,6 +67,9 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
     // Add a buffer pool if one does not exist for this size
     using buf_t = buf_pool_t<Real>::base_t;
     if (pmesh->pool_map.count(buf_size) == 0) {
+      std::cerr << "\ninside nbufs.size = " << nbufs.size();
+      std::cerr << "\nGoing to request " << nbufs[buf_size] << " buffers of size "
+                << buf_size;
       pmesh->pool_map.emplace(std::make_pair(
           buf_size, buf_pool_t<Real>([buf_size, &nbufs](buf_pool_t<Real> *pool) {
             const auto pool_size = static_cast<int64_t>(nbufs[buf_size]) * buf_size;

--- a/src/bvals/comms/build_boundary_buffers.cpp
+++ b/src/bvals/comms/build_boundary_buffers.cpp
@@ -53,7 +53,9 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
     int buf_size = GetBufferSize(pmb, nb, v);
     if (pmb->gid == nb.gid && nb.offsets.IsCell()) buf_size = 0;
 
-    nbufs[buf_size] += 1; // relying on value init of int to 0 for initial entry
+    if (v->IsAllocated()) {
+      nbufs[buf_size] += 1; // relying on value init of int to 0 for initial entry
+    }
   });
 
   ForEachBoundary<BTYPE>(md, [&](auto pmb, sp_mbd_t /*rc*/, nb_t &nb, const sp_cv_t v) {
@@ -64,7 +66,7 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
     // Add a buffer pool if one does not exist for this size
     using buf_t = buf_pool_t<Real>::base_t;
     if (pmesh->pool_map.count(buf_size) == 0) {
-      pmesh->pool_map.emplace(
+      pmesh->pool_map.emplace(std::make_pair(
           buf_size, buf_pool_t<Real>([buf_size, &nbufs](buf_pool_t<Real> *pool) {
             const auto pool_size = static_cast<int64_t>(nbufs[buf_size]) * buf_size;
             buf_t chunk("pool buffer", pool_size);
@@ -73,10 +75,10 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
                   buf_t(chunk, std::make_pair(i * buf_size, (i + 1) * buf_size)));
             }
             return buf_t(chunk, std::make_pair(0, buf_size));
-          }));
+          })));
       // or add to existing pool (if required)
     } else {
-      auto pool = pmesh->pool_map[buf_size];
+      auto &pool = pmesh->pool_map.at(buf_size);
       const auto new_buffers_req = nbufs[buf_size] - pool.NumAvailable();
       if (new_buffers_req > 1) {
         const auto pool_size = static_cast<int64_t>(new_buffers_req) * buf_size;

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -62,9 +62,7 @@ class ObjectPool {
     std::cout << inuse_.size() << " used objects." << std::endl;
   }
 
-  auto NumAvailable() const {
-    return available_.size();
-  }
+  auto NumAvailable() const { return available_.size(); }
 
   std::uint64_t SizeInBytes() const {
     constexpr std::uint64_t datum_size = sizeof(typename base_t::value_type);

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -62,6 +62,10 @@ class ObjectPool {
     std::cout << inuse_.size() << " used objects." << std::endl;
   }
 
+  auto NumAvailable() const {
+    return available_.size();
+  }
+
   std::uint64_t SizeInBytes() const {
     constexpr std::uint64_t datum_size = sizeof(typename base_t::value_type);
     std::uint64_t object_size = 0;

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -62,7 +62,7 @@ class ObjectPool {
     std::cout << inuse_.size() << " used objects." << std::endl;
   }
 
-  auto NumAvailable() const { return available_.size(); }
+  auto NumBuffersInPool() const { return inuse_.size() + available_.size(); }
 
   std::uint64_t SizeInBytes() const {
     constexpr std::uint64_t datum_size = sizeof(typename base_t::value_type);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->
## PR Summary

Tries to reduce the memory footprint of the object pool by precalculating the number of buffers required for each type.
Also fixes an original overflow for very large buffer sizes (and the default 200 number of buffers).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
