### PR TITLE
Output header to history files on each invocation, even restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - [[PR 1239]](https://github.com/parthenon-hpc-lab/parthenon/pull/1239) Automatically cache PackDescriptors in Mesh
 - [[PR 1242]](https://github.com/parthenon-hpc-lab/parthenon/pull/1242) Move to Kokkos 4.6.01 (for AMD APU support)
 - [[PR 1253]](https://github.com/parthenon-hpc-lab/parthenon/pull/1253) Add support for uint64 swarm variables and add default id
+- [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR 1276]](https://github.com/parthenon-hpc-lab/parthenon/pull/1276) Specialize Kokkos::reduction_identity for AmrTag
@@ -40,7 +41,7 @@ Date: 2025-05-19
 - [[PR 1237]](https://github.com/parthenon-hpc-lab/parthenon/pull/1237) Add selector functions to sparse packs, cache sparse packs with different block lists, reorganize files
 - [[PR 1231]](https://github.com/parthenon-hpc-lab/parthenon/pull/1231) Add support for uint8_t parameter types in hdf5 files
 - [[PR 1137]](https://github.com/parthenon-hpc-lab/parthenon/pull/1137) Add spherical and cylindrical coordinate support
-- [[PR 1182]](https://github.com/parthenon-hpc-lab/parthenon/pull/1182) Add a MeshData variant for refinement tagging 
+- [[PR 1182]](https://github.com/parthenon-hpc-lab/parthenon/pull/1182) Add a MeshData variant for refinement tagging
 - [[PR 1210]](https://github.com/parthenon-hpc-lab/parthenon/pull/1210) Add cycle based output
 - [[PR 1103]](https://github.com/parthenon-hpc-lab/parthenon/pull/1103) Add sparsity to vector wave equation test
 - [[PR 1185]](https://github.com/parthenon-hpc-lab/parthenon/pull/1185) Bugfix to particle defragmentation

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "coordinates/coordinates.hpp"
@@ -180,11 +181,11 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       PARTHENON_FAIL(msg);
     }
 
-    // Write the header lines once per invocation of Parthenon -- output variables may
-    // have changed, or we may be restarting in a new directory with no existing
-    // output file
-    static bool first_invocation = true;
-    if (first_invocation) {
+    // Write the header lines once per distinct history file, each once
+    // per invocation of parthenon -- once a header has been output for
+    // the given file_id, ignore it.
+    static std::unordered_set<std::string> ids_output;
+    if (!ids_output.count(output_params.file_id)) {
       int iout = 1;
       std::fprintf(pfile, "#  History data\n"); // descriptor is first line
       std::fprintf(pfile, "# [%d]=time    ", iout++);
@@ -197,7 +198,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
         }
       }
       std::fprintf(pfile, "\n"); // terminate line
-      first_invocation = false;
+      ids_output.insert(output_params.file_id);
     }
 
     // write history variables

--- a/src/outputs/history.cpp
+++ b/src/outputs/history.cpp
@@ -179,8 +179,11 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
       PARTHENON_FAIL(msg);
     }
 
-    // If this is the first output, write header
-    if (output_params.file_number == 0) {
+    // Write the header lines once per invocation of Parthenon -- output variables may
+    // have changed, or we may be restarting in a new directory with no existing
+    // output file
+    static bool first_invocation = true;
+    if (first_invocation) {
       int iout = 1;
       std::fprintf(pfile, "#  History data\n"); // descriptor is first line
       std::fprintf(pfile, "# [%d]=time    ", iout++);
@@ -193,6 +196,7 @@ void HistoryOutput::WriteOutputFile(Mesh *pm, ParameterInput *pin, SimTime *tm,
         }
       }
       std::fprintf(pfile, "\n"); // terminate line
+      first_invocation = false;
     }
 
     // write history variables


### PR DESCRIPTION
This was briefly discussed at the meeting, but for everyone:

When restarting existing simulations parthenon does not print the header on `.hst` history output files.

This was inadequate in two cases: restarts which used a new directory printed header-less histories, and restarts with new packages loaded added a bunch of unlabeled columns.

This outputs the header once each time Parthenon is invoked, which will always print headers when necessary, at the cost of sometimes printing unnecessary headers for routine restarts.  Given it's easy to tell e.g. numpy to ignore these lines, that does not seem like too bad a price, when the alternative is a bunch of logic for whether a file exists and whether its existing columns (which we'd need to read and parse) match the new set of columns.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
