### PR TITLE
WIP: Entirely flattened SetBounds

### DIFF
--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -316,14 +316,20 @@ TaskStatus SetBounds(std::shared_ptr<MeshData<Real>> &md) {
                         bnd_info(b).idxer[it].template StartIdx<1>() + 1) *
                         (bnd_info(b).idxer[it].template EndIdx<2>() -
                         bnd_info(b).idxer[it].template StartIdx<2>() + 1);
+          const int Nidx = (bnd_info(b).idxer[it].template EndIdx<3>() -
+                        bnd_info(b).idxer[it].template StartIdx<3>() + 1) *
+                        (bnd_info(b).idxer[it].template EndIdx<4>() -
+                        bnd_info(b).idxer[it].template StartIdx<4>() + 1) *
+                        (bnd_info(b).idxer[it].template EndIdx<5>() -
+                        bnd_info(b).idxer[it].template StartIdx<5>() + 1);
           if (el >= Nel) return;
           const int Ni = idxer.template EndIdx<5>() - idxer.template StartIdx<5>() + 1;
           if (bnd_info(b).buf_allocated && bnd_info(b).allocated) {
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange<>(team_member, idxer.size() / Nel / Ni),
                 [&](const int idx) {
-                  Real *buf = &bnd_info(b).buf((idx + el) * Ni + idx_offset);
-                  const auto [t, u, v, k, j, i] = idxer((idx + el) * Ni);
+                  Real *buf = &bnd_info(b).buf(el * Nidx + idx * Ni + idx_offset);
+                  const auto [t, u, v, k, j, i] = idxer(el * Nidx + idx * Ni);
                   // Have to do this because of some weird issue about structure bindings
                   // being captured
                   const int tt = t;
@@ -345,7 +351,7 @@ TaskStatus SetBounds(std::shared_ptr<MeshData<Real>> &md) {
             Kokkos::parallel_for(
                 Kokkos::TeamThreadRange<>(team_member, idxer.size() / Nel / Ni),
                 [&](const int idx) {
-                  const auto [t, u, v, k, j, i] = idxer(idx * Ni);
+                  const auto [t, u, v, k, j, i] = idxer(el * Nidx + idx * Ni);
                   const int tt = t;
                   const int uu = u;
                   const int vv = v;


### PR DESCRIPTION
We now have plenty of info on device to just launch a single flat kernel over all boundaries and all possible indices, and deal with what does or does not exist entirely per-thread.  This tries that.  It seems fast but also doesn't pass all tests, maybe it's not doing all the work...

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
