### PR TITLE
Bugfix: Fix issue with using relative residual tolerance in bicgstab solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1178]](https://github.com/parthenon-hpc-lab/parthenon/pull/1178) Fix issue with mesh pointer when using relative residual tolerance in BiCGSTAB solver.
 - [[PR1173]](https://github.com/parthenon-hpc-lab/parthenon/pull/1173) Make debugging easier by making parthenon throw an error if ParameterInput is different on multiple MPI ranks.
 
 ### Infrastructure (changes irrelevant to downstream codes)

--- a/src/solvers/bicgstab_solver.hpp
+++ b/src/solvers/bicgstab_solver.hpp
@@ -144,13 +144,12 @@ class BiCGSTABSolver {
         this);
     tl.AddTask(
         TaskQualifier::once_per_region, initialize, "print to screen",
-        [&](BiCGSTABSolver *solver, std::shared_ptr<Real> res_tol,
-            bool relative_residual, Mesh *pm) {
+        [&](BiCGSTABSolver *solver, std::shared_ptr<Real> res_tol, bool relative_residual,
+            Mesh *pm) {
           if (Globals::my_rank == 0 && params_.print_per_step) {
-            Real tol =
-                relative_residual
-                    ? *res_tol * std::sqrt(solver->rhs2.val / pm->GetTotalCells())
-                    : *res_tol;
+            Real tol = relative_residual
+                           ? *res_tol * std::sqrt(solver->rhs2.val / pm->GetTotalCells())
+                           : *res_tol;
             printf("# [0] v-cycle\n# [1] rms-residual (tol = %e) \n# [2] rms-error\n",
                    tol);
           }

--- a/src/solvers/bicgstab_solver.hpp
+++ b/src/solvers/bicgstab_solver.hpp
@@ -145,18 +145,18 @@ class BiCGSTABSolver {
     tl.AddTask(
         TaskQualifier::once_per_region, initialize, "print to screen",
         [&](BiCGSTABSolver *solver, std::shared_ptr<Real> res_tol,
-            bool relative_residual) {
+            bool relative_residual, Mesh *pm) {
           if (Globals::my_rank == 0 && params_.print_per_step) {
             Real tol =
                 relative_residual
-                    ? *res_tol * std::sqrt(solver->rhs2.val / pmesh->GetTotalCells())
+                    ? *res_tol * std::sqrt(solver->rhs2.val / pm->GetTotalCells())
                     : *res_tol;
             printf("# [0] v-cycle\n# [1] rms-residual (tol = %e) \n# [2] rms-error\n",
                    tol);
           }
           return TaskStatus::complete;
         },
-        this, params_.residual_tolerance, params_.relative_residual);
+        this, params_.residual_tolerance, params_.relative_residual, pmesh);
 
     // BEGIN ITERATIVE TASKS
     auto [itl, solver_id] = tl.AddSublist(initialize, {1, params_.max_iters});


### PR DESCRIPTION
## PR Summary

Previously the pointer to the mesh was captured by reference in the task list, which apparently went stale by the time the task list was run and the returned cell count was undefined(?). Now we explicitly pass the mesh pointer to the task. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
