### PR TITLE
[Bugfix]: Propagate flux `Metadata` correctly in `SparsePool`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [[PR 1172]](https://github.com/parthenon-hpc-lab/parthenon/pull/1172) Make parthenon manager robust against external MPI init and finalize calls
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1249]](https://github.com/parthenon-hpc-lab/parthenon/pull/1249) Fix flux metadata propagation in sparse pools
 - [[PR 1248]](https://github.com/parthenon-hpc-lab/parthenon/pull/1248) Fix edge case regarding AMR de-refinement logic
 - [[PR 1240]](https://github.com/parthenon-hpc-lab/parthenon/pull/1240) Fix I/O for CellMemAligned variables
 - [[PR 1229]](https://github.com/parthenon-hpc-lab/parthenon/pull/1229) Ensure builds function on 32 bit architectures

--- a/src/interface/sparse_pool.cpp
+++ b/src/interface/sparse_pool.cpp
@@ -57,10 +57,13 @@ MakeSparseVarMetadataImpl(Metadata *in, const std::vector<int> &shape,
                           const MetadataFlag *vector_tensor,
                           const std::vector<std::string> &component_labels) {
   // copy shared metadata
+  auto flx_metadata = in->IsSet(Metadata::WithFluxes) ? in->GetSPtrFluxMetadata()
+                                                      : std::make_shared<Metadata>();
   auto this_metadata = std::make_shared<Metadata>(
-      in->Flags(), shape.size() > 0 ? shape : in->Shape(),
+      in->Flags(), flx_metadata->Flags(), shape.size() > 0 ? shape : in->Shape(),
       component_labels.size() > 0 ? component_labels : in->getComponentLabels(),
-      in->getAssociated(), in->GetRefinementFunctions());
+      in->getAssociated(), in->GetRefinementFunctions(),
+      flx_metadata->GetRefinementFunctions());
 
   this_metadata->SetSparseThresholds(in->GetAllocationThreshold(),
                                      in->GetDeallocationThreshold(),


### PR DESCRIPTION
## PR Summary

Currently, when you build a `SparsePool` using `Metadata` where you have changed `Metadata::flux_metadata`, the changes to `Metadata::flux_metadata` are ignored in `MakeSparseVarMetadataImpl`. This PR changes things, so the flux flags and refinement functions are propagated as expected.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
