### PR TITLE
Bugfix to particle defragmentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1185]](https://github.com/parthenon-hpc-lab/parthenon/pull/1185/files) Bugfix to particle defragmentation
 - [[PR 1183]](https://github.com/parthenon-hpc-lab/parthenon/pull/1183) Fix particle leapfrog example initialization data
 - [[PR 1179]](https://github.com/parthenon-hpc-lab/parthenon/pull/1179) Make a global variable for whether simulation is a restart
 - [[PR 1171]](https://github.com/parthenon-hpc-lab/parthenon/pull/1171) Add PARTHENON_USE_SYSTEM_PACKAGES build option

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -50,6 +50,7 @@ variables = particle_deposition
 
 <parthenon/time>
 tlim = 1.e2
+nlim=10 # debug
 integrator = rk1
 
 <Particles>

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -39,9 +39,9 @@ x3max = 0.5
 ix3_bc = periodic
 ox3_bc = periodic
 
-#<parthenon/meshblock>
-#nx1 = 8
-#nx2 = 8
+<parthenon/meshblock>
+nx1 = 8
+nx2 = 8
 
 <parthenon/output0>
 file_type = hdf5
@@ -50,7 +50,6 @@ variables = particle_deposition
 
 <parthenon/time>
 tlim = 1.e2
-nlim=10 # debug
 integrator = rk1
 
 <Particles>

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -39,9 +39,9 @@ x3max = 0.5
 ix3_bc = periodic
 ox3_bc = periodic
 
-<parthenon/meshblock>
-nx1 = 8
-nx2 = 8
+#<parthenon/meshblock>
+#nx1 = 8
+#nx2 = 8
 
 <parthenon/output0>
 file_type = hdf5
@@ -58,4 +58,5 @@ particle_speed = 1.0
 rng_seed = 23487
 const_dt = 0.5
 deposition_method = per_cell
-destroy_particles_frac = 0.1
+destroy_particles_frac = 0.5
+defrag_threshold=1.0

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -58,5 +58,5 @@ particle_speed = 1.0
 rng_seed = 23487
 const_dt = 0.5
 deposition_method = per_cell
-destroy_particles_frac = 0.5
-defrag_threshold=1.0
+destroy_particles_frac = 0.1
+defrag_threshold = 0.9

--- a/example/particles/particles.cpp
+++ b/example/particles/particles.cpp
@@ -62,6 +62,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       destroy_particles_frac >= 0. && destroy_particles_frac <= 1.,
       "Fraction of particles to destroy each timestep must be between 0 and 1");
 
+  Real defrag_threshold = pin->GetOrAddReal("Particles", "defrag_threshold", 0.9);
+  pkg->AddParam<>("defrag_threshold", defrag_threshold);
+  PARTHENON_REQUIRE(defrag_threshold >= 0. && defrag_threshold <= 1.,
+                    "Defragmentation threshold must be between 0 and 1 inclusive.");
+
   std::string deposition_method =
       pin->GetOrAddString("Particles", "deposition_method", "per_particle");
   if (deposition_method == "per_particle") {
@@ -609,6 +614,9 @@ TaskCollection ParticleDriver::MakeFinalizationTaskCollection() const {
     auto &sc1 = pmb->meshblock_data.Get();
     auto &tl = async_region1[i];
 
+    auto pkg = pmb->packages.Get("particles_package");
+    const auto defrag_threshold = pkg->Param<Real>("defrag_threshold");
+
     auto destroy_some_particles = tl.AddTask(none, DestroySomeParticles, pmb.get());
 
     auto sort_particles = tl.AddTask(destroy_some_particles,
@@ -617,7 +625,8 @@ TaskCollection ParticleDriver::MakeFinalizationTaskCollection() const {
     auto deposit_particles = tl.AddTask(sort_particles, DepositParticles, pmb.get());
 
     // Defragment if swarm memory pool occupancy is 90%
-    auto defrag = tl.AddTask(deposit_particles, &SwarmContainer::Defrag, sc.get(), 0.9);
+    auto defrag = tl.AddTask(deposit_particles, &SwarmContainer::Defrag, sc.get(),
+                             defrag_threshold);
 
     // estimate next time step
     auto new_dt = tl.AddTask(

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -362,7 +362,6 @@ void Swarm::Defrag() {
         if (val) {
           update += 1;
         }
-        // TODO(BRR) actually scan_scratch_towrite
         if (final) {
           scan_scratch_toread(n) = update;
           empty_indices(n - num_active) = n;

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -465,6 +465,7 @@ void Swarm::Defrag() {
   }
 
   const int &num_active = num_active_;
+  auto empty_indices = empty_indices_;
   printf("num_active: %i\n", num_active);
   printf("nmax_pool_: %i\n", nmax_pool_);
   printf("nmax_pool_ - num_active_ - 1: %i\n", nmax_pool_ - num_active_ - 1);
@@ -479,7 +480,10 @@ void Swarm::Defrag() {
           update += 1;
         }
         // TODO(BRR) actually scan_scratch_towrite
-        if (final) scan_scratch_toread(n) = update;
+        if (final) {
+          scan_scratch_toread(n) = update;
+          empty_indices(n - num_active) = n;
+        }
       });
 
   for (int n = 0; n < nmax_pool_; n++) {
@@ -587,7 +591,8 @@ void Swarm::Defrag() {
     }
     PARTHENON_REQUIRE(nactive == num_active_, "!");
   }
-  UpdateEmptyIndices();
+
+  // UpdateEmptyIndices();
   printf("%s:%i\n", __FILE__, __LINE__);
   printf("num_active: %i max_active_index: %i\n", num_active_, max_active_index_);
   for (int n = 0; n < nmax_pool_ - num_active_; n++) {

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -89,7 +89,22 @@ Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_
   // Initialize index metadata
   num_active_ = 0;
   max_active_index_ = inactive_max_active_index;
+  printf("%s:%i\n", __FILE__, __LINE__);
   UpdateEmptyIndices();
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
+  printf("%s:%i\n", __FILE__, __LINE__);
+  printf("num_active: %i max_active_index: %i\n", num_active_, max_active_index_);
+  for (int n = 0; n < nmax_pool_ - num_active_; n++) {
+    printf("empty indices[%i] = %i\n", n, static_cast<int>(empty_indices_(n)));
+    PARTHENON_REQUIRE(mask_(empty_indices_(n)) == false, "??");
+  }
 }
 
 void Swarm::Add(const std::vector<std::string> &label_array, const Metadata &metadata) {
@@ -190,6 +205,15 @@ void Swarm::Remove(const std::string &label) {
 }
 
 void Swarm::SetPoolMax(const std::int64_t nmax_pool) {
+  printf("%s:%i\n", __FILE__, __LINE__);
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
   PARTHENON_REQUIRE(nmax_pool > nmax_pool_, "Must request larger pool size!");
   std::int64_t n_new = nmax_pool - nmax_pool_;
 
@@ -230,6 +254,7 @@ void Swarm::SetPoolMax(const std::int64_t nmax_pool) {
   nmax_pool_ = nmax_pool;
 
   // Populate new empty indices
+  printf("%s:%i\n", __FILE__, __LINE__);
   UpdateEmptyIndices();
 
   // Eliminate any cached SwarmPacks, as they will need to be rebuilt following SetPoolMax
@@ -238,15 +263,41 @@ void Swarm::SetPoolMax(const std::int64_t nmax_pool) {
   for (auto &partition : pm->GetDefaultBlockPartitions()) {
     pm->mesh_data.Add("base", partition)->ClearSwarmCaches();
   }
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
+  printf("%s:%i\n", __FILE__, __LINE__);
 }
 
 NewParticlesContext Swarm::AddEmptyParticles(const int num_to_add) {
+  printf("%s:%i\n", __FILE__, __LINE__);
   PARTHENON_DEBUG_REQUIRE(num_to_add >= 0, "Cannot add negative numbers of particles!");
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    printf("AddEmptyParticles nactive: %i num_active_: %i\n", nactive, num_active_);
+    printf("adding: %i particles\n", num_to_add);
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+    for (int n = 0; n < nmax_pool_ - num_active_; n++) {
+      printf("empty indices[%i] = %i\n", n, static_cast<int>(empty_indices_(n)));
+      PARTHENON_REQUIRE(mask_(empty_indices_(n)) == false, "??");
+    }
+  }
 
   auto pmb = GetBlockPointer();
 
   if (num_to_add > 0) {
+    printf("%s:%i\n", __FILE__, __LINE__);
     while (nmax_pool_ - num_active_ < num_to_add) {
+      printf("%s:%i\n", __FILE__, __LINE__);
       IncreasePoolMax();
     }
 
@@ -263,27 +314,51 @@ NewParticlesContext Swarm::AddEmptyParticles(const int num_to_add) {
 
           // Record vote for max active index
           max_ind = new_indices(n);
+          printf("[%i] new_index = %i max_ind = %i\n", n, new_indices(n), max_ind);
         },
         Kokkos::Max<int>(max_new_active_index));
+    printf("max new active index: %i\n", max_new_active_index);
 
     // Update max active index if necessary
     max_active_index_ = std::max(max_active_index_, max_new_active_index);
 
     new_indices_max_idx_ = num_to_add - 1;
     num_active_ += num_to_add;
+    printf("max_active_index_: %i new_indices_max_idx_: %i num_active_: %i\n",
+           max_active_index_, new_indices_max_idx_, num_active_);
 
+    printf("%s:%i\n", __FILE__, __LINE__);
     UpdateEmptyIndices();
   } else {
+    printf("%s:%i\n", __FILE__, __LINE__);
     new_indices_max_idx_ = -1;
   }
 
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    printf("%s:%i mask_active: %i num_active_: %i\n", __FILE__, __LINE__, nactive,
+           num_active_);
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
+
   // Create and return NewParticlesContext
+  printf("%s:%i\n", __FILE__, __LINE__);
   return NewParticlesContext(new_indices_max_idx_, new_indices_);
 }
 
 // Updates the empty_indices_ array so the first N elements contain an ascending list of
 // indices into empty elements of the swarm pool, where N is the number of empty indices
 void Swarm::UpdateEmptyIndices() {
+  printf("%s:%i\n", __FILE__, __LINE__);
+  printf("num_active: %i max_active_index: %i\n", num_active_, max_active_index_);
+  // for (int n = 0; n < nmax_pool_ - num_active_; n++) {
+  //  printf("empty indices[%i] = %i\n", n, static_cast<int>(empty_indices_(n)));
+  //  PARTHENON_REQUIRE(mask_(empty_indices_(n)) == false, "??");
+  //}
   auto &mask = mask_;
   auto &empty_indices = empty_indices_;
 
@@ -311,13 +386,29 @@ void Swarm::UpdateEmptyIndices() {
           empty_indices(empty_indices_scan(n) - 1) = n;
         }
       });
+
+  printf("%s:%i\n", __FILE__, __LINE__);
+  printf("num_active: %i max_active_index: %i\n", num_active_, max_active_index_);
+  for (int n = 0; n < nmax_pool_ - num_active_; n++) {
+    printf("empty indices[%i] = %i\n", n, static_cast<int>(empty_indices(n)));
+    PARTHENON_REQUIRE(mask_(empty_indices_(n)) == false, "??");
+  }
 }
 
 // No active particles: nmax_active_index = inactive_max_active_index (= -1)
 // No particles removed: nmax_active_index unchanged
 // Particles removed: nmax_active_index is new max active index
 void Swarm::RemoveMarkedParticles() {
+  printf("%s:%i\n", __FILE__, __LINE__);
   int &max_active_index = max_active_index_;
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
 
   auto &mask = mask_;
   auto &marked_for_removal = marked_for_removal_;
@@ -339,10 +430,22 @@ void Swarm::RemoveMarkedParticles() {
 
   num_active_ -= num_removed;
 
+  printf("%s:%i\n", __FILE__, __LINE__);
   UpdateEmptyIndices();
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
+  printf("%s:%i\n", __FILE__, __LINE__);
 }
 
 void Swarm::Defrag() {
+  printf("%s:%i\n", __FILE__, __LINE__);
+  printf("Swarm::Defrag()\n");
   if (GetNumActive() == 0) {
     return;
   }
@@ -352,18 +455,36 @@ void Swarm::Defrag() {
   auto &map = scratch_b_;
 
   auto &mask = mask_;
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
 
   const int &num_active = num_active_;
+  printf("num_active: %i\n", num_active);
+  printf("nmax_pool_: %i\n", nmax_pool_);
+  printf("nmax_pool_ - num_active_ - 1: %i\n", nmax_pool_ - num_active_ - 1);
   parthenon::par_scan(
-      "Set empty indices prefix sum", 0, nmax_pool_ - num_active_ - 1,
-      KOKKOS_LAMBDA(const int nn, int &update, const bool &final) {
-        const int n = nn + num_active;
+      //"Set empty indices prefix sum", 0, nmax_pool_ - num_active_ - 1,
+      "Set empty indices prefix sum", num_active, nmax_pool_ - 1,
+      // KOKKOS_LAMBDA(const int nn, int &update, const bool &final) {
+      KOKKOS_LAMBDA(const int n, int &update, const bool &final) {
+        // const int n = nn + num_active;
         const int val = mask(n);
         if (val) {
           update += 1;
         }
+        // TODO(BRR) actually scan_scratch_towrite
         if (final) scan_scratch_toread(n) = update;
       });
+
+  for (int n = 0; n < nmax_pool_; n++) {
+    printf("scan_scratch_toread(%i) = %i\n", n, scan_scratch_toread(n));
+  }
 
   parthenon::par_for(
       PARTHENON_AUTO_LABEL, 0, nmax_pool_ - 1, KOKKOS_LAMBDA(const int n) {
@@ -374,9 +495,16 @@ void Swarm::Defrag() {
           mask(n) = false;
         }
       });
+  for (int n = 0; n < nmax_pool_; n++) {
+    printf("map(%i) = %i\n", n, map(n));
+  }
 
   // Reuse scratch memory
   auto &scan_scratch_towrite = scan_scratch_toread;
+
+  for (int n = 0; n < nmax_pool_; n++) {
+    printf("mask(%i) = %i\n", n, mask_(n));
+  }
 
   // Update list of empty indices
   parthenon::par_scan(
@@ -388,6 +516,9 @@ void Swarm::Defrag() {
         }
         if (final) scan_scratch_towrite(n) = update;
       });
+  for (int n = 0; n < nmax_pool_; n++) {
+    printf("scan_scratch_towrite(%i) = %i\n", n, scan_scratch_towrite(n));
+  }
 
   // Get all dynamical variables in swarm
   auto &int_vector = std::get<getType<int>()>(vectors_);
@@ -403,12 +534,28 @@ void Swarm::Defrag() {
   const int realPackDim = vreal.GetDim(2);
   const int intPackDim = vint.GetDim(2);
 
+  Real hash = 0.;
+  for (int n = 0; n < num_active_ - 1; n++) {
+    if (mask(n)) {
+      for (int vidx = 0; vidx < realPackDim; vidx++) {
+        hash += vreal(vidx, n);
+      }
+    }
+    if (!mask(n)) {
+      for (int vidx = 0; vidx < realPackDim; vidx++) {
+        hash += vreal(vidx, map(scan_scratch_towrite(n) - 1));
+      }
+    }
+  }
+  printf("old hash: %e\n", hash);
+
   // Loop over only the active number of particles, and if mask is empty, copy in particle
   // using address from prefix sum
   parthenon::par_for(
       PARTHENON_AUTO_LABEL, 0, num_active_ - 1, KOKKOS_LAMBDA(const int n) {
         if (!mask(n)) {
           const int nread = map(scan_scratch_towrite(n) - 1);
+          printf("write from %i to %i\n", nread, n);
           for (int vidx = 0; vidx < realPackDim; vidx++) {
             vreal(vidx, n) = vreal(vidx, nread);
           }
@@ -421,6 +568,32 @@ void Swarm::Defrag() {
 
   // Update max_active_index_
   max_active_index_ = num_active_ - 1;
+
+  Real new_hash = 0.;
+  for (int n = 0; n < num_active_ - 1; n++) {
+    if (mask(n)) {
+      for (int vidx = 0; vidx < realPackDim; vidx++) {
+        new_hash += vreal(vidx, n);
+      }
+    }
+  }
+  printf("new hash: %e\n", new_hash);
+  PARTHENON_REQUIRE(std::abs(new_hash - hash) / hash < 1.e-8, "BUG!");
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
+  UpdateEmptyIndices();
+  printf("%s:%i\n", __FILE__, __LINE__);
+  printf("num_active: %i max_active_index: %i\n", num_active_, max_active_index_);
+  for (int n = 0; n < nmax_pool_ - num_active_; n++) {
+    printf("empty indices[%i] = %i\n", n, static_cast<int>(empty_indices_(n)));
+    PARTHENON_REQUIRE(mask_(empty_indices_(n)) == false, "??");
+  }
 }
 
 ///

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -240,6 +240,10 @@ class Swarm {
     return std::get<getType<T>()>(vectors_);
   }
 
+  // Check for internal consistency among member variables and arrays, mainly for
+  // debugging
+  void Validate(bool test_comms = false) const;
+
   static constexpr int inactive_max_active_index = -1;
 
  private:

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -275,15 +275,6 @@ void Swarm::LoadBuffers_() {
 }
 
 void Swarm::Send(BoundaryCommSubset phase) {
-  printf("%s:%i\n", __FILE__, __LINE__);
-  {
-    int nactive = 0;
-    for (int n = 0; n < nmax_pool_; n++) {
-      if (mask_(n)) nactive++;
-      printf("mask(%i) = %i\n", n, mask_(n));
-    }
-    PARTHENON_REQUIRE(nactive == num_active_, "!");
-  }
   auto pmb = GetBlockPointer();
   const int nneighbor = pmb->neighbors.size();
   auto swarm_d = GetDeviceContext();
@@ -296,26 +287,9 @@ void Swarm::Send(BoundaryCommSubset phase) {
 
   // Send buffer data
   vbswarm->Send(phase);
-  {
-    int nactive = 0;
-    for (int n = 0; n < nmax_pool_; n++) {
-      if (mask_(n)) nactive++;
-      printf("mask(%i) = %i\n", n, mask_(n));
-    }
-    PARTHENON_REQUIRE(nactive == num_active_, "!");
-  }
-  printf("%s:%i\n", __FILE__, __LINE__);
 }
 
 void Swarm::UnloadBuffers_() {
-  {
-    int nactive = 0;
-    for (int n = 0; n < nmax_pool_; n++) {
-      if (mask_(n)) nactive++;
-      printf("mask(%i) = %i\n", n, mask_(n));
-    }
-    PARTHENON_REQUIRE(nactive == num_active_, "!");
-  }
   auto pmb = GetBlockPointer();
 
   // Count received particles
@@ -394,18 +368,9 @@ void Swarm::UnloadBuffers_() {
           }
         });
   }
-  {
-    int nactive = 0;
-    for (int n = 0; n < nmax_pool_; n++) {
-      if (mask_(n)) nactive++;
-      printf("mask(%i) = %i\n", n, mask_(n));
-    }
-    PARTHENON_REQUIRE(nactive == num_active_, "!");
-  }
 }
 
 bool Swarm::Receive(BoundaryCommSubset phase) {
-  printf("%s:%i\n", __FILE__, __LINE__);
   auto pmb = GetBlockPointer();
   const int nneighbor = pmb->neighbors.size();
 
@@ -434,7 +399,6 @@ bool Swarm::Receive(BoundaryCommSubset phase) {
       all_boundaries_received = false;
     }
   }
-  printf("%s:%i\n", __FILE__, __LINE__);
 
   return all_boundaries_received;
 }

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -275,6 +275,15 @@ void Swarm::LoadBuffers_() {
 }
 
 void Swarm::Send(BoundaryCommSubset phase) {
+  printf("%s:%i\n", __FILE__, __LINE__);
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
   auto pmb = GetBlockPointer();
   const int nneighbor = pmb->neighbors.size();
   auto swarm_d = GetDeviceContext();
@@ -287,9 +296,26 @@ void Swarm::Send(BoundaryCommSubset phase) {
 
   // Send buffer data
   vbswarm->Send(phase);
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
+  printf("%s:%i\n", __FILE__, __LINE__);
 }
 
 void Swarm::UnloadBuffers_() {
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
   auto pmb = GetBlockPointer();
 
   // Count received particles
@@ -368,9 +394,18 @@ void Swarm::UnloadBuffers_() {
           }
         });
   }
+  {
+    int nactive = 0;
+    for (int n = 0; n < nmax_pool_; n++) {
+      if (mask_(n)) nactive++;
+      printf("mask(%i) = %i\n", n, mask_(n));
+    }
+    PARTHENON_REQUIRE(nactive == num_active_, "!");
+  }
 }
 
 bool Swarm::Receive(BoundaryCommSubset phase) {
+  printf("%s:%i\n", __FILE__, __LINE__);
   auto pmb = GetBlockPointer();
   const int nneighbor = pmb->neighbors.size();
 
@@ -399,6 +434,7 @@ bool Swarm::Receive(BoundaryCommSubset phase) {
       all_boundaries_received = false;
     }
   }
+  printf("%s:%i\n", __FILE__, __LINE__);
 
   return all_boundaries_received;
 }

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -212,6 +212,9 @@ TEST_CASE("Swarm memory management", "[Swarm]") {
   failures_h = failures_d.GetHostMirrorAndCopy();
   REQUIRE(failures_h(0) == 0);
 
+  // Check for internal index consistency after defragmentation operation
+  swarm->Validate();
+
   // Check that data was moved during defrag
   x_h = swarm->Get<Real>(swarm_position::x::name()).Get().GetHostMirrorAndCopy();
   REQUIRE(x_h(2) == 1.1);


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

There was a bug in the defragmentation routine acting on particle lists. The issue was that empty indices weren't being updated after defragmentation. This PR fixes that.

As an aside: this produced the surprising effect that simulation correctness depended on frequency of simulation output, even when no particle fields were being output. This is because particle defragmentation is called during every output cycle. Not saying we can't do this, just mentioning it because it was unexpected. Shouldn't be a correctness issue if defragmentation actually works :)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
