### PR TITLE
[WIP] Add mutability maybe restart and made it so we can read old restart files

### DIFF
--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -11,10 +11,12 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+#include <sstream>
 #include <string>
 
 #include "utils/error_checking.hpp"
 
+#include "globals.hpp"
 #include "kokkos_abstraction.hpp"
 #include "parthenon_arrays.hpp"
 
@@ -55,13 +57,28 @@ template <typename T>
 void Params::ReadFromHDF5AllParamsOfType(const std::string &prefix,
                                          const HDF5::H5G &group) {
   for (auto &[key, pparam] : myParams_) {
-    auto mutability = myMutable_.at(key);
     if (std::type_index(pparam->type()) == std::type_index(typeid(T)) &&
-        mutability == Mutability::Restart) {
+        IsRestartable(key)) {
+      auto mutability = myMutable_.at(key);
       auto typed_ptr = std::any_cast<T>(pparam.get());
       auto &val = *typed_ptr;
-      HDF5::HDF5ReadAttribute(group, prefix + "/" + key, val);
-      Update(key, val);
+      std::string fullpath = prefix + "/" + key;
+      if (mutability == Mutability::Restart) {
+        HDF5::HDF5ReadAttribute(group, fullpath, val);
+        Update(key, val);
+      } else if (mutability == Mutability::MaybeRestart) {
+        try {
+          HDF5::HDF5ReadAttribute(group, fullpath, val);
+          Update(key, val);
+        } catch (std::runtime_error e) {
+          if (Globals::my_rank == 0) {
+            std::stringstream ss;
+            ss << "Failed to load parameter " << fullpath
+               << " from the restart file! Using default value." << std::endl;
+            PARTHENON_WARN(ss);
+          }
+        }
+      }
     }
   }
 }

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -39,7 +39,12 @@ class Params {
   // Immutable is default. Mutable is it can be updated at runtime.
   // Restart is a subset of mutable. Param not only can be updated at
   // runtime, but should be read from the restart file upon restart.
-  enum class Mutability : int { Immutable = 0, Mutable = 1, Restart = 2 };
+  enum class Mutability : int {
+    Immutable = 0,
+    Mutable = 1,
+    Restart = 2,
+    MaybeRestart = 3
+  };
 
   Params() {}
 
@@ -66,7 +71,7 @@ class Params {
   void Update(const std::string &key, T value) {
     PARTHENON_REQUIRE_THROWS((hasKey(key)), "Key " + key + "missing.");
     // immutable casts to false all others cast to true
-    PARTHENON_REQUIRE_THROWS(static_cast<bool>(myMutable_.at(key)),
+    PARTHENON_REQUIRE_THROWS(IsMutable(key),
                              "Parameter " + key + " must be marked as mutable");
     PARTHENON_REQUIRE_THROWS(std::type_index(myParams_.at(key)->type()) ==
                                  std::type_index(typeid(T)),
@@ -128,6 +133,16 @@ class Params {
       keys.push_back(x.first);
     }
     return keys;
+  }
+
+  auto GetMutability(const std::string &key) const { return myMutable_.at(key); }
+  bool IsMutable(const std::string &key) const {
+    return static_cast<bool>(myMutable_.at(key));
+  }
+  bool IsRestartable(const std::string &key) const {
+    auto mutability = myMutable_.at(key);
+    return (mutability == Mutability::Restart) ||
+           (mutability == Mutability::MaybeRestart);
   }
 
   // void Params::

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -138,6 +138,27 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       (*pactive)[iinput] = true;
     }
 
+    // JMM: Backwards compatibility hack. Don't allow this unless
+    // we're restarting from a legacy file format.
+    if (Globals::is_restart) { // should this be pmesh->is_restart?
+      bool next_time_exists = pin->DoesParameterExist(op.block_name, "next_time");
+      bool next_n_exists = pin->DoesParameterExist(op.block_name, "next_n");
+      if (next_time_exists) {
+        Real next_time = pin->GetReal(op.block_name, "next_time");
+        (*plast_times)[iinput] = next_time - dt;
+        pin->RemoveParameter(op.block_name, "next_time");
+      }
+      if (next_n_exists) {
+        int next_n = pin->GetInteger(op.block_name, "next_n");
+        (*plast_ns)[iinput] = next_n - dn;
+        pin->RemoveParameter(op.block_name, "next_n");
+      }
+      if (next_time_exists || next_n_exists) {
+        (*pfile_numbers)[iinput] = pin->GetOrAddInteger(op.block_name, "file_number", 0);
+        pin->RemoveParameter(op.block_name, "file_number");
+      }
+    }
+
     PARTHENON_REQUIRE_THROWS(!(dt >= 0.0 && dn >= 0),
                              "dt and dn are enabled for the same output block, which "
                              "is not supported. Please set at most one value >= 0.");

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "globals.hpp"
 #include "interface/state_descriptor.hpp"
 #include "outputs/outputs_package.hpp"
 #include "parameter_input.hpp"
@@ -53,21 +54,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       std::string outn = pib->block_name.substr(16); // 6 because counting starts at 0!
       std::string block_name = pib->block_name;
 
-      if (pin->DoesParameterExist(block_name, "next_time")) {
-        std::stringstream msg;
-        msg << "You have used the next_time parameter in the " << block_name
-            << " output block. This parameter is deprecated. Instead change"
-            << " the output cadence with dt." << std::endl;
-        PARTHENON_THROW(msg);
-      }
-      if (pin->DoesParameterExist(block_name, "next_n")) {
-        std::stringstream msg;
-        msg << "You have used the next_n parameter in the " << block_name
-            << " output block. This parameter is deprecated. Instead change"
-            << " the output cadence with dn." << std::endl;
-        PARTHENON_THROW(msg);
-      }
-
       // these are used for book-keeping
       block_names.push_back(block_name);
       block_numbers.push_back(atoi(outn.c_str()));
@@ -81,14 +67,30 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       // is that we want to ensure a first output is performed.
       last_times.push_back(std::numeric_limits<Real>::lowest());
       last_ns.push_back(std::numeric_limits<int>::lowest());
+
+      bool next_time_exists = pin->DoesParameterExist(block_name, "next_time");
+      bool next_n_exists = pin->DoesParameterExist(block_name, "next_n");
+      if (next_time_exists || next_n_exists) {
+        std::stringstream msg;
+        msg << "You have used the next_time or next_n parameter in the " << block_name
+            << " output block. This parameter is deprecated. Instead change"
+            << " the output cadence with dt or dn." << std::endl;
+        if (Globals::is_restart) {
+          if (Globals::my_rank == 0) {
+            PARTHENON_WARN(msg);
+          }
+        } else {
+          PARTHENON_THROW(msg);
+        }
+      }
     }
   }
   pkg->AddParam("block_names", block_names);
   pkg->AddParam("block_numbers", block_numbers);
-  pkg->AddParam("active", active, Params::Mutability::Restart);
-  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::Restart);
-  pkg->AddParam("last_times", last_times, Params::Mutability::Restart);
-  pkg->AddParam("last_ns", last_ns, Params::Mutability::Restart);
+  pkg->AddParam("active", active, Params::Mutability::MaybeRestart);
+  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::MaybeRestart);
+  pkg->AddParam("last_times", last_times, Params::Mutability::MaybeRestart);
+  pkg->AddParam("last_ns", last_ns, Params::Mutability::MaybeRestart);
 
   return pkg;
 }

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -73,6 +73,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                                       const SignalHandler::OutputSignal signal) {
   using namespace HDF5;
   using namespace OutputUtils;
+  // modify HDF5 error handling to throw an error
+  H5Eset_auto(H5E_DEFAULT, aborting_error_handler, NULL);
 
   if constexpr (WRITE_SINGLE_PRECISION) {
     Kokkos::Profiling::pushRegion("PHDF5::WriteOutputFileSinglePrec");

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -67,6 +67,12 @@
 namespace parthenon {
 namespace HDF5 {
 
+inline herr_t aborting_error_handler(hid_t stack, void *client_data) {
+  H5Eprint2(stack, stderr);
+  PARTHENON_THROW("HDF5 error detected! Erroring out\n");
+  return -1;
+}
+
 hid_t GenerateFileAccessProps();
 H5G MakeGroup(hid_t file, const std::string &name);
 

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -50,6 +50,8 @@ RestartReaderHDF5::RestartReaderHDF5(const char *filename) : filename_(filename)
       << "is required for restarts" << std::endl;
   PARTHENON_FAIL(msg);
 #else  // HDF5 enabled
+  // modify HDF5 error handling to throw an error
+  H5Eset_auto(H5E_DEFAULT, HDF5::aborting_error_handler, NULL);
   // Open the HDF file in read only mode
   fh_ = H5F::FromHIDCheck(H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT));
   params_group_ = H5G::FromHIDCheck(H5Oopen(fh_, "Params", H5P_DEFAULT));

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -934,6 +934,28 @@ std::string ParameterInput::SetString(const std::string &block, const std::strin
   return value;
 }
 
+void ParameterInput::RemoveParameter(const std::string &block, const std::string &name) {
+  InputBlock *pb = GetPtrToBlock(block);
+  InputLine *plast = pb->pline;
+  bool deleted = false;
+  for (InputLine *pl = pb->pline; pl != nullptr; pl = pl->pnext) {
+    if (name.compare(pl->param_name) == 0) {
+      plast->pnext = pl->pnext;
+      delete pl;
+      deleted = true;
+      break;
+    }
+    plast = pl;
+  }
+  if (deleted) {
+    auto key = std::make_pair(block, name);
+    auto it = queries_.find(key);
+    if (it != queries_.end()) {
+      queries_.erase(it);
+    }
+  }
+}
+
 void ParameterInput::CheckRequired(const std::string &block, const std::string &name) {
   bool missing = true;
   if (DoesParameterExist(block, name)) {

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -275,6 +275,7 @@ class ParameterInput {
     SetQueryDependency_(block, name, ref);
     return ret;
   }
+  void RemoveParameter(const std::string &block, const std::string &name);
   void CheckRequired(const std::string &block, const std::string &name);
   void CheckDesired(const std::string &block, const std::string &name);
   void CheckOrphans() const;

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -176,3 +176,25 @@ TEST_CASE("Parameter inputs can be hashed and hashing provides useful sanity che
     }
   }
 }
+
+TEST_CASE("Test deleting parameters from ParameterInput", "[ParameterInput]") {
+  GIVEN("A ParameterInput object already populated") {
+    ParameterInput in;
+    std::stringstream ss;
+    ss << "<block1>" << std::endl
+       << "var1 = 0   # comment" << std::endl
+       << "<block2>" << std::endl
+       << "var2 = 2"
+       << std::endl
+
+              std::istringstream s(ss.str());
+    in.LoadFromStream(s);
+
+    THEN("block1/var1 exists") { REQUIRE(in.DoesParameterExist("block1", "var1")); }
+
+    WHEN("We delete a parameter") {
+      in.RemoveParameter("block1", "var1");
+      THEN("It no longer exists") { REQUIRE(!in.DoesParameterExist("block1", "var1")); }
+    }
+  }
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This resolves #1293 . As @pgrete reported, #1266 breaks restarts from old runs, where `next_n` or `next_time` were present in the input file. To resolve, I do three things:
1. I add `Mutability::MaybeRestart` which doesn't error out if a param that should be restarted from isn't present. Instead a warning is printed and the code continues. (I do this by changing the error handling in HDF5 to be a bit more exception-ey and then using a try catch block. One could instead check for existence and then read if it exists. This seemed easier. I could be convinced to drop try-catch though.)
2. I modify the outputs logic to warn if `next_n` or `next_time` are present (upon restart, it still errors out if it's a new simulation) and compute the new values for `last_n` and `last_time` from them if they exist. To make it so this error doesn't keep happening, I also delete these from the parameter input object so that on new restart the new format is present, not the old one. Note (sorry @bprather ) this touches the inputs again so it needs to be fused with TOML, again. It's a pretty minor fix though. The TOML version will be much simpler.

This is WIP because I think these changes are kind of gross and I want feedback. But this is basically ready for review, and I can update the changelog and merge it if people like it.

One more outstanding question regarding this machinery: Should the output version be bumped? That would require an upgold. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
