### PR TITLE
generalize MPI_SIZE_T to work on 32 bit architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1229]](https://github.com/parthenon-hpc-lab/parthenon/pull/1229) Ensure builds function on 32 bit architectures
 - [[PR 1217]](https://github.com/parthenon-hpc-lab/parthenon/pull/1217) Swarm comm debug fix
 - [[PR 1215]](https://github.com/parthenon-hpc-lab/parthenon/pull/1215) Fix issue with uninitialized input parameter block data
 - [[PR 1211]](https://github.com/parthenon-hpc-lab/parthenon/pull/1211) remove inline from WriteTaskGraph

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -47,7 +47,7 @@ namespace parthenon {
 
 #define NMAX_NEIGHBORS 56
 
-constexpr bool ARCHITECTURE_64_BIT = (sizeof(void *) == 8);
+constexpr bool ARCHITECTURE_64_BIT = (sizeof(std::uintptr_t) == 8);
 #ifdef MPI_PARALLEL
 constexpr MPI_Datatype MPI_SIZE_T =
     ARCHITECTURE_64_BIT ? MPI_UNSIGNED_LONG_LONG : MPI_UNSIGNED_LONG;

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -22,6 +22,7 @@
 #include <array>
 #include <cmath>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <string>
 
@@ -47,13 +48,11 @@ namespace parthenon {
 
 #define NMAX_NEIGHBORS 56
 
-// JMM: Many alternative implementations here. For example
-// constexpr bool ARCHITECTURE_64_BIT = (sizeof(void*) == 8);
-// I chose one that seemed reasonable and legible.
-constexpr bool ARCHITECTURE_64_BIT = (INTPTR_MAX == INT64_MAX);
+// JMM: This is shockingly difficult to do robustly at compile
+// time. Rather than rely on pre-processor architecture flags, I gave
+// up and switched this to a runtime check.
+const bool ARCHITECTURE_64_BIT = (sizeof(void *) == 8);
 #ifdef MPI_PARALLEL
-// JMM: clang (and only clang) will not init this as a constexpr
-// expression. I don't know why.
 const MPI_Datatype MPI_SIZE_T = ARCHITECTURE_64_BIT ? MPI_UINT64_T : MPI_UINT32_T;
 #endif
 

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -47,8 +47,13 @@ namespace parthenon {
 
 #define NMAX_NEIGHBORS 56
 
+// JMM: Many alternative implementations here. For example
+// constexpr bool ARCHITECTURE_64_BIT = (sizeof(void*) == 8);
+// I chose one that seemed reasonable and legible.
 constexpr bool ARCHITECTURE_64_BIT = (INTPTR_MAX == INT64_MAX);
 #ifdef MPI_PARALLEL
+// JMM: clang (and only clang) will not init this as a constexpr
+// expression. I don't know why.
 const MPI_Datatype MPI_SIZE_T =
     ARCHITECTURE_64_BIT ? MPI_UNSIGNED_LONG_LONG : MPI_UNSIGNED_LONG;
 #endif

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -54,8 +54,7 @@ constexpr bool ARCHITECTURE_64_BIT = (INTPTR_MAX == INT64_MAX);
 #ifdef MPI_PARALLEL
 // JMM: clang (and only clang) will not init this as a constexpr
 // expression. I don't know why.
-const MPI_Datatype MPI_SIZE_T =
-    ARCHITECTURE_64_BIT ? MPI_UNSIGNED_LONG_LONG : MPI_UNSIGNED_LONG;
+const MPI_Datatype MPI_SIZE_T = ARCHITECTURE_64_BIT ? MPI_UINT64_T : MPI_UINT32_T;
 #endif
 
 // forward declarations needed for function pointer type aliases

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -48,12 +48,12 @@ namespace parthenon {
 
 #define NMAX_NEIGHBORS 56
 
-// JMM: This is shockingly difficult to do robustly at compile
-// time. Rather than rely on pre-processor architecture flags, I gave
-// up and switched this to a runtime check.
-const bool ARCHITECTURE_64_BIT = (sizeof(void *) == 8);
+// TODO(JMM): Note this is NOT compile-time. And for whatever reason,
+// the boolean condition can be static_assert checked but cannot be
+// used to set a constexpr var.
 #ifdef MPI_PARALLEL
-const MPI_Datatype MPI_SIZE_T = ARCHITECTURE_64_BIT ? MPI_UINT64_T : MPI_UINT32_T;
+const MPI_Datatype MPI_SIZE_T =
+    (sizeof(std::size_t) == sizeof(std::uint64_t)) ? MPI_UINT64_T : MPI_UINT32_T;
 #endif
 
 // forward declarations needed for function pointer type aliases

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -47,6 +47,12 @@ namespace parthenon {
 
 #define NMAX_NEIGHBORS 56
 
+constexpr bool ARCHITECTURE_64_BIT = (sizeof(void *) == 8);
+#ifdef MPI_PARALLEL
+constexpr MPI_Datatype MPI_SIZE_T =
+    ARCHITECTURE_64_BIT ? MPI_UNSIGNED_LONG_LONG : MPI_UNSIGNED_LONG;
+#endif
+
 // forward declarations needed for function pointer type aliases
 class MeshBlock;
 class ParameterInput;

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -49,7 +49,7 @@ namespace parthenon {
 
 constexpr bool ARCHITECTURE_64_BIT = (INTPTR_MAX == INT64_MAX);
 #ifdef MPI_PARALLEL
-constexpr MPI_Datatype MPI_SIZE_T =
+const MPI_Datatype MPI_SIZE_T =
     ARCHITECTURE_64_BIT ? MPI_UNSIGNED_LONG_LONG : MPI_UNSIGNED_LONG;
 #endif
 

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -47,7 +47,7 @@ namespace parthenon {
 
 #define NMAX_NEIGHBORS 56
 
-constexpr bool ARCHITECTURE_64_BIT = (sizeof(std::uintptr_t) == 8);
+constexpr bool ARCHITECTURE_64_BIT = (INTPTR_MAX == INT64_MAX);
 #ifdef MPI_PARALLEL
 constexpr MPI_Datatype MPI_SIZE_T =
     ARCHITECTURE_64_BIT ? MPI_UNSIGNED_LONG_LONG : MPI_UNSIGNED_LONG;

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -283,7 +283,7 @@ void ComputeCoords(Mesh *pm, bool face, const IndexRange &ib, const IndexRange &
   }
 }
 
-constexpr void CheckMPISizeT() {
+inline void CheckMPISizeT() {
 #ifdef MPI_PARALLEL
   // Need to use sizeof here because unsigned long long and unsigned
   // long are identical under the hood but registered as different
@@ -291,12 +291,12 @@ constexpr void CheckMPISizeT() {
   static_assert(std::is_integral<std::size_t>::value &&
                     !std::is_signed<std::size_t>::value,
                 "size_t is unsigned and integral");
-  if constexpr (parthenon::ARCHITECTURE_64_BIT) {
-    static_assert(sizeof(std::size_t) == sizeof(std::uint64_t), // NOLINT
-                  "MPI_UINT64_T same as size_t");
+  if (parthenon::ARCHITECTURE_64_BIT) {
+    PARTHENON_REQUIRE_THROWS(sizeof(std::size_t) == sizeof(std::uint64_t),
+                             "MPI_UINT64_T same as size_t");
   } else {
-    static_assert(sizeof(std::size_t) == sizeof(std::uint32_t), // NOLINT
-                  "MPI_UINT32_T same as size_t");
+    PARTHENON_REQUIRE_THROWS(sizeof(std::size_t) == sizeof(std::uint32_t),
+                             "MPI_UINT32_T same as size_t");
   }
 #endif
 }

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -283,7 +283,7 @@ void ComputeCoords(Mesh *pm, bool face, const IndexRange &ib, const IndexRange &
   }
 }
 
-inline void CheckMPISizeT() {
+constexpr void CheckMPISizeT() {
 #ifdef MPI_PARALLEL
   // Need to use sizeof here because unsigned long long and unsigned
   // long are identical under the hood but registered as different
@@ -291,13 +291,6 @@ inline void CheckMPISizeT() {
   static_assert(std::is_integral<std::size_t>::value &&
                     !std::is_signed<std::size_t>::value,
                 "size_t is unsigned and integral");
-  if (parthenon::ARCHITECTURE_64_BIT) {
-    PARTHENON_REQUIRE_THROWS(sizeof(std::size_t) == sizeof(std::uint64_t),
-                             "MPI_UINT64_T same as size_t");
-  } else {
-    PARTHENON_REQUIRE_THROWS(sizeof(std::size_t) == sizeof(std::uint32_t),
-                             "MPI_UINT32_T same as size_t");
-  }
 #endif
 }
 

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -285,12 +285,11 @@ void ComputeCoords(Mesh *pm, bool face, const IndexRange &ib, const IndexRange &
 
 constexpr void CheckMPISizeT() {
 #ifdef MPI_PARALLEL
-  // Need to use sizeof here because unsigned long long and unsigned
-  // long are identical under the hood but registered as different
-  // types
   static_assert(std::is_integral<std::size_t>::value &&
                     !std::is_signed<std::size_t>::value,
                 "size_t is unsigned and integral");
+  static_assert((sizeof(void*) == 4) || (sizeof(void*) == 8),
+                "We're on a 32 or 64 bit system.");
 #endif
 }
 

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -292,11 +292,11 @@ constexpr void CheckMPISizeT() {
                     !std::is_signed<std::size_t>::value,
                 "size_t is unsigned and integral");
   if constexpr (parthenon::ARCHITECTURE_64_BIT) {
-    static_assert(sizeof(std::size_t) == sizeof(unsigned long long int), // NOLINT
-                  "MPI_UNSIGNED_LONG_LONG same as size_t");
+    static_assert(sizeof(std::size_t) == sizeof(std::uint64_t), // NOLINT
+                  "MPI_UINT64_T same as size_t");
   } else {
-    static_assert(sizeof(std::size_t) == sizeof(unsigned long int), // NOLINT
-                  "MPI_UNSIGNED_LONG same as size_t");
+    static_assert(sizeof(std::size_t) == sizeof(std::uint32_t), // NOLINT
+                  "MPI_UINT32_T same as size_t");
   }
 #endif
 }

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -1,9 +1,9 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2023-2024 The Parthenon collaboration
+// Copyright(C) 2023-2025 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -288,7 +288,7 @@ constexpr void CheckMPISizeT() {
   static_assert(std::is_integral<std::size_t>::value &&
                     !std::is_signed<std::size_t>::value,
                 "size_t is unsigned and integral");
-  static_assert((sizeof(void*) == 4) || (sizeof(void*) == 8),
+  static_assert((sizeof(void *) == 4) || (sizeof(void *) == 8),
                 "We're on a 32 or 64 bit system.");
 #endif
 }

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -23,6 +23,7 @@
 #include <type_traits>
 #include <vector>
 
+#include "defs.hpp"
 #include "globals.hpp"
 #include "interface/metadata.hpp"
 #include "interface/swarm.hpp"
@@ -290,9 +291,13 @@ constexpr void CheckMPISizeT() {
   static_assert(std::is_integral<std::size_t>::value &&
                     !std::is_signed<std::size_t>::value,
                 "size_t is unsigned and integral");
-  static_assert(sizeof(std::size_t) == sizeof(unsigned long long int), // NOLINT
-                "MPI_UNSIGNED_LONG_LONG same as size_t");
-
+  if constexpr (parthenon::ARCHITECTURE_64_BIT) {
+    static_assert(sizeof(std::size_t) == sizeof(unsigned long long int), // NOLINT
+                  "MPI_UNSIGNED_LONG_LONG same as size_t");
+  } else {
+    static_assert(sizeof(std::size_t) == sizeof(unsigned long int), // NOLINT
+                  "MPI_UNSIGNED_LONG same as size_t");
+  }
 #endif
 }
 
@@ -306,8 +311,7 @@ std::size_t MPIPrefixSum(std::size_t local, std::size_t &tot_count) {
   // types
   CheckMPISizeT();
   std::vector<std::size_t> buffer(Globals::nranks);
-  MPI_Allgather(&local, 1, MPI_UNSIGNED_LONG_LONG, buffer.data(), 1,
-                MPI_UNSIGNED_LONG_LONG, MPI_COMM_WORLD);
+  MPI_Allgather(&local, 1, MPI_SIZE_T, buffer.data(), 1, MPI_SIZE_T, MPI_COMM_WORLD);
   for (int i = 0; i < Globals::my_rank; ++i) {
     out += buffer[i];
   }
@@ -323,8 +327,8 @@ std::size_t MPIPrefixSum(std::size_t local, std::size_t &tot_count) {
 std::size_t MPISum(std::size_t val) {
 #ifdef MPI_PARALLEL
   CheckMPISizeT();
-  PARTHENON_MPI_CHECK(MPI_Allreduce(MPI_IN_PLACE, &val, 1, MPI_UNSIGNED_LONG_LONG,
-                                    MPI_SUM, MPI_COMM_WORLD));
+  PARTHENON_MPI_CHECK(
+      MPI_Allreduce(MPI_IN_PLACE, &val, 1, MPI_SIZE_T, MPI_SUM, MPI_COMM_WORLD));
 #endif
   return val;
 }
@@ -335,8 +339,7 @@ void CheckParameterInputConsistent(ParameterInput *pin) {
 
   std::size_t pin_hash = std::hash<ParameterInput>()(*pin);
   std::size_t pin_hash_root = pin_hash;
-  PARTHENON_MPI_CHECK(
-      MPI_Bcast(&pin_hash_root, 1, MPI_UNSIGNED_LONG_LONG, 0, MPI_COMM_WORLD));
+  PARTHENON_MPI_CHECK(MPI_Bcast(&pin_hash_root, 1, MPI_SIZE_T, 0, MPI_COMM_WORLD));
   PARTHENON_REQUIRE_THROWS(
       pin_hash == pin_hash_root,
       "Parameter input object must be the same on every rank, otherwise I/O may "

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -34,6 +34,7 @@
 
 // Parthenon
 #include "basic_types.hpp"
+#include "defs.hpp"
 #include "interface/metadata.hpp"
 #include "interface/variable.hpp"
 #include "kokkos_abstraction.hpp"
@@ -344,9 +345,6 @@ std::vector<int64_t> ComputeLocs(Mesh *pm);
 std::vector<int> ComputeIDsAndFlags(Mesh *pm);
 std::vector<int> ComputeDerefinementCount(Mesh *pm);
 
-// TODO(JMM): Potentially unsafe if MPI_UNSIGNED_LONG_LONG isn't a size_t
-// however I think it's probably safe to assume we'll be on systems
-// where this is the case?
 // TODO(JMM): If we ever need non-int need to generalize
 std::size_t MPIPrefixSum(std::size_t local, std::size_t &tot_count);
 std::size_t MPISum(std::size_t local);

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -1,9 +1,9 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2023 The Parthenon collaboration
+// Copyright(C) 2023-2025 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Resolves #1226 . When adding robustness to the current MPI parallel HDF5 output infrastructure, I made (and enforced) assumptions that we are on a 64 bit architecture. This MR relaxes that assumption by checking whether or not the architecture is 64 bit and adjusting the MPI datatype corresponding to `std::size_t` appropriately. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
