### PR TITLE
fix cell mem aligned io

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1240]](https://github.com/parthenon-hpc-lab/parthenon/pull/1240) Fix I/O for CellMemAligned variables
 - [[PR 1229]](https://github.com/parthenon-hpc-lab/parthenon/pull/1229) Ensure builds function on 32 bit architectures
 - [[PR 1230]](https://github.com/parthenon-hpc-lab/parthenon/pull/1230) Add missing using statements in curvilinear coordinates classes
 - [[PR 1217]](https://github.com/parthenon-hpc-lab/parthenon/pull/1217) Swarm comm debug fix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ include(cmake/Format.cmake)
 include(cmake/Lint.cmake)
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 25 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 26 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=314dc8312366d81ba33d1fde25812e9a7697b2f529de29e22662df0d458f1c4bc5b5bb4e649888170f66ffec0df1be20a9cf401944531c1c1ad835e26eaad28f"
+  "SHA512=c3f3a2da823a7e65a5800c902d26b3891f0a129812031ceae46e5c394f9c5bea36e26f645007422dca46dfdc7c446271c1ff5c0cec851bc40a186aa874beb643"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ include(cmake/Lint.cmake)
 # regression test reference data
 set(REGRESSION_GOLD_STANDARD_VER 26 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=c3f3a2da823a7e65a5800c902d26b3891f0a129812031ceae46e5c394f9c5bea36e26f645007422dca46dfdc7c446271c1ff5c0cec851bc40a186aa874beb643"
+  "SHA512=4c61a0b78a0d68c3175e506d9fc5bc46ec6e91009413125c358801e230f4d882daf0c4cff6a3017f134d7289471a93f677956c2865dd3253264a15ae96b664b6"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -1,5 +1,5 @@
 # =========================================================================================
-# (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -66,6 +66,10 @@ parser.add_argument(
     help="Tensor components of field to plot. Mutally exclusive with --vector-component.",
 )
 parser.add_argument(
+    "--colorbar", type=str, default=None, help="Add a colorbar with the specified label"
+)
+parser.add_argument("--colormap", type=str, default="plasma", help="Colormap to use")
+parser.add_argument(
     "--swarm",
     type=str,
     default=None,
@@ -195,6 +199,8 @@ def plot_dump(
     q,
     time_title,
     output_file: Path,
+    colormap="viridis",
+    colorbar=None,
     with_mesh=False,
     block_ids=[],
     xi=None,
@@ -247,7 +253,9 @@ def plot_dump(
     for i in range(n_blocks):
         # Plot the actual data, should work if parthenon/output*/ghost_zones = true/false
         # but obviously no ghost data will be shown if ghost_zones = false
-        p.pcolormesh(xf[i, :], yf[i, :], q[i, :, :], vmin=qmin, vmax=qmax)
+        pm = p.pcolormesh(
+            xf[i, :], yf[i, :], q[i, :, :], cmap=colormap, vmin=qmin, vmax=qmax
+        )
 
         # Print the block gid in the center of the block
         if len(block_ids) > 0:
@@ -286,6 +294,8 @@ def plot_dump(
                 p.add_patch(rect)
     if swarmx is not None and swarmy is not None:
         p.scatter(swarmx, swarmy, s=particlesize, c=swarmcolor)
+    if colorbar is not None:
+        plt.colorbar(pm, fraction=0.02, pad=0.04, ax=p)
 
     fig.savefig(output_file, dpi=300)
     plt.close(fig=fig)
@@ -331,7 +341,6 @@ if __name__ == "__main__":
                 ERROR_FLAG = True
                 break
             q = data.Get(args.field, False, not args.debug_plot)
-
             if do_swarm:
                 if args.swarm not in data.Variables:
                     report_find_fail(args.swarm, file_name, data.Variables, logger)
@@ -399,6 +408,8 @@ if __name__ == "__main__":
                         q,
                         current_time,
                         output_file,
+                        args.colormap,
+                        args.colorbar,
                         True,
                         data.gid,
                         data.xig,
@@ -421,6 +432,8 @@ if __name__ == "__main__":
                         q,
                         current_time,
                         output_file,
+                        args.colormap,
+                        args.colorbar,
                         True,
                         components=components,
                         swarmx=swarmx,

--- a/src/mesh/domain.hpp
+++ b/src/mesh/domain.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/mesh/domain.hpp
+++ b/src/mesh/domain.hpp
@@ -74,6 +74,11 @@ enum class IndexDomain {
   inner_x3,
   outer_x3
 };
+KOKKOS_FORCEINLINE_FUNCTION
+bool DomainTouchesOuterGhosts(const IndexDomain domain) {
+  return (domain == IndexDomain::entire) || (domain == IndexDomain::outer_x1) ||
+         (domain == IndexDomain::outer_x2) || (domain == IndexDomain::outer_x3);
+}
 
 //! \class IndexVolume
 //  \brief Defines the dimensions of a shape of indices

--- a/src/outputs/output_utils.cpp
+++ b/src/outputs/output_utils.cpp
@@ -47,6 +47,11 @@ Triple_t<int> VarInfo::GetNumKJI(const IndexDomain domain) const {
     nx2 = std::max(nx2, cellbounds.ncellsj(domain, el));
     nx1 = std::max(nx1, cellbounds.ncellsi(domain, el));
   }
+  if (is_mem_aligned && DomainTouchesOuterGhosts(domain)) {
+    nx1 -= 1;
+    if (nx2 > 1) nx2 -= 1;
+    if (nx3 > 1) nx3 -= 1;
+  }
   return std::make_tuple(nx3, nx2, nx1);
 }
 
@@ -64,6 +69,11 @@ Triple_t<IndexRange> VarInfo::GetPaddedBoundsKJI(const IndexDomain domain) const
     ke = std::max(ke, kb.e);
     je = std::max(je, jb.e);
     ie = std::max(ie, ib.e);
+  }
+  if (is_mem_aligned && DomainTouchesOuterGhosts(domain)) {
+    ie -= 1;
+    if (je > 0) je -= 1;
+    if (ke > 0) ke -= 1;
   }
   IndexRange kb{ks, ke}, jb{js, je}, ib{is, ie};
   return std::make_tuple(kb, jb, ib);

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -57,6 +57,7 @@ struct VarInfo {
   int tensor_rank; // 0- to 3-D for cell-centered variables, 0- to 6-D for arbitrary shape
                    // variables
   MetadataFlag where;
+  bool is_mem_aligned; // true if Metada::CellMemAligned is set.
   bool is_sparse;
   bool is_vector;
   bool is_coordinate_field;
@@ -135,6 +136,8 @@ struct VarInfo {
           bool is_vector, const IndexShape &cellbounds)
       : label(label), num_components(num_components), nx_(nx),
         tensor_rank(metadata.Shape().size()), where(metadata.Where()),
+        is_mem_aligned(metadata.IsSet(Metadata::CellMemAligned) &&
+                       metadata.IsSet(Metadata::Flux)),
         topological_elements(topological_elements), is_sparse(is_sparse),
         is_vector(is_vector), cellbounds(cellbounds), rnx_(nx_.rbegin(), nx_.rend()),
         ntop_elems(topological_elements.size()), element_matters(ntop_elems > 1),

--- a/src/outputs/output_utils.hpp
+++ b/src/outputs/output_utils.hpp
@@ -137,7 +137,7 @@ struct VarInfo {
       : label(label), num_components(num_components), nx_(nx),
         tensor_rank(metadata.Shape().size()), where(metadata.Where()),
         is_mem_aligned(metadata.IsSet(Metadata::CellMemAligned) &&
-                       metadata.IsSet(Metadata::Flux)),
+                       !metadata.IsSet(Metadata::Cell)),
         topological_elements(topological_elements), is_sparse(is_sparse),
         is_vector(is_vector), cellbounds(cellbounds), rnx_(nx_.rbegin(), nx_.rend()),
         ntop_elems(topological_elements.size()), element_matters(ntop_elems > 1),

--- a/tst/regression/test_suites/advection_outflow/parthinput.advection_outflow
+++ b/tst/regression/test_suites/advection_outflow/parthinput.advection_outflow
@@ -64,4 +64,4 @@ num_vars = 1 # number of variables in variable vector
 <parthenon/output0>
 file_type = hdf5
 dt = 0.5
-variables = advected, my_derived_var, bnd_flux::advected
+variables = advected, my_derived_var

--- a/tst/regression/test_suites/advection_outflow/parthinput.advection_outflow
+++ b/tst/regression/test_suites/advection_outflow/parthinput.advection_outflow
@@ -64,4 +64,4 @@ num_vars = 1 # number of variables in variable vector
 <parthenon/output0>
 file_type = hdf5
 dt = 0.5
-variables = advected, my_derived_var
+variables = advected, my_derived_var, bnd_flux::advected

--- a/tst/regression/test_suites/advection_outflow/parthinput.advection_outflow
+++ b/tst/regression/test_suites/advection_outflow/parthinput.advection_outflow
@@ -3,7 +3,7 @@
 #  Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 #  Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-#  (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+#  (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 #
 #  This program was produced under U.S. Government contract 89233218CNA000001 for Los
 #  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/regression/test_suites/output_hdf5/parthinput.advection
+++ b/tst/regression/test_suites/output_hdf5/parthinput.advection
@@ -66,7 +66,8 @@ dt = 1.0
 variables = advected, one_minus_advected, & # comments are ok
             one_minus_advected_sq, & # on every (& characters are ok in comments)
             one_minus_sqrt_one_minus_advected_sq, & # line
-            metadata_none_var
+            metadata_none_var, &
+            bnd_flux::advected
 
 <parthenon/output1>
 file_type = hst

--- a/tst/regression/test_suites/output_hdf5/parthinput.advection
+++ b/tst/regression/test_suites/output_hdf5/parthinput.advection
@@ -3,7 +3,7 @@
 #  Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 #  Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-#  (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+#  (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 #
 #  This program was produced under U.S. Government contract 89233218CNA000001 for Los
 #  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Currently the code segfaults if you request fluxes in an output file. This is because (e.g., cell variable) fluxes are face fields but, because they default to `Metadata::CellMemAligned`, they have a different number of ghost zones than expected. The I/O packing/unpacking logic miscounts, and invalid memory is accessed. This MR resolves this issue. 

Because I wanted it, I also snuck in a minor quality of life improvement to the `movie2d.py` script. Mainly, it now supports a colorbar and the ability to choose a colormap.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
