### PR TITLE
[Trivial] Silence compiler warning 

### DIFF
--- a/src/utils/hash.hpp
+++ b/src/utils/hash.hpp
@@ -31,9 +31,8 @@ std::size_t hash_combine(std::size_t lhs, const T &v, Rest &&...rest) {
   lhs ^= rhs + 0x9e3779b9 + (lhs << 6) + (lhs >> 2);
   if constexpr (sizeof...(Rest) > 0) {
     return hash_combine(lhs, std::forward<Rest>(rest)...);
-  } else {
-    return lhs;
   }
+  return lhs;
 }
 
 template <class Tup, std::size_t I = std::tuple_size<Tup>::value - 1>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This situation:

```c++
T func() {
  if constexpr(...) {
    return ...;
  } else {
    return ...;
  }
}
```
throws a compiler warning ` warning: missing return statement at end of non-void function` for some compilers. This snuck in with #1173 . 

This PR fixes the one instance of this happening. 
 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
