### PR TITLE
Fix for hidden characters in the input file

### DIFF
--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -137,7 +137,6 @@ void ParameterInput::LoadFromStream(std::istream &is) {
     if (first_char == std::string::npos) continue;            // line is all white space
     if (line.compare(first_char, 1, "#") == 0) continue;      // skip comments
     if (line.compare(first_char, 9, "<par_end>") == 0) break; // stop on <par_end>
- 
 
     if (line.compare(first_char, 1, "<") == 0) { // a new block
       if (continuing) {
@@ -200,12 +199,9 @@ void ParameterInput::LoadFromStream(std::istream &is) {
       // Set new state
       continuing = false;
     }
-    
 
     if (!continuing) {
       if (param_name != "") {
-
-
         AddParameter(pib, param_name, param_value, param_comment);
       }
     }

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -126,17 +126,18 @@ void ParameterInput::LoadFromStream(std::istream &is) {
   while (is.good()) {
     std::getline(is, line);
     line_num++;
-    if (line.find('\t') != std::string::npos) {
-      line.erase(std::remove(line.begin(), line.end(), '\t'), line.end());
-      // msg << "### FATAL ERROR in function [ParameterInput::LoadFromStream]"
-      //     << std::endl << "Tab characters are forbidden in input files";
-      // PARTHENON_FAIL(msg);
-    }
+
+    // remove all \t\f\n\r\v but leave pure spaces
+    line.erase(std::remove_if(line.begin(), line.end(), 
+                           [](char c) { return std::isspace(c) && c != ' '; }), 
+           line.end());
+
     if (line.empty()) continue;                               // skip blank line
     first_char = line.find_first_not_of(" ");                 // skip white space
     if (first_char == std::string::npos) continue;            // line is all white space
     if (line.compare(first_char, 1, "#") == 0) continue;      // skip comments
     if (line.compare(first_char, 9, "<par_end>") == 0) break; // stop on <par_end>
+ 
 
     if (line.compare(first_char, 1, "<") == 0) { // a new block
       if (continuing) {
@@ -199,9 +200,12 @@ void ParameterInput::LoadFromStream(std::istream &is) {
       // Set new state
       continuing = false;
     }
+    
 
     if (!continuing) {
       if (param_name != "") {
+
+
         AddParameter(pib, param_name, param_value, param_comment);
       }
     }

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -128,9 +128,9 @@ void ParameterInput::LoadFromStream(std::istream &is) {
     line_num++;
 
     // remove all \t\f\n\r\v but leave pure spaces
-    line.erase(std::remove_if(line.begin(), line.end(), 
-                           [](char c) { return std::isspace(c) && c != ' '; }), 
-           line.end());
+    line.erase(std::remove_if(line.begin(), line.end(),
+                              [](char c) { return std::isspace(c) && c != ' '; }),
+               line.end());
 
     if (line.empty()) continue;                               // skip blank line
     first_char = line.find_first_not_of(" ");                 // skip white space

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -100,6 +100,32 @@ TEST_CASE("Test required/desired checking from inputs", "[ParameterInput]") {
       REQUIRE_THROWS_AS(in.LoadFromStream(s), std::runtime_error);
     }
   }
+
+ GIVEN("An input deck with hidden characters and weird whitespace") {
+   ParameterInput in;
+   std::stringstream ss;
+   ss << "<block1>" << std::endl
+      << "  var1 = 0   # comment\r" << std::endl
+      << "\tvar2 = 1,  \t& # another comment\n\r" << std::endl
+      << "\t\t       2" << std::endl
+      << "<block2>" << std::endl
+      << " var3 = myval\r" << std::endl;
+
+   std::istringstream s(ss.str());
+   in.LoadFromStream(s);
+
+   WHEN("We read the parameters") {
+     THEN("They should be read correctly") {
+       REQUIRE(in.GetInteger("block1", "var1") == 0); 
+       auto var2 = in.GetVector<int>("block1", "var2");
+       REQUIRE(var2.size() == 2 );
+       if (var2.size() == 2) { // to guard against a segfault
+         REQUIRE( ((var2[0] == 1) && ( var2[1] == 2)));
+       }
+       REQUIRE( in.GetString("block2","var3") == "myval");
+     }
+   }
+ }
 }
 
 TEST_CASE("Parameter inputs can be hashed and hashing provides useful sanity checks",

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -101,31 +101,31 @@ TEST_CASE("Test required/desired checking from inputs", "[ParameterInput]") {
     }
   }
 
- GIVEN("An input deck with hidden characters and weird whitespace") {
-   ParameterInput in;
-   std::stringstream ss;
-   ss << "<block1>" << std::endl
-      << "  var1 = 0   # comment\r" << std::endl
-      << "\tvar2 = 1,  \t& # another comment\n\r" << std::endl
-      << "\t\t       2" << std::endl
-      << "<block2>" << std::endl
-      << " var3 = myval\r" << std::endl;
+  GIVEN("An input deck with hidden characters and weird whitespace") {
+    ParameterInput in;
+    std::stringstream ss;
+    ss << "<block1>" << std::endl
+       << "  var1 = 0   # comment\r" << std::endl
+       << "\tvar2 = 1,  \t& # another comment\n\r" << std::endl
+       << "\t\t       2" << std::endl
+       << "<block2>" << std::endl
+       << " var3 = myval\r" << std::endl;
 
-   std::istringstream s(ss.str());
-   in.LoadFromStream(s);
+    std::istringstream s(ss.str());
+    in.LoadFromStream(s);
 
-   WHEN("We read the parameters") {
-     THEN("They should be read correctly") {
-       REQUIRE(in.GetInteger("block1", "var1") == 0); 
-       auto var2 = in.GetVector<int>("block1", "var2");
-       REQUIRE(var2.size() == 2 );
-       if (var2.size() == 2) { // to guard against a segfault
-         REQUIRE( ((var2[0] == 1) && ( var2[1] == 2)));
-       }
-       REQUIRE( in.GetString("block2","var3") == "myval");
-     }
-   }
- }
+    WHEN("We read the parameters") {
+      THEN("They should be read correctly") {
+        REQUIRE(in.GetInteger("block1", "var1") == 0);
+        auto var2 = in.GetVector<int>("block1", "var2");
+        REQUIRE(var2.size() == 2);
+        if (var2.size() == 2) { // to guard against a segfault
+          REQUIRE(((var2[0] == 1) && (var2[1] == 2)));
+        }
+        REQUIRE(in.GetString("block2", "var3") == "myval");
+      }
+    }
+  }
 }
 
 TEST_CASE("Parameter inputs can be hashed and hashing provides useful sanity checks",


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

An artemis user found that this
```
<parthenon/mesh>
refinement = static\r
```
was parsed incorrectly (after spending half a day to find the hidden `\r` character). 

This PR does two things:

- Adds a new unit test that exposes this bug
- Adds a fix which strips out all the nasty characters `\t\r\f\v\n` immediately after reading a line in the input file.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
