### PR TITLE
Fix swarm block neighbor indexing in 1D, 2D

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1184]](https://github.com/parthenon-hpc-lab/parthenon/pull/1184) Fix swarm block neighbor indexing in 1D, 2D
 - [[PR 1183]](https://github.com/parthenon-hpc-lab/parthenon/pull/1183) Fix particle leapfrog example initialization data
 - [[PR 1179]](https://github.com/parthenon-hpc-lab/parthenon/pull/1179) Make a global variable for whether simulation is a restart
 - [[PR 1171]](https://github.com/parthenon-hpc-lab/parthenon/pull/1171) Add PARTHENON_USE_SYSTEM_PACKAGES build option

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -307,6 +307,14 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
 
           weight(n) = 1.0;
 
+          // Check that we are on current meshblock
+          bool is_on_current_mesh_block = false;
+          PARTHENON_REQUIRE(swarm_d.GetNeighborBlockIndex(n, x(n), y(n), z(n),
+                                                          is_on_current_mesh_block) == -1,
+                            "Particle must be on current meshblock!");
+          PARTHENON_REQUIRE(is_on_current_mesh_block == true,
+                            "Particle must be on current meshblock!");
+
           rng_pool.free_state(rng_gen);
         });
   } else {
@@ -332,6 +340,14 @@ TaskStatus CreateSomeParticles(MeshBlock *pmb, const double t0) {
           t(n) = t0;
 
           weight(n) = 1.0;
+
+          // Check that we are on current meshblock
+          bool is_on_current_mesh_block = false;
+          PARTHENON_REQUIRE(swarm_d.GetNeighborBlockIndex(n, x(n), y(n), z(n),
+                                                          is_on_current_mesh_block) == -1,
+                            "Particle must be on current meshblock!");
+          PARTHENON_REQUIRE(is_on_current_mesh_block == true,
+                            "Particle must be on current meshblock!");
 
           rng_pool.free_state(rng_gen);
         });

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -141,6 +141,9 @@ void Swarm::SetupPersistentMPI() {
 
   const int nbmax = vbswarm->bd_var_.nbmax;
 
+  // Build up convenience array of neighbor indices
+  SetNeighborIndices_();
+
   // Build device array mapping neighbor index to neighbor bufid
   if (pmb->neighbors.size() > 0) {
     ParArrayND<int> neighbor_buffer_index("Neighbor buffer index", pmb->neighbors.size());

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -141,9 +141,6 @@ void Swarm::SetupPersistentMPI() {
 
   const int nbmax = vbswarm->bd_var_.nbmax;
 
-  // Build up convenience array of neighbor indices
-  SetNeighborIndices_();
-
   // Build device array mapping neighbor index to neighbor bufid
   if (pmb->neighbors.size() > 0) {
     ParArrayND<int> neighbor_buffer_index("Neighbor buffer index", pmb->neighbors.size());
@@ -437,6 +434,9 @@ void Swarm::AllocateComms(std::weak_ptr<MeshBlock> wpmb) {
   // Enroll SwarmVariable object
   vbswarm->bswarm_index = pmb->pbswarm->bswarms.size();
   pmb->pbswarm->bswarms.push_back(vbswarm);
+
+  // Evaluate neigbor indices
+  SetNeighborIndices_();
 }
 
 } // namespace parthenon

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -44,21 +44,6 @@ void Swarm::SetNeighborIndices_() {
     }
   }
 
-  // Indicate which neighbor regions correspond to this meshblock
-  const int kmin = ndim < 3 ? 0 : 1;
-  const int kmax = ndim < 3 ? 3 : 2;
-  const int jmin = ndim < 2 ? 0 : 1;
-  const int jmax = ndim < 2 ? 3 : 2;
-  const int imin = 1;
-  const int imax = 2;
-  for (int k = kmin; k <= kmax; k++) {
-    for (int j = jmin; j <= jmax; j++) {
-      for (int i = imin; i <= imax; i++) {
-        neighbor_indices_h(k, j, i) = this_block_;
-      }
-    }
-  }
-
   // Create a point in the center of each ghost halo region at maximum refinement level
   // and then test whether each neighbor block includes that point.
   const auto &bsize = pmb->block_size;
@@ -126,6 +111,21 @@ void Swarm::SetNeighborIndices_() {
             break;
           }
         }
+      }
+    }
+  }
+
+  // Indicate which neighbor regions correspond to this meshblock
+  const int kmin = ndim < 3 ? 0 : 1;
+  const int kmax = ndim < 3 ? 3 : 2;
+  const int jmin = ndim < 2 ? 0 : 1;
+  const int jmax = ndim < 2 ? 3 : 2;
+  const int imin = 1;
+  const int imax = 2;
+  for (int k = kmin; k <= kmax; k++) {
+    for (int j = jmin; j <= jmax; j++) {
+      for (int i = imin; i <= imax; i++) {
+        neighbor_indices_h(k, j, i) = this_block_;
       }
     }
   }

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -75,9 +75,9 @@ class SwarmDeviceContext {
 
     // Ignore k,j indices as necessary based on problem dimension
     if (ndim_ == 1) {
-      block_index_(n) = neighbor_indices_(0, 0, i);
+      block_index_(n) = neighbor_indices_(1, 1, i);
     } else if (ndim_ == 2) {
-      block_index_(n) = neighbor_indices_(0, j, i);
+      block_index_(n) = neighbor_indices_(1, j, i);
     } else {
       block_index_(n) = neighbor_indices_(k, j, i);
     }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

For some cases, the current block of particles was being computed incorrectly. This was because the `swarm_comms.cpp` initialization machinery would overwrite the region of `neighbor_indices_h` belonging to the currently active meshblock. I fixed this, and also changed the index we use to compute neighbor indices for unused dimensions in `SwarmDeviceContext` to improve consistency.

This should fix the downstream issue @pdmullen.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
