### PR TITLE
[Trivial] Make more `EvolutionDriver` functions overridable

### DIFF
--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -79,8 +79,8 @@ class EvolutionDriver : public Driver {
     pouts = std::make_unique<Outputs>(pmesh, pinput, &tm);
   }
   DriverStatus Execute() override;
-  void SetGlobalTimeStep();
-  void OutputCycleDiagnostics();
+  virtual void SetGlobalTimeStep();
+  virtual void OutputCycleDiagnostics();
   void DumpInputParameters();
 
   virtual TaskListStatus Step() = 0;


### PR DESCRIPTION
Anything I write here will be longer than the change itself.

Motivation is KHARMA sometimes needs to choose the timestep in unique ways. This has previously been done in the per-package `EstimateTimestep` by manipulating the block/package's return, but globally-enforced limits or alternatives would be cleaner.

Also included a mark for `OutputCycleDiagnostics`, in case having `t` and `dt` to 16 digits of precision isn't somebody's jam for some inscrutable reason.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
