### PR TITLE
Fix particle leapfrog example initialization data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1183]](https://github.com/parthenon-hpc-lab/parthenon/pull/1183) Fix particle leapfrog example initialization data
 - [[PR 1179]](https://github.com/parthenon-hpc-lab/parthenon/pull/1179) Make a global variable for whether simulation is a restart
 - [[PR 1171]](https://github.com/parthenon-hpc-lab/parthenon/pull/1171) Add PARTHENON_USE_SYSTEM_PACKAGES build option
 - [[PR 1161]](https://github.com/parthenon-hpc-lab/parthenon/pull/1161) Make flux field Metadata accessible, add Metadata::CellMemAligned flag, small perfomance upgrades

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -148,7 +148,7 @@ void ProblemGenerator(MeshBlock *pmb, ParameterInput *pin) {
   const Real &y_max = pmb->coords.Xf<2>(jb.e + 1);
   const Real &z_max = pmb->coords.Xf<3>(kb.e + 1);
 
-  const auto &ic = particles_ic;
+  const auto ic = particles_ic;
 
   const bool no_particles = pin->GetOrAddBoolean("Particles", "disable", false);
   if (no_particles) return;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

The `particle_leapfrog` example was generating a compiler error in #910. I was able to reproduce this error with NVHPC 24.7.0/nvcc 12.5 on a Darwin `volta-x86` node. Turns out we can't capture a `Kokkos::Array` of `Kokkos::Array`s as a reference inside device code. I changed this to a copy and the code compiles for me (up to an ICE in `poisson_package.cpp` I am unsure about)

@fglines-nv This should fix the build error you encountered.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
