### PR TITLE
[Trivial] Document that more EvolutionDriver functions are overridable

### DIFF
--- a/doc/sphinx/src/driver.rst
+++ b/doc/sphinx/src/driver.rst
@@ -32,7 +32,9 @@ The ``EvolutionDriver`` class derives from ``Driver``, defining the
 
 loop, including periodic outputs. It has a single pure virtual member
 function called ``Step`` which a derived class must define and which
-will be called during each pass of the loop above.
+will be called during each pass of the loop above. The
+``SetGlobalTimeStep`` and ``OutputCycleDiagnostics`` functions have
+default implementations, but can be overridden for flexibility.
 
 MultiStageDriver
 ----------------


### PR DESCRIPTION
@pgrete brings up the excellent point we should mention which functions are available to override in `EvolutionDriver` now in the docs.  There's even a quite convenient place to do so, so here's that.

Also previous PR had some tests failing, so this can serve to check whether those were just the AMD CI issues, or something substantial.  (I can't imagine marking a method `virtual` in a class with no children could have broken anything though?)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
