### PR TITLE
Bugfix: Fix memory leak 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [[PR 1004]](https://github.com/parthenon-hpc-lab/parthenon/pull/1004) Allow parameter modification from an input file for restarts
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1152]](https://github.com/parthenon-hpc-lab/parthenon/pull/1152) Fix memory leak in task graph outputs related to `abi::__cxa_demangle`
 - [[PR 1146]](https://github.com/parthenon-hpc-lab/parthenon/pull/1146) Fix an issue outputting >4GB single variables per rank
 - [[PR 1144]](https://github.com/parthenon-hpc-lab/parthenon/pull/1144) Fix some restarts w/non-CC fields
 - [[PR 1132]](https://github.com/parthenon-hpc-lab/parthenon/pull/1132) Fix regional dependencies for iterative task lists and make solvers work for arbirtrary MeshData partitioning

--- a/src/tasks/tasks.hpp
+++ b/src/tasks/tasks.hpp
@@ -503,8 +503,10 @@ class TaskList {
     if (!label.has_value()) label = "anon";
 #ifdef HAS_CXX_ABI
     int status;
-    auto signature =
-        std::string(abi::__cxa_demangle(typeid(F).name(), NULL, NULL, &status));
+    // _cxa_demangle calls malloc so we must call free
+    char *signature_name = abi::__cxa_demangle(typeid(F).name(), NULL, NULL, &status);
+    auto signature = std::string(signature_name);
+    std::free(signature_name);
 #else
     std::string signature = " (...)";
 #endif


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Testing in a downstream code caught a bad memory leak related to the tasks that would eventually crash the node. I tracked this down to the use of `abi::__cxa_demangle` for the task graph output machinery.  `abi::__cxa_demangle` for one reason or another explicitly calls `malloc` for the name it returns. So we have to call `free` on the name after it's used. 

I can confirm that this change fixes the memory leak.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
