### PR TITLE
Trivial fix for curvilinear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1230]](https://github.com/parthenon-hpc-lab/parthenon/pull/1230) Add missing using statements in curvilinear coordinates classes
 - [[PR 1217]](https://github.com/parthenon-hpc-lab/parthenon/pull/1217) Swarm comm debug fix
 - [[PR 1215]](https://github.com/parthenon-hpc-lab/parthenon/pull/1215) Fix issue with uninitialized input parameter block data
 - [[PR 1211]](https://github.com/parthenon-hpc-lab/parthenon/pull/1211) remove inline from WriteTaskGraph

--- a/src/coordinates/uniform_cylindrical.hpp
+++ b/src/coordinates/uniform_cylindrical.hpp
@@ -24,12 +24,12 @@ class UniformCylindrical : public UniformCoordinates<UniformCylindrical> {
   using base_t = UniformCoordinates<UniformCylindrical>;
 
  public:
-  using base_t::Xc;
-  using base_t::Dxc;
   using base_t::CellWidth;
+  using base_t::Dxc;
   using base_t::FaceArea;
-  using base_t::Volume;
   using base_t::Scale;
+  using base_t::Volume;
+  using base_t::Xc;
   UniformCylindrical() = default;
   UniformCylindrical(const RegionSize &rs, ParameterInput *pin)
       : UniformCoordinates<UniformCylindrical>(rs, pin) {

--- a/src/coordinates/uniform_cylindrical.hpp
+++ b/src/coordinates/uniform_cylindrical.hpp
@@ -25,6 +25,11 @@ class UniformCylindrical : public UniformCoordinates<UniformCylindrical> {
 
  public:
   using base_t::Xc;
+  using base_t::Dxc;
+  using base_t::CellWidth;
+  using base_t::FaceArea;
+  using base_t::Volume;
+  using base_t::Scale;
   UniformCylindrical() = default;
   UniformCylindrical(const RegionSize &rs, ParameterInput *pin)
       : UniformCoordinates<UniformCylindrical>(rs, pin) {

--- a/src/coordinates/uniform_spherical.hpp
+++ b/src/coordinates/uniform_spherical.hpp
@@ -24,12 +24,12 @@ class UniformSpherical : public UniformCoordinates<UniformSpherical> {
   using base_t = UniformCoordinates<UniformSpherical>;
 
  public:
-  using base_t::Xc;
-  using base_t::Dxc;
   using base_t::CellWidth;
+  using base_t::Dxc;
   using base_t::FaceArea;
-  using base_t::Volume;
   using base_t::Scale;
+  using base_t::Volume;
+  using base_t::Xc;
   UniformSpherical() = default;
   UniformSpherical(const RegionSize &rs, ParameterInput *pin)
       : UniformCoordinates<UniformSpherical>(rs, pin) {

--- a/src/coordinates/uniform_spherical.hpp
+++ b/src/coordinates/uniform_spherical.hpp
@@ -25,6 +25,11 @@ class UniformSpherical : public UniformCoordinates<UniformSpherical> {
 
  public:
   using base_t::Xc;
+  using base_t::Dxc;
+  using base_t::CellWidth;
+  using base_t::FaceArea;
+  using base_t::Volume;
+  using base_t::Scale;
   UniformSpherical() = default;
   UniformSpherical(const RegionSize &rs, ParameterInput *pin)
       : UniformCoordinates<UniformSpherical>(rs, pin) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Not sure how this snuck into the last curvilinear coordinate PR, but I missed a few `using` statements that cause issues when calling base class (`UniformCoordinates`) functions when particular overloads are redefined in the derived classes.  This just adds those `using` statements.

This is so trivial I plan to just pull the trigger ASAP.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
