### PR TITLE
params -> std::any

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [[PR 1257]](https://github.com/parthenon-hpc-lab/parthenon/pull/1257) Clean exit with `-m`
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1281]](https://github.com/parthenon-hpc-lab/parthenon/pull/1281) Move params implementation to std::any
 - [[PR 1162]](https://github.com/parthenon-hpc-lab/parthenon/pull/1162) Update CI container to Cuda 12.8
 
 

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -31,12 +31,10 @@ namespace parthenon {
 template <typename T>
 void Params::WriteToHDF5AllParamsOfType(const std::string &prefix,
                                         const HDF5::H5G &group) const {
-  for (const auto &p : myParams_) {
-    const auto &key = p.first;
-    const auto type = myTypes_.at(key);
-    if (type == std::type_index(typeid(T))) {
-      auto typed_ptr = dynamic_cast<Params::object_t<T> *>((p.second).get());
-      HDF5::HDF5WriteAttribute(prefix + "/" + key, *typed_ptr->pValue, group);
+  for (const auto &[key, pparam] : myParams_) {
+    if (std::type_index(pparam->type()) == std::type_index(typeid(T))) {
+      auto typed_ptr = std::any_cast<T>(pparam.get());
+      HDF5::HDF5WriteAttribute(prefix + "/" + key, *typed_ptr, group);
     }
   }
 }
@@ -56,13 +54,12 @@ void Params::WriteToHDF5AllParamsOfTypeOrVec(const std::string &prefix,
 template <typename T>
 void Params::ReadFromHDF5AllParamsOfType(const std::string &prefix,
                                          const HDF5::H5G &group) {
-  for (auto &p : myParams_) {
-    auto &key = p.first;
-    auto type = myTypes_.at(key);
+  for (auto &[key, pparam] : myParams_) {
     auto mutability = myMutable_.at(key);
-    if (type == std::type_index(typeid(T)) && mutability == Mutability::Restart) {
-      auto typed_ptr = dynamic_cast<Params::object_t<T> *>((p.second).get());
-      auto &val = *(typed_ptr->pValue);
+    if (std::type_index(pparam->type()) == std::type_index(typeid(T)) &&
+        mutability == Mutability::Restart) {
+      auto typed_ptr = std::any_cast<T>(pparam.get());
+      auto &val = *typed_ptr;
       HDF5::HDF5ReadAttribute(group, prefix + "/" + key, val);
       Update(key, val);
     }

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -13,6 +13,7 @@
 #ifndef INTERFACE_PARAMS_HPP_
 #define INTERFACE_PARAMS_HPP_
 
+#include <any>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -51,8 +52,7 @@ class Params {
   template <typename T>
   void Add(const std::string &key, T value, Mutability mutability) {
     PARTHENON_REQUIRE_THROWS(!(hasKey(key)), "Key " + key + " already exists");
-    myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
-    myTypes_.emplace(make_pair(key, std::type_index(typeid(value))));
+    myParams_[key] = std::make_unique<std::any>(value);
     myMutable_[key] = mutability;
   }
   template <typename T>
@@ -68,21 +68,24 @@ class Params {
     // immutable casts to false all others cast to true
     PARTHENON_REQUIRE_THROWS(static_cast<bool>(myMutable_.at(key)),
                              "Parameter " + key + " must be marked as mutable");
-    PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
-                             "WRONG TYPE FOR KEY '" + key + "'");
-    myParams_[key] = std::unique_ptr<Params::base_t>(new object_t<T>(value));
+    PARTHENON_REQUIRE_THROWS(std::type_index(myParams_.at(key)->type()) ==
+                                 std::type_index(typeid(T)),
+                             "Parameter " + key + " must have the relevant type");
+    myParams_[key] = std::make_unique<std::any>(value);
   }
 
   void reset() {
     myParams_.clear();
-    myTypes_.clear();
     myMutable_.clear();
   }
 
   template <typename T>
   const T &Get(const std::string &key) const {
-    auto typed_ptr = GetTypedPointer_<T>(key);
-    return *typed_ptr->pValue;
+    auto &pparam = myParams_.at(key);
+    PARTHENON_REQUIRE_THROWS(std::type_index(pparam->type()) ==
+                                 std::type_index(typeid(T)),
+                             "Parameter " + key + " must have the relevant type");
+    return *std::any_cast<T>(pparam.get());
   }
 
   // Returning a pointer feels safer than returning a non-const reference.
@@ -91,11 +94,14 @@ class Params {
   // This also avoids extraneous copies.
   template <typename T>
   T *GetMutable(const std::string &key) const {
-    auto typed_ptr = GetTypedPointer_<T>(key);
     // immutable casts to false all others cast to true
     PARTHENON_REQUIRE_THROWS(static_cast<bool>(myMutable_.at(key)),
                              "Parameter " + key + " must be marked as mutable");
-    return typed_ptr->pValue.get();
+    auto &pparam = myParams_.at(key);
+    PARTHENON_REQUIRE_THROWS(std::type_index(pparam->type()) ==
+                                 std::type_index(typeid(T)),
+                             "Parameter " + key + " must have the relevant type");
+    return std::any_cast<T>(pparam.get());
   }
 
   bool hasKey(const std::string &key) const {
@@ -112,10 +118,8 @@ class Params {
     return Get<T>(key);
   }
 
-  const std::type_index &GetType(const std::string &key) const {
-    auto const it = myTypes_.find(key);
-    PARTHENON_REQUIRE_THROWS(it != myTypes_.end(), "Key " + key + " doesn't exist");
-    return it->second;
+  const std::type_index GetType(const std::string &key) const {
+    return myParams_.at(key)->type();
   }
 
   std::vector<std::string> GetKeys() const {
@@ -129,9 +133,8 @@ class Params {
   // void Params::
   void list() {
     std::cout << std::endl << "Items are:" << std::endl;
-    for (auto &x : myParams_) {
-      std::cout << "   " << x.first << ":" << x.second.get() << ":" << x.second->address()
-                << ":" << myTypes_.at(x.first).name() << std::endl;
+    for (auto &[k, v] : myParams_) {
+      std::cout << "   " << k << ":" << v.get() << ":" << v->type().name() << std::endl;
     }
     std::cout << std::endl;
   }
@@ -188,32 +191,7 @@ class Params {
 #endif // ifdef ENABLE_HDF5
 
  private:
-  // private first so that I can use the structs defined here
-  struct base_t {
-    virtual ~base_t() = default; // for whatever reason I need a virtual destructor
-    virtual const void *address() { return nullptr; } // for listing and debugging
-  };
-
-  template <typename T>
-  struct object_t : base_t {
-    std::unique_ptr<T> pValue;
-    explicit object_t(T val) : pValue(std::make_unique<T>(val)) {}
-    ~object_t() = default;
-    const void *address() { return reinterpret_cast<void *>(pValue.get()); }
-  };
-
-  template <typename T>
-  auto GetTypedPointer_(const std::string &key) const {
-    auto const it = myParams_.find(key);
-    PARTHENON_REQUIRE_THROWS(it != myParams_.end(), "Key " + key + " doesn't exist");
-    PARTHENON_REQUIRE_THROWS(myTypes_.at(key) == std::type_index(typeid(T)),
-                             "WRONG TYPE FOR KEY '" + key + "'");
-    auto typed_ptr = dynamic_cast<Params::object_t<T> *>((it->second).get());
-    return typed_ptr;
-  }
-
-  std::map<std::string, std::unique_ptr<Params::base_t>> myParams_;
-  std::map<std::string, std::type_index> myTypes_;
+  std::map<std::string, std::unique_ptr<std::any>> myParams_;
   std::map<std::string, Mutability> myMutable_;
 };
 

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -133,7 +133,7 @@ class StateDescriptor {
     return params_.Get(key, value);
   }
 
-  const std::type_index &ParamType(const std::string &key) const {
+  const std::type_index ParamType(const std::string &key) const {
     return params_.GetType(key);
   }
 

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -95,7 +95,7 @@ TEST_CASE("Add, Get, and Update are called", "[Add,Get,Update]") {
     std::string non_existent_key = "key";
     WHEN(" attempting to get a key that does not exist ") {
       THEN("an error is thrown") {
-        REQUIRE_THROWS_AS(params.Get<double>(non_existent_key), std::runtime_error);
+        REQUIRE_THROWS_AS(params.Get<double>(non_existent_key), std::out_of_range);
       }
     }
     WHEN(" attempting to update a key that does not exist ") {
@@ -115,7 +115,7 @@ TEST_CASE("reset is called", "[reset]") {
     params.Add(key, value);
     WHEN("the params are reset") {
       params.reset();
-      REQUIRE_THROWS_AS(params.Get<double>(key), std::runtime_error);
+      REQUIRE_THROWS_AS(params.Get<double>(key), std::out_of_range);
     }
   }
 }

--- a/tst/unit/test_unit_params.cpp
+++ b/tst/unit/test_unit_params.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

While I was at it cleaning things up, I decided to clean up the implementation of params. With C++17 we can use `std::any` instead of our `void` pointer chasing, which basically re-implements the same concept. The functionality `Params` provides is completely unchanged, this is just a simpler implementation.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
