### PR TITLE
[Tiny] Fix bug in #1214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1289]](https://github.com/parthenon-hpc-lab/parthenon/pull/1289) Fix a bug in 1214
 - [[PR 1214]](https://github.com/parthenon-hpc-lab/parthenon/pull/1214) Initialize MPI in catch2 to prevent errors when constructing Meshes
 - [[PR 1276]](https://github.com/parthenon-hpc-lab/parthenon/pull/1276) Specialize Kokkos::reduction_identity for AmrTag
 - [[PR 1275]](https://github.com/parthenon-hpc-lab/parthenon/pull/1275) Remove typeid from interpolation device code

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -68,8 +68,8 @@ int main(int argc, char *argv[]) {
   }
   const auto &config = session.config();
 #ifdef CATCH2_MPI_PARALLEL
-  bool mpi_initialized{false};
-  if (HasMPITests(config)) {
+  bool running_mpi_tests = HasMPITests(config);
+  if (running_mpi_tests) {
     int already_initialized;
     MPI_Initialized(&already_initialized);
     if (!already_initialized && (MPI_SUCCESS != MPI_Init(&argc, &argv))) {
@@ -92,7 +92,7 @@ int main(int argc, char *argv[]) {
   Kokkos::finalize();
 
 #ifdef CATCH2_MPI_PARALLEL
-  if (mpi_initialized) {
+  if (running_mpi_tests) {
     int mpi_finalized;
     MPI_Finalized(&mpi_finalized);
     if (!mpi_finalized) MPI_Finalize();


### PR DESCRIPTION
## PR Summary

#1214 didn't correctly set `running_mpi_tests`, so `MPI_Finalize()` wasn't being called. Sorry for missing this dumb mistake.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
