### PR TITLE
Add more global time step control

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1159]](https://github.com/parthenon-hpc-lab/parthenon/pull/1159) Add additional timestep controllers in parthenon/time.
 - [[PR 1148]](https://github.com/parthenon-hpc-lab/parthenon/pull/1148) Add `GetPackDimension` to `StateDescriptor` for calculating pack sizes before `Mesh` initialization
 - [[PR 1143]](https://github.com/parthenon-hpc-lab/parthenon/pull/1143) Add tensor indices to VariableState, add radiation constant to constants, add TypeLists, allow for arbitrary containers for solvers
 - [[PR 1140]](https://github.com/parthenon-hpc-lab/parthenon/pull/1140) Allow for relative convergence tolerance in BiCGSTAB solver.

--- a/doc/sphinx/src/inputs.rst
+++ b/doc/sphinx/src/inputs.rst
@@ -21,8 +21,8 @@ General parthenon options such as problem name and parameter handling.
 +---------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Option              | Default | Type    | Description                                                                                                                                                                                            |
 +=====================+=========+=========+========================================================================================================================================================================================================+
-|| name               || none   || string || Name of this problem or initialization, prefixed to output files.                                                                                                                                     |
 || archive_parameters || false  || string || Produce a parameter file containing all parameters known to Parthenon. Set to `true` for an output file named `parthinput.archive`. Set to `timestamp` for a file with a name containing a timestamp. |
+|| name               || none   || string || Name of this problem or initialization, prefixed to output files.                                                                                                                                     |
 +---------------------+---------+---------+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
@@ -34,12 +34,23 @@ Options related to time-stepping and printing of diagnostic data.
 +------------------------------+---------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Option                       | Default | Type   | Description                                                                                                                                                           |
 +==============================+=========+========+=======================================================================================================================================================================+
-|| tlim                        || none   || float || Stop criterion on simulation time.                                                                                                                                   |
-|| nlim                        || -1     || int   || Stop criterion on total number of steps taken. Ignored if < 0.                                                                                                       |
-|| perf_cycle_offset           || 0      || int   || Skip the first N cycles when calculating the final performance (e.g., zone-cycles/wall_second). Allows to hide the initialization overhead in Parthenon.             |
+|| dt_ceil                     || none   || Real  || The maximum allowed timestep.                                                                                                                                        |
+|| dt_factor                   || 2.0    || Real  || The maximum allowed relative increase of the timestep over the previous value.                                                                                       |
+|| dt_floor                    || none   || Real  || The minimum allowed timestep.                                                                                                                                        |
+|| dt_force                    || none   || Real  || Force the timestep to this value, ignoring all other conditions.                                                                                                     |
+|| dt_init                     || none   || Real  || The maximum allowed timestep during the first cycle.                                                                                                                 |
+|| dt_init_force               || none   || bool  || If set to true, force the first cycle's timestep to the value given by dt_init.                                                                                      |
+|| dt_min                      || none   || Real  || If the timestep falls below dt_min for dt_min_cycle_limit cycles, Parthenon fatals.                                                                                  |
+|| dt_min_cycle_limit          || 10     || int   || The maximum number of cycles the timestep can be below dt_min.                                                                                                       |
+|| dt_max                      || none   || Real  || If the timestep falls below dt_max for dt_max_cycle_limit cycles, Parthenon fatals.                                                                                  |
+|| dt_max_cycle_limit          || 1      || int   || The maximum number of cycles the timestep an be above dt_max.                                                                                                        |
+|| dt_user                     || none   || Real  || Set a global timestep limit.                                                                                                                                         |
+|| ncrecv_bdry_buf_timeout_sec || -1.0   || Real  || Timeout in seconds for the `ReceiveBoundaryBuffers` tasks. Disabed (negative) by default. Typically no need in production runs. Useful for debugging MPI calls.      |
 || ncycle_out                  || 1      || int   || Number of cycles between short diagnostic output to standard out containing, e.g., current time, dt, zone-update/wsec. Default: 1 (i.e, every cycle).                |
 || ncycle_out_mesh             || 0      || int   || Number of cycles between printing the mesh structure to standard out. Use a negative number to also print every time the mesh was modified. Default: 0 (i.e, off).   |
-|| ncrecv_bdry_buf_timeout_sec || -1.0   || Real  || Timeout in seconds for the `ReceiveBoundaryBuffers` tasks. Disabed (negative) by default. Typically no need in production runs. Useful for debugging MPI calls.      |
+|| nlim                        || -1     || int   || Stop criterion on total number of steps taken. Ignored if < 0.                                                                                                       |
+|| perf_cycle_offset           || 0      || int   || Skip the first N cycles when calculating the final performance (e.g., zone-cycles/wall_second). Allows to hide the initialization overhead in Parthenon.             |
+|| tlim                        || none   || Real  || Stop criterion on simulation time.                                                                                                                                   |
 +------------------------------+---------+--------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
 
@@ -64,9 +75,9 @@ See the :ref:`sparse impl` documentation for details.
 +--------------------+---------+--------+----------------------------------------------------------------------------------------------------------------------------------------------+
 | Option             | Default | Type   | Description                                                                                                                                  |
 +====================+=========+========+==============================================================================================================================================+
-|| enable_sparse     || `true` || bool  || If set to false, sparse variables will always be allocated, see also :ref:`sparse run-time`                                                 |
 || alloc_threshold   || 1e-12  || float || Global (for all sparse variables) threshold to trigger allocation of a variable if cells in the receiving ghost cells are above this value. |
-|| dealloc_threshold || 1e-14  || float || Global (for all sparse variables) threshold to trigger deallocation if all active cells of a variable in a block are below this value.      |
 || dealloc_count     || 5      || int   || First deallocate a sparse variable if the `dealloc_threshold` has been met in this number of consecutive cycles.                            |
+|| dealloc_threshold || 1e-14  || float || Global (for all sparse variables) threshold to trigger deallocation if all active cells of a variable in a block are below this value.      |
+|| enable_sparse     || `true` || bool  || If set to false, sparse variables will always be allocated, see also :ref:`sparse run-time`                                                 |
 +--------------------+---------+--------+----------------------------------------------------------------------------------------------------------------------------------------------+
 

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -240,9 +240,9 @@ void EvolutionDriver::SetGlobalTimeStep() {
       msg << "Timesetep has fallen bellow minimum (parthenon/time/dt_min=" << dt_min
           << ") for more than " << dt_min_count_max << " steps";
       PARTHENON_FAIL(msg);
-    } else {
-      dt_min_count = 0;
     }
+  } else {
+    dt_min_count = 0;
   }
   if (tm.dt >= dt_max) {
     if (++dt_max_count >= dt_max_count_max) {
@@ -250,9 +250,9 @@ void EvolutionDriver::SetGlobalTimeStep() {
       msg << "Timesetep has risen above maximum (parthenon/time/dt_max=" << dt_max
           << ") for more than " << dt_max_count_max << " steps";
       PARTHENON_FAIL(msg);
-    } else {
-      dt_max_count = 0;
     }
+  } else {
+    dt_max_count = 0;
   }
 
   // Limit timestep if it would take us past desired endpoint

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -226,7 +226,7 @@ void EvolutionDriver::SetGlobalTimeStep() {
       tm.dt = std::min(tm.dt, pmb->NewDt());
       pmb->SetAllowedDt(std::numeric_limits<Real>::max());
     }
-    // Allow the user to vote
+    // Allow the user to enforce maximum timestep
     tm.dt = std::min(tm.dt, dt_user);
     // Force timestep to be in the allowable range
     tm.dt = std::max(dt_floor, std::min(tm.dt, dt_ceil));

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -69,6 +69,21 @@ class EvolutionDriver : public Driver {
                                       std::numeric_limits<Real>::infinity());
     Real dt =
         pinput->GetOrAddReal("parthenon/time", "dt", std::numeric_limits<Real>::max());
+    dt_min = pinput->GetOrAddReal("parthenon/time", "dt_min",
+                                  std::numeric_limits<Real>::min());
+    dt_max = pinput->GetOrAddReal("parthenon/time", "dt_max",
+                                  std::numeric_limits<Real>::max());
+    dt_init = pinput->GetOrAddReal("parthenon/time", "dt_init",
+                                   std::numeric_limits<Real>::max());
+    dt_user = pinput->GetOrAddReal("parthenon/time", "dt_user",
+                                   std::numeric_limits<Real>::max());
+    dt_force = pinput->GetOrAddReal("parthenon/time", "dt_force",
+                                    std::numeric_limits<Real>::lowest());
+    dt_min_count_max =
+        pinput->GetOrAddInteger("parthenon/time", "dt_min_cycle_limit", 10);
+    dt_max_count_max = pinput->GetOrAddInteger("parthenon/time", "dt_max_cycle_limit", 1);
+    dt_min_count = 0;
+    dt_max_count = 0;
     const auto ncycle = pinput->GetOrAddInteger("parthenon/time", "ncycle", 0);
     const auto nmax = pinput->GetOrAddInteger("parthenon/time", "nlim", -1);
     const auto nout = pinput->GetOrAddInteger("parthenon/time", "ncycle_out", 1);
@@ -88,6 +103,9 @@ class EvolutionDriver : public Driver {
 
  protected:
   void PostExecute(DriverStatus status) override;
+  Real dt_user, dt_force, dt_init, dt_min, dt_max;
+  int dt_min_count, dt_max_count;
+  int dt_min_count_max, dt_max_count_max;
 
  private:
   void InitializeBlockTimeSteps();

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -75,15 +75,24 @@ class EvolutionDriver : public Driver {
                                   std::numeric_limits<Real>::max());
     dt_init = pinput->GetOrAddReal("parthenon/time", "dt_init",
                                    std::numeric_limits<Real>::max());
+    dt_init_force = pinput->GetOrAddBoolean("parthenon/time", "dt_init_force", false);
+
     dt_user = pinput->GetOrAddReal("parthenon/time", "dt_user",
                                    std::numeric_limits<Real>::max());
     dt_force = pinput->GetOrAddReal("parthenon/time", "dt_force",
                                     std::numeric_limits<Real>::lowest());
+    dt_floor = pinput->GetOrAddReal("parthenon/time", "dt_floor",
+                                    std::numeric_limits<Real>::min());
+    dt_ceil = pinput->GetOrAddReal("parthenon/time", "dt_ceil",
+                                   std::numeric_limits<Real>::max());
     dt_min_count_max =
         pinput->GetOrAddInteger("parthenon/time", "dt_min_cycle_limit", 10);
     dt_max_count_max = pinput->GetOrAddInteger("parthenon/time", "dt_max_cycle_limit", 1);
     dt_min_count = 0;
     dt_max_count = 0;
+
+    dt_factor = pinput->GetOrAddReal("parthenon/time", "dt_factor", 2.0);
+
     const auto ncycle = pinput->GetOrAddInteger("parthenon/time", "ncycle", 0);
     const auto nmax = pinput->GetOrAddInteger("parthenon/time", "nlim", -1);
     const auto nout = pinput->GetOrAddInteger("parthenon/time", "ncycle_out", 1);
@@ -103,7 +112,9 @@ class EvolutionDriver : public Driver {
 
  protected:
   void PostExecute(DriverStatus status) override;
-  Real dt_user, dt_force, dt_init, dt_min, dt_max;
+  Real dt_user, dt_force, dt_init, dt_min, dt_max, dt_floor, dt_ceil;
+  Real dt_factor;
+  bool dt_init_force;
   int dt_min_count, dt_max_count;
   int dt_min_count_max, dt_max_count_max;
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This was originally in a downstream PR, but some functionality was not available, so I've moved it upstream. 

This adds some extra timestep controllers that are not package / meshblock / processor dependent.
- `dt_min`: if `dt <= dt_min` for `dt_min_count_max` cycles, then `PARTHENON_FAIL`. Defaults to 10 bad cycles in a row.
- `dt_max`: if `dt >= dt_max`, for `dt_max_count_max` cycles, then `PARTHENON_FAIL`. Defaults to 1 bad cycle in a row.
- `dt_user`: user settable timestep suggestion (`dt = min(dt, dt_user)`)
- `dt_force`: Force the timestep to `dt_force` regardless of other controllers
- `dt_init`: Set the first timestep to this value but allow it to be smaller if it wants to be. To force this value, the user can set `dt_init_force = true`. 
- `dt_floor`: sets `dt = std::max(dt , dt_floor)`
- `dt_ceil` : sets `dt = std::min(dt, dt_ceil)`
- `dt_factor`: `dt / dt_previous <= dt_factor`. Previously, this was hard coded to 2.

The main purpose of `dt_min` and `dt_max` is to stop simulations from going off the rails and cycling on `1e-20` timesteps or blowing up.  

All of these options are "off" by default. 

I have tested all options in a downstream code.



<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
