### PR TITLE
Fix: Bounds in output for Metadata::None variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1188]](https://github.com/parthenon-hpc-lab/parthenon/pull/1188) Fix hdf5 output issue for metadata none variables, update test.
 - [[PR 1178]](https://github.com/parthenon-hpc-lab/parthenon/pull/1178) Fix issue with mesh pointer when using relative residual tolerance in BiCGSTAB solver.
 - [[PR 1173]](https://github.com/parthenon-hpc-lab/parthenon/pull/1173) Make debugging easier by making parthenon throw an error if ParameterInput is different on multiple MPI ranks.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ include(cmake/Lint.cmake)
 # regression test reference data
 set(REGRESSION_GOLD_STANDARD_VER 25 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=1e83445b117c5062cc33f3ec65ed70a2057f945c64aa4ea2ee9fa321716b931dec8dbc068376df60e84b4336f03c4204438938fdc09c72794a02597654298d65"
+  "SHA512=698b38f997af9e716293fbd17d0e929d5a7fbee2d763a6b5adf32907f36ef0c79793ae87e5953935d4bf6c36c5637492d4ec3ae85c7977b6a0e612a6ac50009e"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 24 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 25 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=e220df92a335131131e42ddb52dc221a6dbd6bb56361483b4af0292620eeb82ffb21ef3b95fd9a7c5cc158fb754da0bf1a1015bec98b5bbad05f4bceb1ee99bc"
+  "SHA512=1e83445b117c5062cc33f3ec65ed70a2057f945c64aa4ea2ee9fa321716b931dec8dbc068376df60e84b4336f03c4204438938fdc09c72794a02597654298d65"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ include(cmake/Lint.cmake)
 # regression test reference data
 set(REGRESSION_GOLD_STANDARD_VER 25 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=698b38f997af9e716293fbd17d0e929d5a7fbee2d763a6b5adf32907f36ef0c79793ae87e5953935d4bf6c36c5637492d4ec3ae85c7977b6a0e612a6ac50009e"
+  "SHA512=314dc8312366d81ba33d1fde25812e9a7697b2f529de29e22662df0d458f1c4bc5b5bb4e649888170f66ffec0df1be20a9cf401944531c1c1ad835e26eaad28f"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -329,14 +329,10 @@ void PreFill(MeshBlockData<Real> *rc) {
     PackIndexMap imap;
     const auto &v = rc->PackVariables(vars, imap);
 
-    const int ivar_lo = imap.get("metadata_none_var").first;
-    const int ivar_hi = imap.get("metadata_none_var").second;
     pmb->par_for(
         PARTHENON_AUTO_LABEL, 0, 2, 0, nx3, 0, nx2, 0, nx1,
         KOKKOS_LAMBDA(const int n, const int k, const int j, const int i) {
-          v(ivar_lo, n, k, j, i) = n + k * j * i;
-          v(ivar_lo + 1, n, k, j, i) = 1 + n + k * j * i;
-          v(ivar_hi, n, k, j, i) = 2 + n + k * j * i;
+          v(n, k, j, i) = n + k + j + i;
         });
   }
 }

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -312,11 +312,11 @@ void PackOrUnpackVar(const VarInfo &info, bool do_ghosts, idx_t &idx, Function_t
   auto [kb, jb, ib] = info.GetPaddedBoundsKJI(domain);
   if (info.where == MetadataFlag({Metadata::None})) {
     kb.s = 0;
-    kb.e = shape[4];
+    kb.e = std::max(0, shape[4] - 1);
     jb.s = 0;
-    jb.e = shape[5];
+    jb.e = std::max(0, shape[5] - 1);
     ib.s = 0;
-    ib.e = shape[6];
+    ib.e = std::max(0, shape[6] - 1);
   }
   for (int topo = 0; topo < shape[0]; ++topo) {
     for (int t = 0; t < shape[1]; ++t) {

--- a/tst/regression/test_suites/output_hdf5/output_hdf5.py
+++ b/tst/regression/test_suites/output_hdf5/output_hdf5.py
@@ -190,6 +190,18 @@ class TestCase(utils.test_case.TestCaseAbs):
                 )
                 analyze_status = False
 
+        # check contents of matadata_none_var
+        for dim in [2, 3]:
+            data = phdf.phdf(f"advection_{dim}d.out0.final.phdf")
+            profile = data.Get("metadata_none_var", flatten=False)
+            for index in np.ndindex(profile.shape):
+                ib, j, k, l, m = index
+                expected_value = l + k + j + m
+                actual_value = profile[ib, j, k, l, m]
+                if expected_value != actual_value:
+                    print("metadata_none_var is incorrect")
+                    analyze_status = False
+
         # Checking Parthenon histograms versus numpy ones
         for dim in [2, 3]:
             # 1D histogram with binning of a variable with bins defined by a var

--- a/tst/regression/test_suites/output_hdf5/parthinput.advection
+++ b/tst/regression/test_suites/output_hdf5/parthinput.advection
@@ -54,6 +54,7 @@ vx = 1.0
 vy = 1.0
 vz = 1.0
 profile = hard_sphere
+test_metadata_none = true
 
 refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
@@ -64,7 +65,8 @@ file_type = hdf5
 dt = 1.0
 variables = advected, one_minus_advected, & # comments are ok
             one_minus_advected_sq, & # on every (& characters are ok in comments)
-            one_minus_sqrt_one_minus_advected_sq # line
+            one_minus_sqrt_one_minus_advected_sq, & # line
+            metadata_none_var
 
 <parthenon/output1>
 file_type = hst


### PR DESCRIPTION
In updating `phoebus` to use up-to-date `parthenon` I ran into an issue where a `Metadata::None` variable was failing to output due to view bounds accesses. There seems to have been an off-by-one error in the relevant code block in `output_utils.hpp:313`. I've updated the bounds there to correctly output `Metadata::None` variables. 

To test this, I modified the advection example to have an optional `Metadata::None` variable (enabled in the input deck `<Advection>/test_metadata_none`). I set the output_hdf5 test to use this variable.


## PR Checklist

- [ ] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
