### PR TITLE
Specialize `Kokkos::reduction_identity` for `AmrTag`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - [[PR 1253]](https://github.com/parthenon-hpc-lab/parthenon/pull/1253) Add support for uint64 swarm variables and add default id
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1276]](https://github.com/parthenon-hpc-lab/parthenon/pull/1276) Specialize Kokkos::reduction_identity for AmrTag
 - [[PR 1254]](https://github.com/parthenon-hpc-lab/parthenon/pull/1254) Fix task failure handling
 - [[PR 1272]](https://github.com/parthenon-hpc-lab/parthenon/pull/1272) Remove mistakenly included pdf files in the base directory
 - [[PR 1257]](https://github.com/parthenon-hpc-lab/parthenon/pull/1257) Clean exit with `-m`

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include <vector>
 
+#include <amr_criteria/refinement_package.hpp>
 #include <coordinates/coordinates.hpp>
 #include <globals.hpp>
 #include <parthenon/package.hpp>

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -19,7 +19,6 @@
 #include <string>
 #include <vector>
 
-#include <amr_criteria/refinement_package.hpp>
 #include <coordinates/coordinates.hpp>
 #include <globals.hpp>
 #include <parthenon/package.hpp>

--- a/src/amr_criteria/refinement_package.hpp
+++ b/src/amr_criteria/refinement_package.hpp
@@ -53,15 +53,5 @@ void SecondDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::stri
                       const int max_level_);
 
 } // namespace Refinement
-
 } // namespace parthenon
-namespace Kokkos {
-template <>
-struct reduction_identity<parthenon::AmrTag> {
-  using AmrTag = parthenon::AmrTag;
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static AmrTag max() { return AmrTag::refine; }
-  KOKKOS_FORCEINLINE_FUNCTION constexpr static AmrTag min() { return AmrTag::derefine; }
-};
-} // namespace Kokkos
-
 #endif // AMR_CRITERIA_REFINEMENT_PACKAGE_HPP_

--- a/src/amr_criteria/refinement_package.hpp
+++ b/src/amr_criteria/refinement_package.hpp
@@ -17,8 +17,6 @@
 #include <memory>
 #include <string>
 
-#include <Kokkos_ReductionIdentity.hpp>
-
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
 

--- a/src/amr_criteria/refinement_package.hpp
+++ b/src/amr_criteria/refinement_package.hpp
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include <Kokkos_ReductionIdentity.hpp>
+
 #include "defs.hpp"
 #include "parthenon_arrays.hpp"
 
@@ -53,5 +55,13 @@ void SecondDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::stri
 } // namespace Refinement
 
 } // namespace parthenon
+namespace Kokkos {
+template <>
+struct reduction_identity<parthenon::AmrTag> {
+  using AmrTag = parthenon::AmrTag;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static AmrTag max() { return AmrTag::refine; }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static AmrTag min() { return AmrTag::derefine; }
+};
+} // namespace Kokkos
 
 #endif // AMR_CRITERIA_REFINEMENT_PACKAGE_HPP_

--- a/src/basic_types.hpp
+++ b/src/basic_types.hpp
@@ -251,4 +251,15 @@ template <typename T>
 using Triple_t = std::tuple<T, T, T>;
 } // namespace parthenon
 
+namespace Kokkos {
+// this specialization is needed for AmrTags to be used as the type in a
+// Kokkos::ScatterView
+template <>
+struct reduction_identity<parthenon::AmrTag> {
+  using AmrTag = parthenon::AmrTag;
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static AmrTag max() { return AmrTag::derefine; }
+  KOKKOS_FORCEINLINE_FUNCTION constexpr static AmrTag min() { return AmrTag::refine; }
+};
+} // namespace Kokkos
+
 #endif // BASIC_TYPES_HPP_


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Provides a specialization for `parthenon::AmrTag` needed in the non-atomic `ScatterView`s used in the `MeshData` amr criteria. This would only show up when building with the openMP backend in Kokkos.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

addresses #1274 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
