### PR TITLE
Add support for uint8_t data types in hdf5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1137]](https://github.com/parthenon-hpc-lab/parthenon/pull/1231) Add support for uint8_t parameter types in hdf5 files
 - [[PR 1137]](https://github.com/parthenon-hpc-lab/parthenon/pull/1137) Add spherical and cylindrical coordinate support
 - [[PR 1182]](https://github.com/parthenon-hpc-lab/parthenon/pull/1182) Add a MeshData variant for refinement tagging 
 - [[PR 1210]](https://github.com/parthenon-hpc-lab/parthenon/pull/1210) Add cycle based output

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -90,6 +90,7 @@ void Params::WriteAllToHDF5(const std::string &prefix, const HDF5::H5G &group) c
   WriteToHDF5AllParamsOfTypeOrVec<uint64_t>(prefix, group);
   WriteToHDF5AllParamsOfTypeOrVec<float>(prefix, group);
   WriteToHDF5AllParamsOfTypeOrVec<double>(prefix, group);
+  WriteToHDF5AllParamsOfTypeOrVec<uint8_t>(prefix, group);
 
   // strings
   WriteToHDF5AllParamsOfType<std::string>(prefix, group);
@@ -106,6 +107,7 @@ void Params::ReadFromRestart(const std::string &prefix, const HDF5::H5G &group) 
   ReadFromHDF5AllParamsOfTypeOrVec<uint64_t>(prefix, group);
   ReadFromHDF5AllParamsOfTypeOrVec<float>(prefix, group);
   ReadFromHDF5AllParamsOfTypeOrVec<double>(prefix, group);
+  ReadFromHDF5AllParamsOfTypeOrVec<uint8_t>(prefix, group);
 
   // strings
   ReadFromHDF5AllParamsOfType<std::string>(prefix, group);

--- a/src/outputs/parthenon_hdf5_types.hpp
+++ b/src/outputs/parthenon_hdf5_types.hpp
@@ -115,6 +115,7 @@ static hid_t getHDF5Type(const uint64_t *) { return H5T_NATIVE_UINT64; }
 static hid_t getHDF5Type(const float *) { return H5T_NATIVE_FLOAT; }
 static hid_t getHDF5Type(const double *) { return H5T_NATIVE_DOUBLE; }
 static hid_t getHDF5Type(const char *) { return H5T_NATIVE_CHAR; }
+static hid_t getHDF5Type(const uint8_t *) { return H5T_NATIVE_B8; }
 
 // On MacOS size_t is "unsigned long" and uint64_t is != "unsigned long".
 // Thus, size_t is not captured by the overload above and needs to selectively enabled.

--- a/src/outputs/parthenon_hdf5_types.hpp
+++ b/src/outputs/parthenon_hdf5_types.hpp
@@ -1,6 +1,6 @@
 //========================================================================================
 // Parthenon performance portable AMR framework
-// Copyright(C) 2020-2024 The Parthenon collaboration
+// Copyright(C) 2020-2025 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
 // (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In artemis, we store the contents of a binary file in params and read/write it in restart files. Previously, we've read that into a `std::vector<char>` variable, but we recently ran into a portability error when moving a restart file between two machines that (I think) define `char` differently. A solution to that problem is to use a more portable type like `uint8_t` instead of `char`. This adds support for that type to the hdf5 machinery. 

I've tested this in artemis and it works on read/write of the restart file.  

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
