### PR TITLE
Ordered history output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR 1161]](https://github.com/parthenon-hpc-lab/parthenon/pull/1161) Make flux field Metadata accessible, add Metadata::CellMemAligned flag, small perfomance upgrades
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 1209]](https://github.com/parthenon-hpc-lab/parthenon/pull/1209) Ordered history output
 - [[PR 1206]](https://github.com/parthenon-hpc-lab/parthenon/pull/1206) Leapfrog fix
 - [[PR1203]](https://github.com/parthenon-hpc-lab/parthenon/pull/1203) Pin Ubuntu CI image
 - [[PR1177]](https://github.com/parthenon-hpc-lab/parthenon/pull/1177) Make mesh-level boundary conditions usable without the "user" flag

--- a/doc/sphinx/src/outputs.rst
+++ b/doc/sphinx/src/outputs.rst
@@ -194,7 +194,9 @@ block might look like
 
 This will produce a text file (``.hst``) output file every 1 units of
 simulation time. The content of the file is determined by the functions
-enrolled by specific packages, see :ref:`state history output`.
+enrolled by specific packages, see :ref:`state history output`. Per-package history
+outputs will always be in alphabetical order by package name, which may not match
+the order in which packages were added to a simulation.
 
 Histograms
 ----------

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -95,8 +95,8 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
 
   // Loop over all packages of the application in alphabetical order
   std::vector<std::string> keys;
-  for (const auto& pair : packages) {
-        keys.push_back(pair.first);
+  for (const auto &pair : packages) {
+    keys.push_back(pair.first);
   }
   std::sort(keys.begin(), keys.end());
   for (const auto &key : keys) {

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -101,7 +101,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
   std::sort(keys.begin(), keys.end());
   for (const auto &key : keys) {
     const auto &pkg = packages[key];
-    const auto &params = pkg.second->AllParams();
+    const auto &params = pkg->AllParams();
 
     // Check if the package has enrolled scalar history functions which are stored in the
     // Params under the `hist_param_key` name.

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -93,7 +93,8 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     md_base->Initialize(pm->block_list, pm);
   }
 
-  // Loop over all packages of the application in alphabetical order
+  // Loop over all packages of the application in alphabetical order to ensure consistency
+  // of ordering of data in columns.
   std::vector<std::string> keys;
   for (const auto &pair : packages) {
     keys.push_back(pair.first);

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -18,6 +18,7 @@
 //  \brief writes history output data, volume-averaged quantities that are output
 //         frequently in time to trace their history.
 
+#include <algorithm>
 #include <cstdio>
 #include <cstdlib>
 #include <iomanip>

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -93,8 +93,14 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
     md_base->Initialize(pm->block_list, pm);
   }
 
-  // Loop over all packages of the application
-  for (const auto &pkg : packages) {
+  // Loop over all packages of the application in alphabetical order
+  std::vector<std::string> keys;
+  for (const auto& pair : packages) {
+        keys.push_back(pair.first);
+  }
+  std::sort(keys.begin(), keys.end());
+  for (const auto &key : keys) {
+    const auto &pkg = packages[key];
     const auto &params = pkg.second->AllParams();
 
     // Check if the package has enrolled scalar history functions which are stored in the


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

When populating history outputs, we index through a `Dictionary` of packages, which is an unordered map, and so the order in which we retrieve the packages isn't guaranteed. We've seen this cause inconsistencies in history outputs between platforms, and a more significant concern is that the order of the numbers in a history output could change between simulation runs. 

This is a simple fix that just always creates history outputs in alphabetical order of the name of the packages. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
