### PR TITLE
Parameter Papercuts

### DIFF
--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -66,6 +66,7 @@ jobs:
         # -O0 option causes compiler issue for the navi 1030 GPU at
         # compile time, see https://github.com/parthenon-hpc-lab/parthenon/pull/1191#issuecomment-2492035364
         run: |
+          git config --global --add safe.directory $(pwd)
           cmake -B builddir \
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -152,6 +152,7 @@ jobs:
 
       - name: Configure
         run: |
+          git config --global --add safe.directory $(pwd)
           cmake -B build \
             -DMACHINE_CFG=${PWD}/cmake/machinecfg/GitHubActions.cmake \
             -DCMAKE_BUILD_TYPE=Release \

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -150,6 +150,7 @@ jobs:
           submodules: 'true'
       - name: Configure
         run: |
+          git config --global --add safe.directory $(pwd)
           cmake -B build \
             -DMACHINE_CFG=${PWD}/cmake/machinecfg/GitHubActions.cmake \
             -DCMAKE_BUILD_TYPE=Release \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [[PR 1254]](https://github.com/parthenon-hpc-lab/parthenon/pull/1254) Fix task failure handling
 - [[PR 1272]](https://github.com/parthenon-hpc-lab/parthenon/pull/1272) Remove mistakenly included pdf files in the base directory
 - [[PR 1257]](https://github.com/parthenon-hpc-lab/parthenon/pull/1257) Clean exit with `-m`
+- [[PR 1284]](https://github.com/parthenon-hpc-lab/parthenon/pull/1284) Fix some parameter types, move `DumpInputParameters` to `Driver`
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[PR 1281]](https://github.com/parthenon-hpc-lab/parthenon/pull/1281) Move params implementation to std::any

--- a/cmake/Lint.cmake
+++ b/cmake/Lint.cmake
@@ -60,8 +60,13 @@ function(lint_target TARGET_NAME)
     else()
       set(TARGET_OUTPUTS)
       foreach(SOURCE ${TARGET_SOURCES})
+        # exclude sources in generator expressions as they may or may
+        # not exist at cmake time
+        string(GENEX_STRIP ${SOURCE} no_genex)
+        if (SOURCE STREQUAL no_genex)
           lint_file(${TARGET_SOURCE_DIR} ${SOURCE} ${SOURCE}.lint)
           list(APPEND TARGET_OUTPUTS ${SOURCE}.lint)
+        endif()
       endforeach()
 
       add_custom_target(

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -175,7 +175,7 @@ DriverStatus EvolutionDriver::Execute() {
       }
     } // END OF MAIN INTEGRATION LOOP
       // ======================================================
-  } // Main t < tmax loop region
+  }   // Main t < tmax loop region
 
   if (pmesh->UserWorkAfterLoop != nullptr) {
     pmesh->UserWorkAfterLoop(pmesh, pinput, tm);

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -40,7 +40,37 @@ Kokkos::Timer Driver::timer_main;
 Kokkos::Timer Driver::timer_cycle;
 Kokkos::Timer Driver::timer_LBandAMR;
 
+void Driver::DumpInputParameters() {
+  auto archive_parameters =
+      pinput->GetOrAddBoolean("parthenon/job", "archive_parameters", false);
+  auto archive_timestamp =
+      pinput->GetOrAddBoolean("parthenon/job", "archive_timestamp", false);
+  if (archive_parameters && Globals::my_rank == 0) {
+    std::ostringstream ss;
+    if (archive_timestamp) {
+      auto itt_now =
+          std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
+      ss << "parthinput.archive." << std::put_time(std::gmtime(&itt_now), "%FT%TZ");
+    } else {
+      ss << "parthinput.archive";
+    }
+    std::fstream pars;
+    pars.open(ss.str(), std::fstream::out | std::fstream::trunc);
+    pinput->ParameterDump(pars);
+    pars.close();
+  }
+  auto print_parameters =
+      pinput->GetOrAddBoolean("parthenon/job", "print_parameters", false);
+  if (print_parameters && Globals::my_rank == 0) {
+    pinput->ParameterDump(std::cout);
+  }
+}
+
 void Driver::PreExecute() {
+  // Output a text file of all parameters at this point
+  // Optionally also dump to console
+  DumpInputParameters();
+
   if (Globals::my_rank == 0) {
     std::cout << "# Variables in use:\n" << *(pmesh->resolved_packages) << std::endl;
     std::cout << std::endl;
@@ -89,10 +119,6 @@ DriverStatus EvolutionDriver::Execute() {
   pmesh->mbcnt = 0;
   int perf_cycle_offset =
       pinput->GetOrAddInteger("parthenon/time", "perf_cycle_offset", 0);
-
-  // Output a text file of all parameters at this point
-  // Defaults must be set across all ranks
-  DumpInputParameters();
 
   { // Main t < tmax loop region
     PARTHENON_INSTRUMENT
@@ -149,7 +175,7 @@ DriverStatus EvolutionDriver::Execute() {
       }
     } // END OF MAIN INTEGRATION LOOP
       // ======================================================
-  }   // Main t < tmax loop region
+  } // Main t < tmax loop region
 
   if (pmesh->UserWorkAfterLoop != nullptr) {
     pmesh->UserWorkAfterLoop(pmesh, pinput, tm);
@@ -266,26 +292,6 @@ void EvolutionDriver::SetGlobalTimeStep() {
   // away from tlim
   if (tm.time < tm.tlim && (tm.tlim - tm.time) < tm.dt) {
     tm.dt = tm.tlim - tm.time;
-  }
-}
-
-void EvolutionDriver::DumpInputParameters() {
-  auto archive_settings =
-      pinput->GetOrAddString("parthenon/job", "archive_parameters", "false",
-                             std::vector<std::string>{"true", "false", "timestamp"});
-  if (archive_settings != "false" && Globals::my_rank == 0) {
-    std::ostringstream ss;
-    if (archive_settings == "timestamp") {
-      auto itt_now =
-          std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
-      ss << "parthinput.archive." << std::put_time(std::gmtime(&itt_now), "%FT%TZ");
-    } else {
-      ss << "parthinput.archive";
-    }
-    std::fstream pars;
-    pars.open(ss.str(), std::fstream::out | std::fstream::trunc);
-    pinput->ParameterDump(pars);
-    pars.close();
   }
 }
 

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -41,6 +41,7 @@ class Driver {
       : pinput(pin), app_input(app_in), pmesh(pm), mbcnt_prev(), time_LBandAMR() {}
   virtual DriverStatus Execute() = 0;
   void InitializeOutputs() { pouts = std::make_unique<Outputs>(pmesh, pinput); }
+  void DumpInputParameters();
 
   ParameterInput *pinput;
   ApplicationInput *app_input;
@@ -105,7 +106,6 @@ class EvolutionDriver : public Driver {
   DriverStatus Execute() override;
   virtual void SetGlobalTimeStep();
   virtual void OutputCycleDiagnostics();
-  void DumpInputParameters();
 
   virtual TaskListStatus Step() = 0;
   SimTime tm;

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -71,13 +71,9 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
       multilevel(
           (adaptive ||
            pin->GetOrAddString("parthenon/mesh", "refinement", "none") == "static" ||
-           pin->GetOrAddString("parthenon/mesh", "multigrid", "false") == "true")
-              ? true
-              : false),
-      multigrid(pin->GetOrAddString("parthenon/mesh", "multigrid", "false") == "true"
-                    ? true
-                    : false),
-      nbnew(), nbdel(), step_since_lb(), gflag(), packages(packages),
+           pin->GetOrAddBoolean("parthenon/mesh", "multigrid", false))),
+      multigrid(pin->GetOrAddBoolean("parthenon/mesh", "multigrid", false)), nbnew(),
+      nbdel(), step_since_lb(), gflag(), packages(packages),
       resolved_packages(ResolvePackages(packages)),
       // private members:
       num_mesh_threads_(pin->GetOrAddInteger("parthenon/mesh", "num_threads", 1)),

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -163,7 +163,7 @@ ParthenonStatus ParthenonManager::ParthenonInitEnv(int argc, char *argv[]) {
 
   // set boundary comms buffer switch trigger
   Globals::refinement::min_num_bufs =
-      pinput->GetOrAddReal("parthenon/mesh", "refinement_in_one_min_nbufs", 64);
+      pinput->GetOrAddInteger("parthenon/mesh", "refinement_in_one_min_nbufs", 64);
 
   return ParthenonStatus::ok;
 }

--- a/tst/regression/test_suites/particle_tracers/parthinput.particle_tracers
+++ b/tst/regression/test_suites/particle_tracers/parthinput.particle_tracers
@@ -53,13 +53,8 @@ v = 1.0
 file_type = hdf5
 dt = 0.05
 variables = advected, tracer_deposition
+swarms = tracers
+swarm_variables = id
 
 <Tracers>
 num_tracers = 10
-
-<parthenon/output0>
-file_type = hdf5
-dt = 0.05
-variables = advected
-swarms = tracers
-swarm_variables = id


### PR DESCRIPTION
This is all the bugfix pieces of #1277 split out so that they can go in sooner.

There is one substantial change: I move `DumpInputParameters` up to `Driver` so that non-`EvolutionDriver` codes such as the pi calculation test, and one of my downstreams, can take advantage.  This was useful in debugging some parsing of AMR parameters which was messed up by #1277.

One other potential choice: the particle tracers example had two `<parthenon/output0>` blocks.  I merge them, but I could see splitting them into an `output0` and `output1` if the test is supposed to cover more diverse output types.  That didn't seem to be the intent though, and I think the other particle tests cover the same thing.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
