### PR TITLE
WIP: Add boundary comm inner loop specializations for performance and allow setting vector length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 
 ### Infrastructure (changes irrelevant to downstream codes)
-
+- [[PR 1175]](https://github.com/parthenon-hpc-lab/parthenon/pull/1175) Add inner comm loop specializations to maximize comms performance
 
 ### Removed (removing behavior/API/varaibles/...)
 

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -41,6 +41,7 @@ using Real = double;
 struct IndexRange {
   int s = 0; /// Starting Index (inclusive)
   int e = 0; /// Ending Index (inclusive)
+  operator std::pair<int, int>() const {return {s, e};}
 };
 
 // Enum speficying whether or not you requested a flux variable in

--- a/src/mesh/forest/logical_coordinate_transformation.hpp
+++ b/src/mesh/forest/logical_coordinate_transformation.hpp
@@ -52,6 +52,13 @@ struct LogicalCoordinateTransformation {
                                    std::int64_t origin) const;
   CellCentOffsets Transform(CellCentOffsets in) const;
 
+  // Check if this transformation includes at most a translation
+  KOKKOS_INLINE_FUNCTION
+  bool IsTrivial() const {
+    return (dir_connection[0] == 0) && (dir_connection[1] == 1) &&
+           (dir_connection[2] == 2) && !dir_flip[0] && !dir_flip[1] && !dir_flip[2];
+  }
+
   KOKKOS_INLINE_FUNCTION
   std::tuple<TopologicalElement, Real> Transform(TopologicalElement el) const {
     int iel = static_cast<int>(el);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -77,6 +77,8 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
       default_pack_size_(pin->GetOrAddInteger("parthenon/mesh", "pack_size", -1)),
       // private members:
       num_mesh_threads_(pin->GetOrAddInteger("parthenon/mesh", "num_threads", 1)),
+      comm_vector_length_(
+          pin->GetOrAddInteger("parthenon/mesh", "comm_vector_length", 1)),
       use_uniform_meshgen_fn_{true, true, true, true}, lb_flag_(true), lb_automatic_(),
       lb_manual_(), nslist(Globals::nranks), nblist(Globals::nranks),
       nref(Globals::nranks), nderef(Globals::nranks), rdisp(Globals::nranks),

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -99,6 +99,8 @@ class Mesh {
     return nblist[my_rank];
   }
   int GetNumMeshThreads() const { return num_mesh_threads_; }
+  int GetCommVectorLength() const { return comm_vector_length_; }
+
   std::int64_t GetTotalCells();
   // TODO(JMM): Move block_size into mesh.
   int GetNumberOfMeshBlockCells() const;
@@ -258,6 +260,7 @@ class Mesh {
   // data
   int root_level, max_level, current_level;
   int num_mesh_threads_;
+  int comm_vector_length_;
   /// Maps Global Block IDs to which rank the block is mapped to.
   std::vector<int> ranklist;
   /// Maps rank to start of local block IDs.

--- a/src/utils/indexer.hpp
+++ b/src/utils/indexer.hpp
@@ -94,6 +94,11 @@ struct Indexer {
   std::tuple<Ts...> operator()(int idx) const {
     return GetIndicesImpl(idx, std::make_index_sequence<sizeof...(Ts)>());
   }
+  
+  KOKKOS_FORCEINLINE_FUNCTION
+  std::size_t GetFlatIdx(Ts... ts) const {
+    return GetFlatIndexImpl(ts..., std::make_index_sequence<sizeof...(Ts)>()); 
+  }
 
   KOKKOS_FORCEINLINE_FUNCTION
   auto GetIdxArray(int idx) const {
@@ -126,6 +131,19 @@ struct Indexer {
         }(),
         ...);
     return idxs;
+  }
+
+  template <std::size_t... Is>
+  KOKKOS_FORCEINLINE_FUNCTION std::size_t
+  GetFlatIndexImpl(Ts... idxs, std::index_sequence<Is...>) const {
+    std::size_t out{0};
+    (  
+        [&] {
+          idxs -= start[Is];
+          out += idxs * N[Is]; 
+        }(),
+        ...);
+    return out;
   }
 
   template <std::size_t... Is>

--- a/src/utils/indexer.hpp
+++ b/src/utils/indexer.hpp
@@ -94,10 +94,10 @@ struct Indexer {
   std::tuple<Ts...> operator()(int idx) const {
     return GetIndicesImpl(idx, std::make_index_sequence<sizeof...(Ts)>());
   }
-  
+
   KOKKOS_FORCEINLINE_FUNCTION
   std::size_t GetFlatIdx(Ts... ts) const {
-    return GetFlatIndexImpl(ts..., std::make_index_sequence<sizeof...(Ts)>()); 
+    return GetFlatIndexImpl(ts..., std::make_index_sequence<sizeof...(Ts)>());
   }
 
   KOKKOS_FORCEINLINE_FUNCTION
@@ -137,10 +137,10 @@ struct Indexer {
   KOKKOS_FORCEINLINE_FUNCTION std::size_t
   GetFlatIndexImpl(Ts... idxs, std::index_sequence<Is...>) const {
     std::size_t out{0};
-    (  
+    (
         [&] {
           idxs -= start[Is];
-          out += idxs * N[Is]; 
+          out += idxs * N[Is];
         }(),
         ...);
     return out;


### PR DESCRIPTION
## PR Summary

This PR adds various inner loop specializations to avoid calling reductions, coordinate transformations, and masks in the inner boundary buffer setting loops where possible. I found this made a little bit of a difference for the multigrid communication, not sure that it really matters elsewhere.

It also exposes a flag `parthenon/mesh/comm_vector_length` which sets the vector length of the outer team policy. We have always used the Kokkos default value here (which is one). I am not sure if changing this value has any impact, but I at least wanted to be able to play around with it. 

As an aside, once #1142 is in, we may want to switch these loops to `par_for`s instead of raw Kokkos loops. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
