### PR TITLE
Change typeid to std::is_same_v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [[PR 1253]](https://github.com/parthenon-hpc-lab/parthenon/pull/1253) Add support for uint64 swarm variables and add default id
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1275]](https://github.com/parthenon-hpc-lab/parthenon/pull/1275) Remove typeid from interpolation device code
 - [[PR 1272]](https://github.com/parthenon-hpc-lab/parthenon/pull/1272) Remove mistakenly included pdf files in the base directory
 - [[PR 1257]](https://github.com/parthenon-hpc-lab/parthenon/pull/1257) Clean exit with `-m`
 

--- a/src/utils/interpolation.hpp
+++ b/src/utils/interpolation.hpp
@@ -63,7 +63,7 @@ KOKKOS_INLINE_FUNCTION void GetWeights(const Real x, const int nx,
                                        const Coordinates_t &coords, int &ix,
                                        weights_t &w) {
   PARTHENON_DEBUG_REQUIRE(
-      (std::is_same_v<Coordinates_t,UniformCartesian>),
+      (std::is_same_v<Coordinates_t, UniformCartesian>),
       "Interpolation routines currently only work for UniformCartesian");
   const Real min = coords.Xc<DIR>(0);             // assume uniform Cartesian
   const Real dx = coords.CellWidth<DIR>(0, 0, 0); // assume uniform Cartesian

--- a/src/utils/interpolation.hpp
+++ b/src/utils/interpolation.hpp
@@ -63,7 +63,7 @@ KOKKOS_INLINE_FUNCTION void GetWeights(const Real x, const int nx,
                                        const Coordinates_t &coords, int &ix,
                                        weights_t &w) {
   PARTHENON_DEBUG_REQUIRE(
-      typeid(Coordinates_t) == typeid(UniformCartesian),
+      (std::is_same_v<Coordinates_t,UniformCartesian>),
       "Interpolation routines currently only work for UniformCartesian");
   const Real min = coords.Xc<DIR>(0);             // assume uniform Cartesian
   const Real dx = coords.CellWidth<DIR>(0, 0, 0); // assume uniform Cartesian


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

The `typeid` in `interpolation.hpp` cause an error when compiling Debug+CUDA. I only encountered this while compiling AthenaPK in debug mode. Error below, the fix is quick. 
```
/project/athenapk/external/parthenon/src/utils/interpolation.hpp(66): error: The operator 'typeid' is not allowed in device code
    if (!(typeid(Coordinates_t) == typeid(UniformCartesian))) { parthenon::ErrorChecking::require("typeid(Coordinates_t) == typeid(UniformCartesian)", "Interpolation routines currently only work for UniformCartesian", "/project/athenapk/external/parthenon/src/utils/interpolation.hpp", 66); }
          ^
          detected during:
            instantiation of "parthenon::Real parthenon::interpolation::cent::linear::Do3D(int, parthenon::Real, parthenon::Real, parthenon::Real, const Pack &, int) [with Pack=parthenon::VariablePack<parthenon::Real>]" at line 156
            instantiation of "parthenon::Real parthenon::interpolation::cent::linear::Do(int, parthenon::Real, parthenon::Real, parthenon::Real, const Pack &, int) [with Pack=parthenon::VariablePack<parthenon::Real>]" at line 224 of /project/athenapk/src/tracers/tracers.cpp

/project/athenapk/external/parthenon/src/utils/interpolation.hpp(66): error: The operator 'typeid' is not allowed in device code
    if (!(typeid(Coordinates_t) == typeid(UniformCartesian))) { parthenon::ErrorChecking::require("typeid(Coordinates_t) == typeid(UniformCartesian)", "Interpolation routines currently only work for UniformCartesian", "/project/athenapk/external/parthenon/src/utils/interpolation.hpp", 66); }
                                   ^
          detected during:
            instantiation of "parthenon::Real parthenon::interpolation::cent::linear::Do3D(int, parthenon::Real, parthenon::Real, parthenon::Real, const Pack &, int) [with Pack=parthenon::VariablePack<parthenon::Real>]" at line 156
            instantiation of "parthenon::Real parthenon::interpolation::cent::linear::Do(int, parthenon::Real, parthenon::Real, parthenon::Real, const Pack &, int) [with Pack=parthenon::VariablePack<parthenon::Real>]" at line 224 of /project/athenapk/src/tracers/tracers.cpp

2 errors detected in the compilation of "/project/athenapk/src/tracers/tracers.cpp".
```


<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
