### PR TITLE
Small: Changes to `DataCollection::Add` and `MeshBlockData::Intialize`

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
           run: |
-            pip install sphinx
-            pip install sphinx-rtd-theme
-            pip install sphinx-multiversion
+            pip install --break-system-packages sphinx
+            pip install --break-system-packages sphinx-rtd-theme
+            pip install --break-system-packages sphinx-multiversion
         - name: build docs
           run: |
             echo "Repo = ${GITHUB_REPOSITORY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1161]](https://github.com/parthenon-hpc-lab/parthenon/pull/1161) Make flux field Metadata accessible, add Metadata::CellMemAligned flag, small perfomance upgrades
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 1187]](https://github.com/parthenon-hpc-lab/parthenon/pull/1187) Make DataCollection::Add safer and generalize MeshBlockData::Initialize
 - [[PR 1186]](https://github.com/parthenon-hpc-lab/parthenon/pull/1186) Bump Kokkos submodule to 4.4.1
 - [[PR 1171]](https://github.com/parthenon-hpc-lab/parthenon/pull/1171) Add PARTHENON_USE_SYSTEM_PACKAGES build option
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -58,7 +58,7 @@ class DataCollection {
     auto key = GetKey(name, src);
     auto it = containers_.find(key);
     if (it != containers_.end()) {
-      if (fields.size() && !(it->second)->Contains(fields)) {
+      if (fields.size() && !(it->second)->CreatedFrom(fields)) {
         PARTHENON_THROW(key + " already exists in collection but fields do not match.");
       }
       return it->second;

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -476,6 +476,14 @@ class MeshData {
                        [this, vars](const auto &b) { return b->ContainsExactly(vars); });
   }
 
+  // Checks that the same set of variables was requested to create this container
+  // (which may be different than the set of variables in the container because of fluxes)
+  template <typename Vars_t>
+  bool CreatedFrom(const Vars_t &vars) const noexcept {
+    return std::all_of(block_data_.begin(), block_data_.end(),
+                       [this, vars](const auto &b) { return b->CreatedFrom(vars); });
+  }
+
   std::shared_ptr<SwarmContainer> GetSwarmData(int n) {
     PARTHENON_REQUIRE(n >= 0 && n < block_data_.size(),
                       "MeshData::GetSwarmData requires n within [0, block_data_.size()]");

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -196,8 +196,7 @@ class MeshBlockData {
             if (!found) add_var(src->GetVarPtr(flx_name));
           }
         }
-      } else if constexpr (std::is_same_v<SRC_t, MeshBlock> &&
-                           std::is_same_v<ID_t, std::string>) {
+      } else if constexpr (std::is_same_v<SRC_t, MeshBlock>) {
         for (const auto &v : vars) {
           const auto &vid = resolved_packages->GetFieldVarID(v);
           const auto &md = resolved_packages->GetFieldMetadata(v);
@@ -205,20 +204,16 @@ class MeshBlockData {
           // Add the associated flux as well if not explicitly
           // asked for
           if (md.IsSet(Metadata::WithFluxes)) {
-            auto flx_name = md.GetFluxName();
+            auto flx_vid = resolved_packages->GetFieldVarID(md.GetFluxName());
             bool found = false;
             for (const auto &v2 : vars)
-              if (v2 == flx_name) found = true;
+              if (resolved_packages->GetFieldVarID(v2) == flx_vid) found = true;
             if (!found) {
-              const auto &vid = resolved_packages->GetFieldVarID(flx_name);
-              const auto &md = resolved_packages->GetFieldMetadata(flx_name);
-              AddField(vid.base_name, md, vid.sparse_id);
+              const auto &flx_md = resolved_packages->GetFieldMetadata(flx_vid);
+              AddField(flx_vid.base_name, flx_md, flx_vid.sparse_id);
             }
           }
         }
-      } else {
-        PARTHENON_FAIL("Variable subset selection not yet implemented for MeshBlock "
-                       "input with unique ids.");
       }
     }
 

--- a/src/interface/state_descriptor.cpp
+++ b/src/interface/state_descriptor.cpp
@@ -316,6 +316,7 @@ bool StateDescriptor::AddFieldImpl_(const VarID &vid, const Metadata &m_in,
       AddFieldImpl_(fId, *(m.GetSPtrFluxMetadata()), control_vid);
       m.SetFluxName(fId.label());
     }
+    labelToVidMap_.insert({vid.label(), vid});
     metadataMap_.insert({vid, m});
     refinementFuncMaps_.Register(m, vid.label());
     allocControllerReverseMap_.insert({vid, control_vid});

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -204,8 +204,9 @@ class StateDescriptor {
   std::vector<std::string> Swarms() noexcept;
 
   const auto GetFieldVarID(const VarID &id) const {
-    PARTHENON_REQUIRE_THROWS(metadataMap_.count(id),
-                             "Asking for a variable that is not in this StateDescriptor.");
+    PARTHENON_REQUIRE_THROWS(
+        metadataMap_.count(id),
+        "Asking for a variable that is not in this StateDescriptor.");
     return id;
   }
 

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -203,6 +203,12 @@ class StateDescriptor {
   // retrieve all swarm names
   std::vector<std::string> Swarms() noexcept;
 
+  const auto GetFieldVarID(const VarID &id) const {
+    PARTHENON_REQUIRE_THROWS(metadataMap_.count(id),
+                             "Asking for a variable that is not in this StateDescriptor.");
+    return id;
+  }
+
   const auto &GetFieldVarID(const std::string &label) const {
     return labelToVidMap_.at(label);
   }

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -203,6 +203,13 @@ class StateDescriptor {
   // retrieve all swarm names
   std::vector<std::string> Swarms() noexcept;
 
+  const auto &GetFieldVarID(const std::string &label) const {
+    return labelToVidMap_.at(label);
+  }
+  const auto &GetFieldMetadata(const std::string &label) const {
+    return metadataMap_.at(labelToVidMap_.at(label));
+  }
+  const auto &GetFieldMetadata(const VarID &id) const { return metadataMap_.at(id); }
   const auto &AllFields() const noexcept { return metadataMap_; }
   const auto &AllSparsePools() const noexcept { return sparsePoolMap_; }
   const auto &AllSwarms() const noexcept { return swarmMetadataMap_; }
@@ -397,6 +404,7 @@ class StateDescriptor {
   const std::string label_;
 
   // for each variable label (full label for sparse variables) hold metadata
+  std::unordered_map<std::string, VarID> labelToVidMap_;
   std::unordered_map<VarID, Metadata, VarIDHasher> metadataMap_;
   std::unordered_map<VarID, VarID, VarIDHasher> allocControllerReverseMap_;
   std::unordered_map<std::string, std::vector<std::string>> allocControllerMap_;

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -979,8 +979,9 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
         auto &md_noncc = mesh_data.AddShallow(noncc, md, noncc_names);
       }
 
-      CommunicateBoundaries(noncc); // Called to make sure shared values are correct,
-                                    // ghosts of non-cell centered vars may get some junk
+      CommunicateBoundaries(
+          noncc, noncc_names); // Called to make sure shared values are correct,
+                               // ghosts of non-cell centered vars may get some junk
       // Now there is the correct data for prolongating on un-shared topological elements
       // on the new fine blocks
       if (nprolong > 0) {

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -329,7 +329,8 @@ class Mesh {
 
   void SetupMPIComms();
   void BuildTagMapAndBoundaryBuffers();
-  void CommunicateBoundaries(std::string md_name = "base");
+  void CommunicateBoundaries(std::string md_name = "base",
+                             const std::vector<std::string> &fields = {});
   void PreCommFillDerived();
   void FillDerived();
 


### PR DESCRIPTION
## PR Summary

This PR does two related things:

1. It adds a check in `DataCollection::Add` that if a container already exists, it was created with the exact same list of fields as were passed into the current call to `Add`. Previously, it was just checked that the pre-existing container had a superset of the requested fields, which lead to a communication bug in multigrid that took me a long time to figure out.
2.  Adds the ability to call `DataCollection::Add` on a partition with a list of fields to include. Previously, this resulted in a `PARTHENON_FAIL`.

I am open to arguments on 1) why this isn't the behavior we desire. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
