### PR TITLE
Update Kokkos version to 4.4.1

### DIFF
--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -1,6 +1,14 @@
 name: Check compilers
 
-on: [push, pull_request]
+on:
+  # run every day at 06:00 UTC
+  schedule:
+    - cron: '0 6 * * *'
+  # when triggered manually
+  workflow_dispatch:
+  # when auto merge is enabled (hack to make sure it's run before merging)
+  pull_request:
+    types: [auto_merge_enabled]
 
 # Cancel "duplicated" workflows triggered by pushes to internal
 # branches with associated PRs.

--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -13,8 +13,8 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        cxx: ['g++', 'clang++-15']
-        cmake_build_type: ['Release', 'Debug']
+        cxx
+        cmake_build_type: ['Release', 'DbgNoSym']
         device: ['cuda', 'host']
         parallel: ['serial', 'mpi']
         exclude:
@@ -23,7 +23,7 @@ jobs:
           # https://github.com/lanl/parthenon/issues/630
           - cxx: clang++-15
             device: cuda
-            cmake_build_type: Debug
+            cmake_build_type: DbgNoSym
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
@@ -48,7 +48,7 @@ jobs:
     strategy:
       matrix:
         cxx: ['hipcc']
-        cmake_build_type: ['Release', 'Debug']
+        cmake_build_type: ['Release', 'DbgNoSym']
         device: ['hip']
         parallel: ['serial', 'mpi']
     runs-on: ubuntu-latest

--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -61,7 +61,7 @@ jobs:
         parallel: ['serial', 'mpi']
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/parthenon-hpc-lab/rocm5.4.3-mpi-hdf5
+      image: ghcr.io/parthenon-hpc-lab/rocm6.2-mpi-hdf5
     env:
       CMAKE_GENERATOR: Ninja
     steps:
@@ -74,7 +74,11 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DMACHINE_CFG=${PWD}/cmake/machinecfg/GitHubActions.cmake \
-            -DMACHINE_VARIANT=${{ matrix.device }}_${{ matrix.parallel }}
+            -DMACHINE_VARIANT=${{ matrix.device }}_${{ matrix.parallel }} \
+            # Manually chaning the arch for this (debug) build as the
+            # -O0 option causes compiler issue for the navi 1030 GPU at
+            # compile time, see https://github.com/parthenon-hpc-lab/parthenon/pull/1191#issuecomment-2492035364
+            -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ARCH_NAVI1030=OFF
       - name: Build
         run: |
           cmake --build builddir --parallel 2

--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -69,15 +69,15 @@ jobs:
         with:
           submodules: 'true'
       - name: CMake
+        # Manually chaning the arch for this (debug) build as the
+        # -O0 option causes compiler issue for the navi 1030 GPU at
+        # compile time, see https://github.com/parthenon-hpc-lab/parthenon/pull/1191#issuecomment-2492035364
         run: |
           cmake -B builddir \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DMACHINE_CFG=${PWD}/cmake/machinecfg/GitHubActions.cmake \
             -DMACHINE_VARIANT=${{ matrix.device }}_${{ matrix.parallel }} \
-            # Manually chaning the arch for this (debug) build as the
-            # -O0 option causes compiler issue for the navi 1030 GPU at
-            # compile time, see https://github.com/parthenon-hpc-lab/parthenon/pull/1191#issuecomment-2492035364
             -DKokkos_ARCH_AMD_GFX90A=ON -DKokkos_ARCH_NAVI1030=OFF
       - name: Build
         run: |

--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -21,7 +21,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        cxx
+        cxx: ['g++', 'clang++-15']
         cmake_build_type: ['Release', 'DbgNoSym']
         device: ['cuda', 'host']
         parallel: ['serial', 'mpi']

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -21,6 +21,8 @@ env:
   CMAKE_BUILD_PARALLEL_LEVEL: 5 # num threads for build
   MACHINE_CFG: cmake/machinecfg/CI.cmake
   OMPI_MCA_mpi_common_cuda_event_max: 1000
+  # CUDA IPC within docker repeated seem to cause issue on the CI machine
+  OMPI_MCA_btl_smcuda_use_cuda_ipc: 0
   # https://github.com/open-mpi/ompi/issues/4948#issuecomment-395468231
   OMPI_MCA_btl_vader_single_copy_mechanism: none
 
@@ -34,7 +36,7 @@ jobs:
     container:
       image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -32,9 +32,9 @@ jobs:
         parallel: ['serial', 'mpi']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
         with:
@@ -91,27 +91,27 @@ jobs:
           ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       # Test Ascent integration (only most complex setup with MPI and on device)
-      # - name: Ascent tests
-      #   if: ${{ matrix.parallel == 'mpi' && matrix.device == 'cuda' }}
-      #   run: |
-      #     cmake -B build-ascent \
-      #       -DCMAKE_BUILD_TYPE=Release \
-      #       -DMACHINE_VARIANT=${{ matrix.device }}-${{ matrix.parallel }} \
-      #       -DPARTHENON_ENABLE_ASCENT=ON \
-      #       -DAscent_DIR=/usr/local/ascent-develop/lib/cmake/ascent
-      #     cmake --build build-ascent
-      #     cd example/advection/
-      #     # Pick GPU with most available memory
-      #     export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
-      #     mpirun -np 2 ../../build-ascent/example/advection/advection-example \
-      #       -i parthinput.advection \
-      #       parthenon/output5/dt=0.05 \
-      #       parthenon/time/tlim=0.1
-      #     # check if file exists
-      #     if [ ! -f "ascent_render_57.png" ]; then
-      #       echo "'ascent_render_57.png' does not exist."
-      #       exit 1
-      #     fi
+      - name: Ascent tests
+        if: ${{ matrix.parallel == 'mpi' && matrix.device == 'cuda' }}
+        run: |
+          cmake -B build-ascent \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DMACHINE_VARIANT=${{ matrix.device }}-${{ matrix.parallel }} \
+            -DPARTHENON_ENABLE_ASCENT=ON \
+            -DAscent_DIR=/usr/local/ascent-develop/lib/cmake/ascent
+          cmake --build build-ascent
+          cd example/advection/
+          # Pick GPU with most available memory
+          export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
+          mpirun -np 2 ../../build-ascent/example/advection/advection-example \
+            -i parthinput.advection \
+            parthenon/output5/dt=0.05 \
+            parthenon/time/tlim=0.1
+          # check if file exists
+          if [ ! -f "ascent_render_57.png" ]; then
+            echo "'ascent_render_57.png' does not exist."
+            exit 1
+          fi
 
       - uses: actions/upload-artifact@v3
         with:
@@ -120,7 +120,7 @@ jobs:
             build/CMakeFiles/CMakeOutput.log
             build/tst/regression/outputs/advection_convergence*/advection-errors.dat
             build/tst/regression/outputs/advection_convergence*/advection-errors.png
-          # example/advection/ascent_render_57.png
+            example/advection/ascent_render_57.png
           retention-days: 3
 
   perf-and-regression-amdgpu:

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -32,9 +32,9 @@ jobs:
         parallel: ['serial', 'mpi']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:
@@ -91,27 +91,27 @@ jobs:
           ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       # Test Ascent integration (only most complex setup with MPI and on device)
-      - name: Ascent tests
-        if: ${{ matrix.parallel == 'mpi' && matrix.device == 'cuda' }}
-        run: |
-          cmake -B build-ascent \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DMACHINE_VARIANT=${{ matrix.device }}-${{ matrix.parallel }} \
-            -DPARTHENON_ENABLE_ASCENT=ON \
-            -DAscent_DIR=/usr/local/ascent-develop/lib/cmake/ascent
-          cmake --build build-ascent
-          cd example/advection/
-          # Pick GPU with most available memory
-          export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
-          mpirun -np 2 ../../build-ascent/example/advection/advection-example \
-            -i parthinput.advection \
-            parthenon/output5/dt=0.05 \
-            parthenon/time/tlim=0.1
-          # check if file exists
-          if [ ! -f "ascent_render_57.png" ]; then
-            echo "'ascent_render_57.png' does not exist."
-            exit 1
-          fi
+      # - name: Ascent tests
+      #   if: ${{ matrix.parallel == 'mpi' && matrix.device == 'cuda' }}
+      #   run: |
+      #     cmake -B build-ascent \
+      #       -DCMAKE_BUILD_TYPE=Release \
+      #       -DMACHINE_VARIANT=${{ matrix.device }}-${{ matrix.parallel }} \
+      #       -DPARTHENON_ENABLE_ASCENT=ON \
+      #       -DAscent_DIR=/usr/local/ascent-develop/lib/cmake/ascent
+      #     cmake --build build-ascent
+      #     cd example/advection/
+      #     # Pick GPU with most available memory
+      #     export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
+      #     mpirun -np 2 ../../build-ascent/example/advection/advection-example \
+      #       -i parthinput.advection \
+      #       parthenon/output5/dt=0.05 \
+      #       parthenon/time/tlim=0.1
+      #     # check if file exists
+      #     if [ ! -f "ascent_render_57.png" ]; then
+      #       echo "'ascent_render_57.png' does not exist."
+      #       exit 1
+      #     fi
 
       - uses: actions/upload-artifact@v3
         with:
@@ -120,7 +120,7 @@ jobs:
             build/CMakeFiles/CMakeOutput.log
             build/tst/regression/outputs/advection_convergence*/advection-errors.dat
             build/tst/regression/outputs/advection_convergence*/advection-errors.png
-            example/advection/ascent_render_57.png
+          # example/advection/ascent_render_57.png
           retention-days: 3
 
   perf-and-regression-amdgpu:

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -13,6 +13,8 @@ env:
   CMAKE_BUILD_PARALLEL_LEVEL: 5 # num threads for build
   MACHINE_CFG: cmake/machinecfg/CI.cmake
   OMPI_MCA_mpi_common_cuda_event_max: 1000
+  # CUDA IPC within docker repeated seem to cause issue on the CI machine
+  OMPI_MCA_btl_smcuda_use_cuda_ipc: 0
   # https://github.com/open-mpi/ompi/issues/4948#issuecomment-395468231
   OMPI_MCA_btl_vader_single_copy_mechanism: none
 
@@ -22,7 +24,7 @@ jobs:
     container:
       image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:
@@ -47,7 +49,7 @@ jobs:
     container:
       image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:
@@ -79,7 +81,7 @@ jobs:
     container:
       image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -20,9 +20,9 @@ jobs:
   style:
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,9 +45,9 @@ jobs:
         device: ['cuda', 'host']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
         with:
@@ -77,9 +77,9 @@ jobs:
         device: ['cuda', 'host']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
+      options: --user 1001
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -20,9 +20,9 @@ jobs:
   style:
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:
@@ -45,9 +45,9 @@ jobs:
         device: ['cuda', 'host']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:
@@ -77,9 +77,9 @@ jobs:
         device: ['cuda', 'host']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda11.6-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda11.6-noascent
       # map to local user id on CI  machine to allow writing to build cache
-      options: --user 1001
+      options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,10 @@ on:
 jobs:
     docs:
       name: build and deploy docs
-      runs-on: ubuntu-latest
+      # not using latest due to issues with pip user packages, see
+      # https://github.com/actions/runner-images/issues/10781 and
+      # https://github.com/actions/runner-images/issues/10636
+      runs-on: ubuntu-22.04
 
       steps:      
         - name: Checkout code
@@ -23,9 +26,9 @@ jobs:
           run: export DEBIAN_FRONTEND=noninteractive
         - name: install dependencies
           run: |
-            pip install --break-system-packages sphinx
-            pip install --break-system-packages sphinx-rtd-theme
-            pip install --break-system-packages sphinx-multiversion
+            pip install sphinx
+            pip install sphinx-rtd-theme
+            pip install sphinx-multiversion
         - name: build docs
           run: |
             echo "Repo = ${GITHUB_REPOSITORY}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,8 @@
 - [[PR 1161]](https://github.com/parthenon-hpc-lab/parthenon/pull/1161) Make flux field Metadata accessible, add Metadata::CellMemAligned flag, small perfomance upgrades
 
 ### Changed (changing behavior/API/variables/...)
-- [[PR1191]](https://github.com/parthenon-hpc-lab/parthenon/pull/1191) Update Kokkos version to 4.2.01
+- [[PR 1191]](https://github.com/parthenon-hpc-lab/parthenon/pull/1191) Update Kokkos version to 4.4.1
 - [[PR 1187]](https://github.com/parthenon-hpc-lab/parthenon/pull/1187) Make DataCollection::Add safer and generalize MeshBlockData::Initialize
-- [[Issue 1165]](https://github.com/parthenon-hpc-lab/parthenon/issues/1165) Bump Kokkos submodule to 4.4.1
 - [[PR 1171]](https://github.com/parthenon-hpc-lab/parthenon/pull/1171) Add PARTHENON_USE_SYSTEM_PACKAGES build option
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1161]](https://github.com/parthenon-hpc-lab/parthenon/pull/1161) Make flux field Metadata accessible, add Metadata::CellMemAligned flag, small perfomance upgrades
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR1191]](https://github.com/parthenon-hpc-lab/parthenon/pull/1191) Update Kokkos version to 4.2.01
 - [[PR 1187]](https://github.com/parthenon-hpc-lab/parthenon/pull/1187) Make DataCollection::Add safer and generalize MeshBlockData::Initialize
 - [[Issue 1165]](https://github.com/parthenon-hpc-lab/parthenon/issues/1165) Bump Kokkos submodule to 4.4.1
 - [[PR 1171]](https://github.com/parthenon-hpc-lab/parthenon/pull/1171) Add PARTHENON_USE_SYSTEM_PACKAGES build option

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Parthenon -- a performance portable block-structured adaptive mesh refinement fr
 
 * CMake 3.16 or greater
 * C++17 compatible compiler
-* Kokkos 4.1.1 or greater
+* Kokkos 4.4.1 or greater
 
 ## Optional (enabling features)
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Parthenon -- a performance portable block-structured adaptive mesh refinement fr
 
 * CMake 3.16 or greater
 * C++17 compatible compiler
-* Kokkos 4.0.1 or greater
+* Kokkos 4.1.1 or greater
 
 ## Optional (enabling features)
 

--- a/cmake/machinecfg/GitHubActions.cmake
+++ b/cmake/machinecfg/GitHubActions.cmake
@@ -19,6 +19,7 @@ message(STATUS "Loading machine configuration for GitHub Actions CI. ")
 
 # common options
 set(NUM_MPI_PROC_TESTING "2" CACHE STRING "CI runs tests with 2 MPI ranks")
+set(Kokkos_ENABLE_ROCTHRUST OFF CACHE BOOL "Temporarily disabled as the container needs to be updated to the `-complete` base image.")
 
 set(MACHINE_CXX_FLAGS "")
 if (${MACHINE_VARIANT} MATCHES "cuda")

--- a/cmake/machinecfg/GitHubActions.cmake
+++ b/cmake/machinecfg/GitHubActions.cmake
@@ -21,6 +21,8 @@ message(STATUS "Loading machine configuration for GitHub Actions CI. ")
 set(NUM_MPI_PROC_TESTING "2" CACHE STRING "CI runs tests with 2 MPI ranks")
 set(Kokkos_ENABLE_ROCTHRUST OFF CACHE BOOL "Temporarily disabled as the container needs to be updated to the `-complete` base image.")
 
+set(CMAKE_CXX_FLAGS_DBGNOSYM "-O0" CACHE STRING "Debug build without symbols")
+
 set(MACHINE_CXX_FLAGS "")
 if (${MACHINE_VARIANT} MATCHES "cuda")
   # using an arbitrary arch as GitHub Action runners don't have GPUs

--- a/doc/sphinx/src/development.rst
+++ b/doc/sphinx/src/development.rst
@@ -21,7 +21,10 @@ Kokkos wrappers/abstractions
 -  ``par_for`` wrappers use inclusive bounds, i.e., the loop will
    include the last index given
 -  ``ParArrayND`` arrays by default allocate on the *device* using
-   default precision configured
+   default precision configured and come with a `State` that can
+   be used to store additional metadata.
+- ``ParArray#DRaw`` directly map to Kokkos ``Views`` that are allocated
+   on *device* using default precision.
 -  To create an array on the host with identical layout to the device
    array either use
 
@@ -65,7 +68,7 @@ tightly nested loops. The wrappers are documented
 View of Views
 -------------
 
-Special care needs to be taken when working with a ``View`` of ``View``.
+Special care needs to be taken when working with a ``View`` of ``Views``.
 
 To repeat the Kokkos documenation: `Don't use them <https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/View.html#can-i-make-a-view-of-views>`__
 
@@ -74,19 +77,27 @@ then follow this pattern:
 
 .. code:: c++
 
-   Kokkos::View<ParArray1D<Real> *> view_of_pararrays(parthenon::ViewOfViewAlloc("myname"), 10);
+   ParArray1DRaw<ParArray1D<Real>> view_of_pararrays(parthenon::ViewOfViewAlloc("myname"), 10);
 
 The ``ViewOfViewAlloc`` ensures that the ``Kokkos::SequentialHostInit`` property is added,
 which results in the (inner ``View`` ) deallocators being called on the host (rather than on
 the device by default).
+Also note the use of the "raw" ``ParArray1DRaw``, which directly maps to a Kokkos ``View``
+(that is required to process the allocation property as this interface is not exposed
+in the more generic ``ParArrayND``).
 
 Similarly, when you create a host mirror of said ``View`` of ``View`` add the additional
 property for the same reason.
 
 .. code:: c++
 
+   // explicit theoretical example -- don't use this
    auto view_of_pararrays_h =
         Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), view_of_pararrays);
+
+   // but instead use this interface provided by Parthenon:
+   auto view_of_pararrays_h = create_view_of_view_mirror(view_of_pararrays);
+
 
 Note that the ``SequentialHostInit`` was only added in Kokkos 4.4.1 (which is now the default in Parthenon).
 

--- a/doc/sphinx/src/development.rst
+++ b/doc/sphinx/src/development.rst
@@ -62,6 +62,34 @@ parallelism interface that is needed for managing memory cached in
 tightly nested loops. The wrappers are documented
 :ref:`here <nested par for>`.
 
+View of Views
+-------------
+
+Special care needs to be taken when working with a ``View`` of ``View``.
+
+To repeat the Kokkos documenation: `Don't use them <https://kokkos.org/kokkos-core-wiki/ProgrammingGuide/View.html#can-i-make-a-view-of-views>`__
+
+But if you have to (which is the case in some places inside Parthenon)
+then follow this pattern:
+
+.. code:: c++
+
+   Kokkos::View<ParArray1D<Real> *> view_of_pararrays(parthenon::ViewOfViewAlloc("myname"), 10);
+
+The ``ViewOfViewAlloc`` ensures that the ``Kokkos::SequentialHostInit`` property is added,
+which results in the (inner ``View`` ) deallocators being called on the host (rather than on
+the device by default).
+
+Similarly, when you create a host mirror of said ``View`` of ``View`` add the additional
+property for the same reason.
+
+.. code:: c++
+
+   auto view_of_pararrays_h =
+        Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), view_of_pararrays);
+
+Note that the ``SequentialHostInit`` was only added in Kokkos 4.4.1 (which is now the default in Parthenon).
+
 The need for reductions within function handling ``MeshBlock`` data
 -------------------------------------------------------------------
 

--- a/scripts/docker/Dockerfile.hip-rocm
+++ b/scripts/docker/Dockerfile.hip-rocm
@@ -1,4 +1,4 @@
-FROM rocm/dev-ubuntu-20.04:5.4.3
+FROM rocm/dev-ubuntu-24.04:6.2
 
 RUN apt-get clean && apt-get update -y && \
     DEBIAN_FRONTEND="noninteractive" TZ=America/New_York apt-get install -y --no-install-recommends git python3-minimal libpython3-stdlib bc hwloc wget openssh-client python3-numpy python3-h5py python3-matplotlib lcov curl cmake ninja-build openmpi-bin libopenmpi-dev && \
@@ -14,12 +14,10 @@ RUN cd /tmp && \
     cd / && \
     rm -rf /tmp/hdf5-1.10.8*
 
-# "mpic++ --showme" forgets open-pal in Ubuntu 20.04 + OpenMPI 4.0.3
-#   https://bugs.launchpad.net/ubuntu/+source/openmpi/+bug/1941786
-#   https://github.com/open-mpi/ompi/issues/9317
-ENV LDFLAGS="-lopen-pal"
-
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
-# uid 1000 maps to the one running the container on the CI host
-RUN useradd --create-home --shell /bin/bash -u 1000 -G render ci
+# Latest image has default user with uid 1000 (which maps to the one running the container on the CI host
+# Need to add user to the group that can access the GPU
+RUN usermod -a -G render ubuntu
+
+WORKDIR /home/ubuntu

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -101,9 +101,6 @@ class BoundarySwarm : public BoundaryCommunication {
   explicit BoundarySwarm(std::weak_ptr<MeshBlock> pmb, const std::string &label);
   ~BoundarySwarm() = default;
 
-  std::vector<ParArrayND<int>> vars_int;
-  std::vector<ParArrayND<Real>> vars_real;
-
   // (usuallly the std::size_t unsigned integer type)
   std::vector<BoundaryCommunication *>::size_type bswarm_index;
 

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -41,7 +41,8 @@ namespace parthenon {
 
 void ProResCache_t::Initialize(int n_regions, StateDescriptor *pkg) {
   prores_info = ParArray1D<ProResInfo>("prores_info", n_regions);
-  prores_info_h = Kokkos::create_mirror_view(prores_info);
+  prores_info_h = Kokkos::create_mirror_view(
+      Kokkos::view_alloc(Kokkos::SequentialHostInit), prores_info);
   int nref_funcs = pkg->NumRefinementFuncs();
   // Note that assignment of Kokkos views resets them, but
   // buffer_subset_sizes is a std::vector. It must be cleared, then

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -40,7 +40,7 @@
 namespace parthenon {
 
 void ProResCache_t::Initialize(int n_regions, StateDescriptor *pkg) {
-  prores_info = ParArray1D<ProResInfo>("prores_info", n_regions);
+  prores_info = ProResInfoArr_t(ViewOfViewAlloc("prores_info"), n_regions);
   prores_info_h = Kokkos::create_mirror_view(
       Kokkos::view_alloc(Kokkos::SequentialHostInit), prores_info);
   int nref_funcs = pkg->NumRefinementFuncs();

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -41,8 +41,7 @@ namespace parthenon {
 
 void ProResCache_t::Initialize(int n_regions, StateDescriptor *pkg) {
   prores_info = ProResInfoArr_t(ViewOfViewAlloc("prores_info"), n_regions);
-  prores_info_h = Kokkos::create_mirror_view(
-      Kokkos::view_alloc(Kokkos::SequentialHostInit), prores_info);
+  prores_info_h = create_view_of_view_mirror(prores_info);
   int nref_funcs = pkg->NumRefinementFuncs();
   // Note that assignment of Kokkos views resets them, but
   // buffer_subset_sizes is a std::vector. It must be cleared, then

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -127,7 +127,7 @@ struct ProResInfo {
 int GetBufferSize(MeshBlock *pmb, const NeighborBlock &nb,
                   std::shared_ptr<Variable<Real>> v);
 
-using BndInfoArr_t = ParArray1D<BndInfo>;
+using BndInfoArr_t = Kokkos::View<BndInfo *, LayoutWrapper, DevMemSpace>;
 using BndInfoArrHost_t = typename BndInfoArr_t::HostMirror;
 
 using ProResInfoArr_t = ParArray1D<ProResInfo>;

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -128,10 +128,10 @@ struct ProResInfo {
 int GetBufferSize(MeshBlock *pmb, const NeighborBlock &nb,
                   std::shared_ptr<Variable<Real>> v);
 
-using BndInfoArr_t = Kokkos::View<BndInfo *, LayoutWrapper, DevMemSpace>;
+using BndInfoArr_t = ParArray1DRaw<BndInfo>;
 using BndInfoArrHost_t = typename BndInfoArr_t::HostMirror;
 
-using ProResInfoArr_t = Kokkos::View<ProResInfo *, LayoutWrapper, DevMemSpace>;
+using ProResInfoArr_t = ParArray1DRaw<ProResInfo>;
 using ProResInfoArrHost_t = typename ProResInfoArr_t::HostMirror;
 class StateDescriptor;
 struct ProResCache_t {

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -26,6 +26,7 @@
 #include "bvals/neighbor_block.hpp"
 #include "coordinates/coordinates.hpp"
 #include "interface/variable_state.hpp"
+#include "kokkos_abstraction.hpp"
 #include "mesh/domain.hpp"
 #include "mesh/forest/logical_coordinate_transformation.hpp"
 #include "utils/communication_buffer.hpp"
@@ -130,8 +131,8 @@ int GetBufferSize(MeshBlock *pmb, const NeighborBlock &nb,
 using BndInfoArr_t = Kokkos::View<BndInfo *, LayoutWrapper, DevMemSpace>;
 using BndInfoArrHost_t = typename BndInfoArr_t::HostMirror;
 
-using ProResInfoArr_t = ParArray1D<ProResInfo>;
-using ProResInfoArrHost_t = typename ParArray1D<ProResInfo>::HostMirror;
+using ProResInfoArr_t = Kokkos::View<ProResInfo *, LayoutWrapper, DevMemSpace>;
+using ProResInfoArrHost_t = typename ProResInfoArr_t::HostMirror;
 class StateDescriptor;
 struct ProResCache_t {
   ProResInfoArr_t prores_info{};

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -215,9 +215,9 @@ inline void RebuildBufferCache(std::shared_ptr<MeshData<Real>> md, int nbound,
   using namespace loops;
   using namespace loops::shorthands;
   BvarsSubCache_t &cache = md->GetBvarsCache().GetSubCache(BOUND_TYPE, SENDER);
-  cache.bnd_info =
-      BndInfoArr_t(Kokkos::view_alloc("bnd_info", Kokkos::SequentialHostInit), nbound);
-  cache.bnd_info_h = Kokkos::create_mirror_view(cache.bnd_info);
+  cache.bnd_info = BndInfoArr_t("bnd_info", nbound);
+  cache.bnd_info_h = Kokkos::create_mirror_view(
+      Kokkos::view_alloc(Kokkos::SequentialHostInit), cache.bnd_info);
 
   // prolongation/restriction sub-sets
   // TODO(JMM): Right now I exclude fluxcorrection boundaries but if

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -215,7 +215,8 @@ inline void RebuildBufferCache(std::shared_ptr<MeshData<Real>> md, int nbound,
   using namespace loops;
   using namespace loops::shorthands;
   BvarsSubCache_t &cache = md->GetBvarsCache().GetSubCache(BOUND_TYPE, SENDER);
-  cache.bnd_info = BndInfoArr_t("bnd_info", nbound);
+  cache.bnd_info =
+      BndInfoArr_t(Kokkos::view_alloc("bnd_info", Kokkos::SequentialHostInit), nbound);
   cache.bnd_info_h = Kokkos::create_mirror_view(cache.bnd_info);
 
   // prolongation/restriction sub-sets

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -28,6 +28,7 @@
 #include "bvals/comms/bnd_info.hpp"
 #include "bvals/comms/bvals_in_one.hpp"
 #include "interface/variable.hpp"
+#include "kokkos_abstraction.hpp"
 #include "mesh/domain.hpp"
 #include "mesh/mesh.hpp"
 #include "mesh/meshblock.hpp"
@@ -215,7 +216,7 @@ inline void RebuildBufferCache(std::shared_ptr<MeshData<Real>> md, int nbound,
   using namespace loops;
   using namespace loops::shorthands;
   BvarsSubCache_t &cache = md->GetBvarsCache().GetSubCache(BOUND_TYPE, SENDER);
-  cache.bnd_info = BndInfoArr_t("bnd_info", nbound);
+  cache.bnd_info = BndInfoArr_t(ViewOfViewAlloc("bnd_info"), nbound);
   cache.bnd_info_h = Kokkos::create_mirror_view(
       Kokkos::view_alloc(Kokkos::SequentialHostInit), cache.bnd_info);
 

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -217,8 +217,7 @@ inline void RebuildBufferCache(std::shared_ptr<MeshData<Real>> md, int nbound,
   using namespace loops::shorthands;
   BvarsSubCache_t &cache = md->GetBvarsCache().GetSubCache(BOUND_TYPE, SENDER);
   cache.bnd_info = BndInfoArr_t(ViewOfViewAlloc("bnd_info"), nbound);
-  cache.bnd_info_h = Kokkos::create_mirror_view(
-      Kokkos::view_alloc(Kokkos::SequentialHostInit), cache.bnd_info);
+  cache.bnd_info_h = create_view_of_view_mirror(cache.bnd_info);
 
   // prolongation/restriction sub-sets
   // TODO(JMM): Right now I exclude fluxcorrection boundaries but if

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -150,7 +150,8 @@ const MeshBlockPack<P> &PackOnMesh(M &map, BlockDataList_t<Real> &block_data_,
 
   if (make_new_pack) {
     ParArray1D<P> packs("MeshData::PackVariables::packs", nblocks);
-    auto packs_host = Kokkos::create_mirror_view(packs);
+    auto packs_host =
+        Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), packs);
 
     for (size_t i = 0; i < nblocks; i++) {
       const auto &pack = packing_function(block_data_[i], this_map, this_key);

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -150,10 +150,8 @@ const MeshBlockPack<P> &PackOnMesh(M &map, BlockDataList_t<Real> &block_data_,
   }
 
   if (make_new_pack) {
-    Kokkos::View<P *, LayoutWrapper, DevMemSpace> packs(
-        ViewOfViewAlloc("MeshData::PackVariables::packs"), nblocks);
-    auto packs_host =
-        Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), packs);
+    ParArray1DRaw<P> packs(ViewOfViewAlloc("MeshData::PackVariables::packs"), nblocks);
+    auto packs_host = create_view_of_view_mirror(packs);
 
     for (size_t i = 0; i < nblocks; i++) {
       const auto &pack = packing_function(block_data_[i], this_map, this_key);

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -26,6 +26,7 @@
 #include "interface/sparse_pack_base.hpp"
 #include "interface/swarm_pack_base.hpp"
 #include "interface/variable_pack.hpp"
+#include "kokkos_abstraction.hpp"
 #include "mesh/domain.hpp"
 #include "mesh/meshblock.hpp"
 #include "mesh/meshblock_pack.hpp"
@@ -149,7 +150,8 @@ const MeshBlockPack<P> &PackOnMesh(M &map, BlockDataList_t<Real> &block_data_,
   }
 
   if (make_new_pack) {
-    ParArray1D<P> packs("MeshData::PackVariables::packs", nblocks);
+    Kokkos::View<P *, LayoutWrapper, DevMemSpace> packs(
+        ViewOfViewAlloc("MeshData::PackVariables::packs"), nblocks);
     auto packs_host =
         Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), packs);
 

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -152,7 +152,8 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
     leading_dim += 2;
   }
   pack.pack_ = pack_t("data_ptr", leading_dim, pack.nblocks_, max_size);
-  pack.pack_h_ = Kokkos::create_mirror_view(pack.pack_);
+  pack.pack_h_ = Kokkos::create_mirror_view(
+      Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.pack_);
 
   // For non-flat packs, shape of pack is type x block x var x k x j x i
   // where type here might be a flux.
@@ -168,7 +169,8 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
   pack.block_props_h_ = Kokkos::create_mirror_view(pack.block_props_);
 
   pack.coords_ = coords_t("coords", desc.flat ? max_size : nblocks);
-  auto coords_h = Kokkos::create_mirror_view(pack.coords_);
+  auto coords_h = Kokkos::create_mirror_view(
+      Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.coords_);
 
   // Fill the views
   int idx = 0;

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -153,8 +153,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
     leading_dim += 2;
   }
   pack.pack_ = pack_t(ViewOfViewAlloc("data_ptr"), leading_dim, pack.nblocks_, max_size);
-  pack.pack_h_ = Kokkos::create_mirror_view(
-      Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.pack_);
+  pack.pack_h_ = create_view_of_view_mirror(pack.pack_);
 
   // For non-flat packs, shape of pack is type x block x var x k x j x i
   // where type here might be a flux.
@@ -170,8 +169,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
   pack.block_props_h_ = Kokkos::create_mirror_view(pack.block_props_);
 
   pack.coords_ = coords_t(ViewOfViewAlloc("coords"), desc.flat ? max_size : nblocks);
-  auto coords_h = Kokkos::create_mirror_view(
-      Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.coords_);
+  auto coords_h = create_view_of_view_mirror(pack.coords_);
 
   // Fill the views
   int idx = 0;

--- a/src/interface/sparse_pack_base.cpp
+++ b/src/interface/sparse_pack_base.cpp
@@ -30,6 +30,7 @@
 #include "interface/sparse_pack_base.hpp"
 #include "interface/state_descriptor.hpp"
 #include "interface/variable.hpp"
+#include "kokkos_abstraction.hpp"
 #include "utils/utils.hpp"
 namespace parthenon {
 namespace impl {
@@ -151,7 +152,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
   } else if (contains_face_or_edge) {
     leading_dim += 2;
   }
-  pack.pack_ = pack_t("data_ptr", leading_dim, pack.nblocks_, max_size);
+  pack.pack_ = pack_t(ViewOfViewAlloc("data_ptr"), leading_dim, pack.nblocks_, max_size);
   pack.pack_h_ = Kokkos::create_mirror_view(
       Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.pack_);
 
@@ -168,7 +169,7 @@ SparsePackBase SparsePackBase::Build(T *pmd, const PackDescriptor &desc,
   pack.block_props_ = block_props_t("block_props", nblocks, 27 + 1);
   pack.block_props_h_ = Kokkos::create_mirror_view(pack.block_props_);
 
-  pack.coords_ = coords_t("coords", desc.flat ? max_size : nblocks);
+  pack.coords_ = coords_t(ViewOfViewAlloc("coords"), desc.flat ? max_size : nblocks);
   auto coords_h = Kokkos::create_mirror_view(
       Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.coords_);
 

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -56,14 +56,13 @@ class SparsePackBase {
 
   using alloc_t = std::vector<int>;
   using include_t = std::vector<bool>;
-  using pack_t =
-      Kokkos::View<ParArray3D<Real, VariableState> ***, LayoutWrapper, DevMemSpace>;
+  using pack_t = ParArray3DRaw<ParArray3D<Real, VariableState>>;
   using pack_h_t = typename pack_t::HostMirror;
   using bounds_t = ParArray3D<int>;
   using bounds_h_t = typename bounds_t::HostMirror;
   using block_props_t = ParArray2D<int>;
   using block_props_h_t = typename block_props_t::HostMirror;
-  using coords_t = Kokkos::View<ParArray0D<Coordinates_t> *, LayoutWrapper, DevMemSpace>;
+  using coords_t = ParArray1DRaw<ParArray0D<Coordinates_t>>;
 
   // Returns a SparsePackBase object that is either newly created or taken
   // from the cache in pmd. The cache itself handles the all of this logic

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -63,7 +63,7 @@ class SparsePackBase {
   using bounds_h_t = typename bounds_t::HostMirror;
   using block_props_t = ParArray2D<int>;
   using block_props_h_t = typename block_props_t::HostMirror;
-  using coords_t = ParArray1D<ParArray0D<Coordinates_t>>;
+  using coords_t = Kokkos::View<ParArray0D<Coordinates_t> *, LayoutWrapper, DevMemSpace>;
 
   // Returns a SparsePackBase object that is either newly created or taken
   // from the cache in pmd. The cache itself handles the all of this logic

--- a/src/interface/sparse_pack_base.hpp
+++ b/src/interface/sparse_pack_base.hpp
@@ -30,6 +30,7 @@
 #include "interface/state_descriptor.hpp"
 #include "interface/variable.hpp"
 #include "interface/variable_state.hpp"
+#include "kokkos_abstraction.hpp"
 #include "utils/utils.hpp"
 
 namespace parthenon {
@@ -55,7 +56,8 @@ class SparsePackBase {
 
   using alloc_t = std::vector<int>;
   using include_t = std::vector<bool>;
-  using pack_t = ParArray3D<ParArray3D<Real, VariableState>>;
+  using pack_t =
+      Kokkos::View<ParArray3D<Real, VariableState> ***, LayoutWrapper, DevMemSpace>;
   using pack_h_t = typename pack_t::HostMirror;
   using bounds_t = ParArray3D<int>;
   using bounds_h_t = typename bounds_t::HostMirror;

--- a/src/interface/swarm_comms.cpp
+++ b/src/interface/swarm_comms.cpp
@@ -157,6 +157,7 @@ void Swarm::SetupPersistentMPI() {
 }
 
 void Swarm::CountParticlesToSend_() {
+  // TODO(PG->BRR) What's going on here? Why is the mask being copied?
   auto mask_h = Kokkos::create_mirror_view_and_copy(HostMemSpace(), mask_);
   auto swarm_d = GetDeviceContext();
   auto pmb = GetBlockPointer();

--- a/src/interface/swarm_pack_base.hpp
+++ b/src/interface/swarm_pack_base.hpp
@@ -109,7 +109,8 @@ class SwarmPackBase {
     // Allocate the views
     int leading_dim = 1;
     pack.pack_ = pack_t("data_ptr", leading_dim, nblocks, max_size);
-    auto pack_h = Kokkos::create_mirror_view(pack.pack_);
+    auto pack_h = Kokkos::create_mirror_view(
+        Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.pack_);
 
     pack.bounds_ = bounds_t("bounds", 2, nblocks, nvar);
     auto bounds_h = Kokkos::create_mirror_view(pack.bounds_);
@@ -154,7 +155,8 @@ class SwarmPackBase {
     Kokkos::deep_copy(pack.bounds_, bounds_h);
 
     pack.contexts_ = contexts_t("contexts", nblocks);
-    pack.contexts_h_ = Kokkos::create_mirror_view(pack.contexts_);
+    pack.contexts_h_ = Kokkos::create_mirror_view(
+        Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.contexts_);
     pack.max_active_indices_ = max_active_indices_t("max_active_indices", nblocks);
     pack.flat_index_map_ = max_active_indices_t("flat_index_map", nblocks + 1);
     BuildSupplemental(pmd, desc, pack);

--- a/src/interface/swarm_pack_base.hpp
+++ b/src/interface/swarm_pack_base.hpp
@@ -44,9 +44,9 @@ class SwarmPackBase {
   SwarmPackBase() = default;
   virtual ~SwarmPackBase() = default;
 
-  using pack_t = Kokkos::View<ParArray1D<TYPE> ***, LayoutWrapper, DevMemSpace>;
+  using pack_t = ParArray3DRaw<ParArray1D<TYPE>>;
   using bounds_t = ParArray3D<int>;
-  using contexts_t = Kokkos::View<SwarmDeviceContext *, LayoutWrapper, DevMemSpace>;
+  using contexts_t = ParArray1DRaw<SwarmDeviceContext>;
   using contexts_h_t = typename contexts_t::HostMirror;
   using max_active_indices_t = ParArray1D<int>;
   using desc_t = impl::SwarmPackDescriptor<TYPE>;
@@ -110,8 +110,7 @@ class SwarmPackBase {
     // Allocate the views
     int leading_dim = 1;
     pack.pack_ = pack_t(ViewOfViewAlloc("data_ptr"), leading_dim, nblocks, max_size);
-    auto pack_h = Kokkos::create_mirror_view(
-        Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.pack_);
+    auto pack_h = create_view_of_view_mirror(pack.pack_);
 
     pack.bounds_ = bounds_t("bounds", 2, nblocks, nvar);
     auto bounds_h = Kokkos::create_mirror_view(pack.bounds_);
@@ -156,8 +155,7 @@ class SwarmPackBase {
     Kokkos::deep_copy(pack.bounds_, bounds_h);
 
     pack.contexts_ = contexts_t(ViewOfViewAlloc("contexts"), nblocks);
-    pack.contexts_h_ = Kokkos::create_mirror_view(
-        Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.contexts_);
+    pack.contexts_h_ = create_view_of_view_mirror(pack.contexts_);
     pack.max_active_indices_ = max_active_indices_t("max_active_indices", nblocks);
     pack.flat_index_map_ = max_active_indices_t("flat_index_map", nblocks + 1);
     BuildSupplemental(pmd, desc, pack);

--- a/src/interface/swarm_pack_base.hpp
+++ b/src/interface/swarm_pack_base.hpp
@@ -28,6 +28,7 @@
 #include "interface/state_descriptor.hpp"
 #include "interface/swarm_device_context.hpp"
 #include "interface/variable.hpp"
+#include "kokkos_abstraction.hpp"
 #include "utils/utils.hpp"
 
 namespace parthenon {
@@ -43,10 +44,10 @@ class SwarmPackBase {
   SwarmPackBase() = default;
   virtual ~SwarmPackBase() = default;
 
-  using pack_t = ParArray3D<ParArray1D<TYPE>>;
+  using pack_t = Kokkos::View<ParArray1D<TYPE> ***, LayoutWrapper, DevMemSpace>;
   using bounds_t = ParArray3D<int>;
-  using contexts_t = ParArray1D<SwarmDeviceContext>;
-  using contexts_h_t = typename ParArray1D<SwarmDeviceContext>::HostMirror;
+  using contexts_t = Kokkos::View<SwarmDeviceContext *, LayoutWrapper, DevMemSpace>;
+  using contexts_h_t = typename contexts_t::HostMirror;
   using max_active_indices_t = ParArray1D<int>;
   using desc_t = impl::SwarmPackDescriptor<TYPE>;
   using idx_map_t = std::unordered_map<std::string, std::size_t>;
@@ -108,7 +109,7 @@ class SwarmPackBase {
 
     // Allocate the views
     int leading_dim = 1;
-    pack.pack_ = pack_t("data_ptr", leading_dim, nblocks, max_size);
+    pack.pack_ = pack_t(ViewOfViewAlloc("data_ptr"), leading_dim, nblocks, max_size);
     auto pack_h = Kokkos::create_mirror_view(
         Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.pack_);
 
@@ -154,7 +155,7 @@ class SwarmPackBase {
     Kokkos::deep_copy(pack.pack_, pack_h);
     Kokkos::deep_copy(pack.bounds_, bounds_h);
 
-    pack.contexts_ = contexts_t("contexts", nblocks);
+    pack.contexts_ = contexts_t(ViewOfViewAlloc("contexts"), nblocks);
     pack.contexts_h_ = Kokkos::create_mirror_view(
         Kokkos::view_alloc(Kokkos::SequentialHostInit), pack.contexts_);
     pack.max_active_indices_ = max_active_indices_t("max_active_indices", nblocks);

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -570,10 +570,11 @@ void FillVarView(const VariableVector<T> &vars, int vsize, bool coarse,
   assert(vsize == sparse_id_out.size());
   assert(vsize == vector_component_out.size());
 
-  auto host_cv = Kokkos::create_mirror_view(Kokkos::HostSpace(), cv_out);
-  auto host_sp = Kokkos::create_mirror_view(Kokkos::HostSpace(), sparse_id_out);
-  auto host_vc = Kokkos::create_mirror_view(Kokkos::HostSpace(), vector_component_out);
-  auto host_al = Kokkos::create_mirror_view(Kokkos::HostSpace(), allocated_out);
+  auto host_cv =
+      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), cv_out);
+  auto host_sp = Kokkos::create_mirror_view(sparse_id_out);
+  auto host_vc = Kokkos::create_mirror_view(vector_component_out);
+  auto host_al = Kokkos::create_mirror_view(allocated_out);
 
   int vindex = 0;
   for (const auto &v : vars) {
@@ -634,7 +635,8 @@ void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars,
                       ViewOfParArrays1D<T> &cv_out, PackIndexMap *pvmap) {
   using vpack_types::IndexPair;
 
-  auto host_cv = Kokkos::create_mirror_view(Kokkos::HostSpace(), cv_out);
+  auto host_cv =
+      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), cv_out);
 
   int vindex = 0;
   for (const auto v : vars) {
@@ -675,10 +677,13 @@ void FillFluxViews(const VariableVector<T> &vars, const int ndim,
                    PackIndexMap *pvmap) {
   using vpack_types::IndexPair;
 
-  auto host_f1 = Kokkos::create_mirror_view(Kokkos::HostSpace(), f1_out);
-  auto host_f2 = Kokkos::create_mirror_view(Kokkos::HostSpace(), f2_out);
-  auto host_f3 = Kokkos::create_mirror_view(Kokkos::HostSpace(), f3_out);
-  auto host_al = Kokkos::create_mirror_view(Kokkos::HostSpace(), flux_allocated_out);
+  auto host_f1 =
+      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), f1_out);
+  auto host_f2 =
+      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), f2_out);
+  auto host_f3 =
+      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), f3_out);
+  auto host_al = Kokkos::create_mirror_view(flux_allocated_out);
 
   int vindex = 0;
   for (const auto &v : vars) {

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -244,10 +244,11 @@ class PackIndexMap {
 };
 
 template <typename T>
-using ViewOfParArrays = ParArray1D<ParArray3D<T, VariableState>>;
+using ViewOfParArrays =
+    Kokkos::View<ParArray3D<T, VariableState> *, LayoutWrapper, DevMemSpace>;
 
 template <typename T>
-using ViewOfParArrays1D = ParArray1D<ParArray1D<T>>;
+using ViewOfParArrays1D = Kokkos::View<ParArray1D<T> *, LayoutWrapper, DevMemSpace>;
 
 // forward declaration
 template <typename T>
@@ -760,10 +761,11 @@ VariableFluxPack<T> MakeFluxPack(const VarListWithKeys<T> &var_list,
   }
 
   // make the outer view
-  ViewOfParArrays<T> cv("MakeFluxPack::cv", vsize * (extra_components ? 3 : 1));
-  ViewOfParArrays<T> f1("MakeFluxPack::f1", fsize);
-  ViewOfParArrays<T> f2("MakeFluxPack::f2", fsize);
-  ViewOfParArrays<T> f3("MakeFluxPack::f3", fsize);
+  ViewOfParArrays<T> cv(ViewOfViewAlloc("MakeFluxPack::cv"),
+                        vsize * (extra_components ? 3 : 1));
+  ViewOfParArrays<T> f1(ViewOfViewAlloc("MakeFluxPack::f1"), fsize);
+  ViewOfParArrays<T> f2(ViewOfViewAlloc("MakeFluxPack::f2"), fsize);
+  ViewOfParArrays<T> f3(ViewOfViewAlloc("MakeFluxPack::f3"), fsize);
   ParArray1D<bool> flux_allocated("MakePack::allocated", fsize);
   ParArray1D<int> sparse_id("MakeFluxPack::sparse_id", vsize);
   ParArray1D<int> vector_component("MakeFluxPack::vector_component", vsize);
@@ -814,7 +816,8 @@ VariablePack<T> MakePack(const VarListWithKeys<T> &var_list, bool coarse,
   }
 
   // make the outer view
-  ViewOfParArrays<T> cv("MakePack::cv", vsize * (extra_components ? 3 : 1));
+  ViewOfParArrays<T> cv(ViewOfViewAlloc("MakePack::cv"),
+                        vsize * (extra_components ? 3 : 1));
   ParArray1D<int> sparse_id("MakePack::sparse_id", vsize);
   ParArray1D<int> vector_component("MakePack::vector_component", vsize);
   ParArray1D<bool> allocated("MakePack::allocated", vsize);
@@ -847,7 +850,7 @@ SwarmVariablePack<T> MakeSwarmPack(const vpack_types::SwarmVarList<T> &vars,
   }
 
   // make the outer view
-  ViewOfParArrays1D<T> cv("MakePack::cv", vsize);
+  ViewOfParArrays1D<T> cv(ViewOfViewAlloc("MakePack::cv"), vsize);
 
   std::array<int, 2> cv_size{0, 0};
   if (vsize > 0) {

--- a/src/interface/variable_pack.hpp
+++ b/src/interface/variable_pack.hpp
@@ -244,11 +244,10 @@ class PackIndexMap {
 };
 
 template <typename T>
-using ViewOfParArrays =
-    Kokkos::View<ParArray3D<T, VariableState> *, LayoutWrapper, DevMemSpace>;
+using ViewOfParArrays = ParArray1DRaw<ParArray3D<T, VariableState>>;
 
 template <typename T>
-using ViewOfParArrays1D = Kokkos::View<ParArray1D<T> *, LayoutWrapper, DevMemSpace>;
+using ViewOfParArrays1D = ParArray1DRaw<ParArray1D<T>>;
 
 // forward declaration
 template <typename T>
@@ -571,8 +570,7 @@ void FillVarView(const VariableVector<T> &vars, int vsize, bool coarse,
   assert(vsize == sparse_id_out.size());
   assert(vsize == vector_component_out.size());
 
-  auto host_cv =
-      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), cv_out);
+  auto host_cv = create_view_of_view_mirror(cv_out);
   auto host_sp = Kokkos::create_mirror_view(sparse_id_out);
   auto host_vc = Kokkos::create_mirror_view(vector_component_out);
   auto host_al = Kokkos::create_mirror_view(allocated_out);
@@ -636,8 +634,7 @@ void FillSwarmVarView(const vpack_types::SwarmVarList<T> &vars,
                       ViewOfParArrays1D<T> &cv_out, PackIndexMap *pvmap) {
   using vpack_types::IndexPair;
 
-  auto host_cv =
-      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), cv_out);
+  auto host_cv = create_view_of_view_mirror(cv_out);
 
   int vindex = 0;
   for (const auto v : vars) {
@@ -678,12 +675,9 @@ void FillFluxViews(const VariableVector<T> &vars, const int ndim,
                    PackIndexMap *pvmap) {
   using vpack_types::IndexPair;
 
-  auto host_f1 =
-      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), f1_out);
-  auto host_f2 =
-      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), f2_out);
-  auto host_f3 =
-      Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), f3_out);
+  auto host_f1 = create_view_of_view_mirror(f1_out);
+  auto host_f2 = create_view_of_view_mirror(f2_out);
+  auto host_f3 = create_view_of_view_mirror(f3_out);
   auto host_al = Kokkos::create_mirror_view(flux_allocated_out);
 
   int vindex = 0;

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -1035,6 +1035,19 @@ par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int il, cons
       reduction);
 }
 
+// For ViewOfView we need to call the destructor of the inner views on
+// the host and not on the device (which would happen by default).
+// Thus, we need to pass `SquentialHostInit` as allocator, but only if the ViewOfView is
+// on the host. If the ViewOfViews in on the device, then `SequentialHostInit` should be
+// passed when calling `create_mirror_view`.
+auto ViewOfViewAlloc(const std::string &label) {
+  if constexpr (std::is_same_v<DevMemSpace, HostMemSpace>) {
+    return Kokkos::view_alloc(Kokkos::SequentialHostInit, label);
+  } else {
+    return Kokkos::view_alloc(label);
+  }
+}
+
 // reused from kokoks/core/perf_test/PerfTest_ExecSpacePartitioning.cpp
 // commit a0d011fb30022362c61b3bb000ae3de6906cb6a7
 template <class ExecSpace>

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -72,30 +72,45 @@ using BufArray1D = Kokkos::View<T *, LayoutWrapper, BufMemSpace>;
 template <typename T>
 using buf_pool_t = ObjectPool<BufArray1D<T>>;
 
+// Raw ParArrays (that directly map a view)
+template <typename T>
+using ParArray0DRaw = Kokkos::View<T, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray1DRaw = Kokkos::View<T *, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray2DRaw = Kokkos::View<T **, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray3DRaw = Kokkos::View<T ***, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray4DRaw = Kokkos::View<T ****, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray5DRaw = Kokkos::View<T *****, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray6DRaw = Kokkos::View<T ******, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray7DRaw = Kokkos::View<T *******, LayoutWrapper, DevMemSpace>;
+template <typename T>
+using ParArray8DRaw = Kokkos::View<T ********, LayoutWrapper, DevMemSpace>;
+
+//  Standard ParArrays that wrap a raw view and a Stage
 template <typename T, typename State = empty_state_t>
-using ParArray0D = ParArrayGeneric<Kokkos::View<T, LayoutWrapper, DevMemSpace>, State>;
+using ParArray0D = ParArrayGeneric<ParArray0DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray1D = ParArrayGeneric<Kokkos::View<T *, LayoutWrapper, DevMemSpace>, State>;
+using ParArray1D = ParArrayGeneric<ParArray1DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray2D = ParArrayGeneric<Kokkos::View<T **, LayoutWrapper, DevMemSpace>, State>;
+using ParArray2D = ParArrayGeneric<ParArray2DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray3D =
-    ParArrayGeneric<Kokkos::View<T ***, LayoutWrapper, DevMemSpace>, State>;
+using ParArray3D = ParArrayGeneric<ParArray3DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray4D =
-    ParArrayGeneric<Kokkos::View<T ****, LayoutWrapper, DevMemSpace>, State>;
+using ParArray4D = ParArrayGeneric<ParArray4DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray5D =
-    ParArrayGeneric<Kokkos::View<T *****, LayoutWrapper, DevMemSpace>, State>;
+using ParArray5D = ParArrayGeneric<ParArray5DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray6D =
-    ParArrayGeneric<Kokkos::View<T ******, LayoutWrapper, DevMemSpace>, State>;
+using ParArray6D = ParArrayGeneric<ParArray6DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray7D =
-    ParArrayGeneric<Kokkos::View<T *******, LayoutWrapper, DevMemSpace>, State>;
+using ParArray7D = ParArrayGeneric<ParArray7DRaw<T>, State>;
 template <typename T, typename State = empty_state_t>
-using ParArray8D =
-    ParArrayGeneric<Kokkos::View<T ********, LayoutWrapper, DevMemSpace>, State>;
+using ParArray8D = ParArrayGeneric<ParArray8DRaw<T>, State>;
 
 // Host mirrors
 template <typename T>
@@ -1039,7 +1054,8 @@ par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int il, cons
 // the host and not on the device (which would happen by default).
 // Thus, we need to pass `SquentialHostInit` as allocator, but only if the ViewOfView is
 // on the host. If the ViewOfViews in on the device, then `SequentialHostInit` should be
-// passed when calling `create_mirror_view`.
+// passed when calling `create_mirror_view`, which is automatically handled by the
+// create_view_of_view_mirror() function below.
 template <typename T = DevMemSpace>
 auto ViewOfViewAlloc(const std::string &label) {
   if constexpr (std::is_same_v<T, HostMemSpace>) {
@@ -1047,6 +1063,13 @@ auto ViewOfViewAlloc(const std::string &label) {
   } else {
     return Kokkos::view_alloc(label);
   }
+}
+
+// Returns a host mirror view with the `SequentialHostInit` property for proper
+// deallocations of inner views in views of views.
+template <typename T>
+auto create_view_of_view_mirror(T view) {
+  return Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), view);
 }
 
 // reused from kokoks/core/perf_test/PerfTest_ExecSpacePartitioning.cpp

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -1040,8 +1040,9 @@ par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int il, cons
 // Thus, we need to pass `SquentialHostInit` as allocator, but only if the ViewOfView is
 // on the host. If the ViewOfViews in on the device, then `SequentialHostInit` should be
 // passed when calling `create_mirror_view`.
+template <typename T = DevMemSpace>
 auto ViewOfViewAlloc(const std::string &label) {
-  if constexpr (std::is_same_v<DevMemSpace, HostMemSpace>) {
+  if constexpr (std::is_same_v<T, HostMemSpace>) {
     return Kokkos::view_alloc(Kokkos::SequentialHostInit, label);
   } else {
     return Kokkos::view_alloc(label);

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -38,8 +38,7 @@ class MeshBlockPack {
   using pack_type = T;
 
   MeshBlockPack() = default;
-  MeshBlockPack(const Kokkos::View<T *, LayoutWrapper, DevMemSpace> view,
-                const std::array<int, 5> dims)
+  MeshBlockPack(const ParArray1DRaw<T> view, const std::array<int, 5> dims)
       : v_(view), dims_(dims), ndim_((dims[2] > 1 ? 3 : (dims[1] > 1 ? 2 : 1))) {}
 
   KOKKOS_FORCEINLINE_FUNCTION
@@ -86,7 +85,7 @@ class MeshBlockPack {
   const Coordinates_t &GetCoords(const int i) const { return v_(i).GetCoords(); }
 
  private:
-  Kokkos::View<T *, LayoutWrapper, DevMemSpace> v_;
+  ParArray1DRaw<T> v_;
   std::array<int, 5> dims_;
   int ndim_;
 };

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -21,6 +21,7 @@
 #include <utility>
 #include <vector>
 
+#include "Kokkos_Core_fwd.hpp"
 #include "coordinates/coordinates.hpp"
 #include "interface/variable_pack.hpp"
 #include "kokkos_abstraction.hpp"
@@ -38,7 +39,8 @@ class MeshBlockPack {
   using pack_type = T;
 
   MeshBlockPack() = default;
-  MeshBlockPack(const ParArray1D<T> view, const std::array<int, 5> dims)
+  MeshBlockPack(const Kokkos::View<T *, LayoutWrapper, DevMemSpace> view,
+                const std::array<int, 5> dims)
       : v_(view), dims_(dims), ndim_((dims[2] > 1 ? 3 : (dims[1] > 1 ? 2 : 1))) {}
 
   KOKKOS_FORCEINLINE_FUNCTION
@@ -85,7 +87,7 @@ class MeshBlockPack {
   const Coordinates_t &GetCoords(const int i) const { return v_(i).GetCoords(); }
 
  private:
-  ParArray1D<T> v_;
+  Kokkos::View<T *, LayoutWrapper, DevMemSpace> v_;
   std::array<int, 5> dims_;
   int ndim_;
 };

--- a/src/mesh/meshblock_pack.hpp
+++ b/src/mesh/meshblock_pack.hpp
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 
-#include "Kokkos_Core_fwd.hpp"
 #include "coordinates/coordinates.hpp"
 #include "interface/variable_pack.hpp"
 #include "kokkos_abstraction.hpp"

--- a/src/parthenon_array_generic.hpp
+++ b/src/parthenon_array_generic.hpp
@@ -221,6 +221,8 @@ class ParArrayGeneric : public State {
     // return GetDim(1) * GetDim(2) * GetDim(3) * GetDim(4) * GetDim(5) * GetDim(6);
   }
 
+  // TODO(PG?) Can we use concepts here to add a
+  // Kokkos::view_alloc(Kokkos::SequentialHostInit) when the original is a ViewOfView?
   template <typename MemSpace>
   auto GetMirror(MemSpace const &memspace) {
     auto mirror = Kokkos::create_mirror_view(memspace, data_);
@@ -333,6 +335,8 @@ inline auto subview(std::index_sequence<I...>,
   return parthenon::ParArrayGeneric<decltype(v), SU>(v, arr);
 }
 
+// TODO(PG?) Can we use concepts here to add a
+// Kokkos::view_alloc(Kokkos::SequentialHostInit) when the original is a ViewOfView?
 template <class Space, class U, class SU>
 inline auto create_mirror_view_and_copy(Space const &space,
                                         const parthenon::ParArrayGeneric<U, SU> &arr) {

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -451,7 +451,7 @@ TEST_CASE("ParArray state", "[ParArrayND]") {
   }
 
   GIVEN("An array of ParArrays filled with the values contained in their state") {
-    parthenon::ParArray1D<arr3d_t> pack("test pack", NS);
+    Kokkos::View<arr3d_t *> pack(parthenon::ViewOfViewAlloc("test pack"), NS);
     auto pack_h =
         Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), pack);
 

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -452,7 +452,8 @@ TEST_CASE("ParArray state", "[ParArrayND]") {
 
   GIVEN("An array of ParArrays filled with the values contained in their state") {
     parthenon::ParArray1D<arr3d_t> pack("test pack", NS);
-    auto pack_h = Kokkos::create_mirror_view(pack);
+    auto pack_h =
+        Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), pack);
 
     for (int b = 0; b < NS; ++b) {
       state_t state(static_cast<double>(b));
@@ -544,7 +545,8 @@ TEST_CASE("Check registry pressure", "[ParArrayND][performance]") {
     new (&views[n])
         view_3d_t(Kokkos::view_alloc(label, Kokkos::WithoutInitializing), N, N, N);
     auto a_h = arrays(n).GetHostMirror();
-    auto v_h = Kokkos::create_mirror_view(views(n));
+    auto v_h = Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit),
+                                          views(n));
     for (int k = 0; k < N; k++) {
       for (int j = 0; j < N; j++) {
         for (int i = 0; i < N; i++) {

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -451,9 +451,8 @@ TEST_CASE("ParArray state", "[ParArrayND]") {
   }
 
   GIVEN("An array of ParArrays filled with the values contained in their state") {
-    Kokkos::View<arr3d_t *> pack(parthenon::ViewOfViewAlloc("test pack"), NS);
-    auto pack_h =
-        Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit), pack);
+    parthenon::ParArray1DRaw<arr3d_t> pack(parthenon::ViewOfViewAlloc("test pack"), NS);
+    auto pack_h = create_view_of_view_mirror(pack);
 
     for (int b = 0; b < NS; ++b) {
       state_t state(static_cast<double>(b));
@@ -547,8 +546,7 @@ TEST_CASE("Check registry pressure", "[ParArrayND][performance]") {
     new (&views[n])
         view_3d_t(Kokkos::view_alloc(label, Kokkos::WithoutInitializing), N, N, N);
     auto a_h = arrays(n).GetHostMirror();
-    auto v_h = Kokkos::create_mirror_view(Kokkos::view_alloc(Kokkos::SequentialHostInit),
-                                          views(n));
+    auto v_h = parthenon::create_view_of_view_mirror(views(n));
     for (int k = 0; k < N; k++) {
       for (int j = 0; j < N; j++) {
         for (int i = 0; i < N; i++) {

--- a/tst/unit/test_pararrays.cpp
+++ b/tst/unit/test_pararrays.cpp
@@ -528,6 +528,8 @@ TEST_CASE("Check registry pressure", "[ParArrayND][performance]") {
 
   // view of views. See:
   // https://github.com/kokkos/kokkos/wiki/View#6232-whats-the-problem-with-a-view-of-views
+  // TODO(PG) depending on the results of the view of view discussion, we should add
+  // destructor or ViewOfViewAlloc with SequentialHostInit
   using view_3d_t =
       Kokkos::View<Real ***, parthenon::LayoutWrapper, parthenon::DevMemSpace>;
   using arrays_t = Kokkos::View<parthenon::ParArray6D<Real> *, UVMSpace>;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Bumps Kokkos to 4.4.1.

This revealed some memory leaks in our view of view (because we never deallocate/destruct the inner views).
This PR fixes this by using the `SequentialHostInit` property that was introduced in 4.4.1 for the outer view allocation.
With this property the destructors of the inner views are called plainly on the host (rather than inside a parallel region, which is illegal in the Kokkos programming model).
Moreover, this required different logic as our view of view are on device (so we need to take special care when to pass `SequentialHostInit` because it cannot be passed to a device outer view).
Thus we only pass `SequentialHostInit` in the outer view allocation when compiling for a host execution space (because mirror views are noops then) and only pass `SequentialHostInit` for the outer view host *mirror*, when compiling on device.

Given that our ParArray#D interface did not allow to parse arbitrary allocation properties in the ctor, I decided to switch the outer views to plain Kokkos::Views (without `state` info) over changing the ctor interface of the ParArray#D to also parse allocation properties (to keep the interface small/clean).

It's probably worth to double check if any of the outer views need a `state` (but I don't think so because the code compiles fine).

Additional details/discussion also https://github.com/parthenon-hpc-lab/parthenon/issues/1205 and https://github.com/parthenon-hpc-lab/parthenon/issues/1193

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
