### PR TITLE
Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, ,`is_restart`) 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, `is_restart`)
-- [[PR 1289]](https://github.com/parthenon-hpc-lab/parthenon/pull/1289) Fix a bug in 1214
 - [[PR 1291]](https://github.com/parthenon-hpc-lab/parthenon/pull/1291) Fix provenance for downstream codes 
 - [[PR 1289]](https://github.com/parthenon-hpc-lab/parthenon/pull/1289) Fix a bug in 1214
 - [[PR 1214]](https://github.com/parthenon-hpc-lab/parthenon/pull/1214) Initialize MPI in catch2 to prevent errors when constructing Meshes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, `is_restart`)
+- [[PR 1289]](https://github.com/parthenon-hpc-lab/parthenon/pull/1289) Fix a bug in 1214
 - [[PR 1291]](https://github.com/parthenon-hpc-lab/parthenon/pull/1291) Fix provenance for downstream codes 
 - [[PR 1289]](https://github.com/parthenon-hpc-lab/parthenon/pull/1289) Fix a bug in 1214
 - [[PR 1214]](https://github.com/parthenon-hpc-lab/parthenon/pull/1214) Initialize MPI in catch2 to prevent errors when constructing Meshes
@@ -37,6 +39,7 @@
 
 ### Incompatibilities (i.e. breaking changes)
 - [[PR 1253]](https://github.com/parthenon-hpc-lab/parthenon/pull/1253) Add support for uint64 swarm variables and add default id
+- [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) `pmesh->is_restart` removed in favor of `Globals::is_restart`
 
 
 

--- a/doc/sphinx/src/interface/state.rst
+++ b/doc/sphinx/src/interface/state.rst
@@ -121,8 +121,8 @@ several useful features and functions.
   has been generated, (2) problem generators are called, and (3) comms
   are executed, but before any time evolution. This work is done both on
   first initialization and on restart. If you would like to avoid doing the
-  work upon restart, you can check for the const ``is_restart`` member
-  field of the ``Mesh`` object.  It is worth making a clear distinction
+  work upon restart, you can check the ``Globals::is_restart`` variable.
+  It is worth making a clear distinction
   between ``UserWorkBeforeLoopMesh`` and ``ApplicationInput``s
   ``PostInitialization``.  ``PostInitialization`` is very much so tied to
   initialization, and will not be called upon restarts.  ``PostInitialization``

--- a/example/advection/advection_package.cpp
+++ b/example/advection/advection_package.cpp
@@ -249,7 +249,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 void AdvectionGreetings(Mesh *pmesh, ParameterInput *pin, parthenon::SimTime &tm) {
   if (parthenon::Globals::my_rank == 0) {
     std::cout << "Hello from the advection package in the advection example!\n"
-              << "This run is a restart: " << pmesh->is_restart << "\n"
+              << "This run is a restart: " << parthenon::Globals::is_restart << "\n"
               << std::endl;
   }
 }

--- a/example/diffusion/diffusion_driver.hpp
+++ b/example/diffusion/diffusion_driver.hpp
@@ -37,8 +37,6 @@ class DiffusionDriver : public EvolutionDriver {
 
   // DriverStatus Execute() override;
 
-  Real final_rms_error, final_rms_residual;
-
  private:
   LowStorageIntegrator integrator;
 };

--- a/example/diffusion/main.cpp
+++ b/example/diffusion/main.cpp
@@ -48,11 +48,7 @@ int main(int argc, char *argv[]) {
 
     // This line actually runs the simulation
     auto driver_status = driver.Execute();
-    if (driver_status != parthenon::DriverStatus::complete ||
-        driver.final_rms_residual > 1.e-10 || driver.final_rms_error > 1.e-12)
-      success = false;
-    if (driver.final_rms_residual != driver.final_rms_residual) success = false;
-    if (driver.final_rms_error != driver.final_rms_error) success = false;
+    success = (driver_status != parthenon::DriverStatus::complete);
   }
   // call MPI_Finalize and Kokkos::finalize if necessary
   pman.ParthenonFinalize();

--- a/example/diffusion/main.cpp
+++ b/example/diffusion/main.cpp
@@ -48,7 +48,7 @@ int main(int argc, char *argv[]) {
 
     // This line actually runs the simulation
     auto driver_status = driver.Execute();
-    success = (driver_status != parthenon::DriverStatus::complete);
+    success = (driver_status == parthenon::DriverStatus::complete);
   }
   // call MPI_Finalize and Kokkos::finalize if necessary
   pman.ParthenonFinalize();

--- a/example/poisson_gmg/poisson_driver.hpp
+++ b/example/poisson_gmg/poisson_driver.hpp
@@ -27,7 +27,7 @@ using namespace parthenon::driver::prelude;
 class PoissonDriver : public Driver {
  public:
   PoissonDriver(ParameterInput *pin, ApplicationInput *app_in, Mesh *pm)
-      : Driver(pin, app_in, pm) {
+      : Driver(pin, app_in, pm), final_rms_error(0.0), final_rms_residual(0.0) {
     InitializeOutputs();
   }
   // This next function essentially defines the driver.

--- a/src/argument_parser.hpp
+++ b/src/argument_parser.hpp
@@ -51,12 +51,12 @@ class ArgParse {
           break;
         case 'r': // -r <restart_file>
           invalid = invalid_arg();
-          res_flag = 1;
+          is_restart = true;
           restart_filename = argv[++i];
           break;
         case 'a': // -a <restart_file>
           invalid = invalid_arg();
-          res_flag = 1;
+          is_restart = true;
           analysis_flag = true;
           restart_filename = argv[++i];
           break;
@@ -135,7 +135,7 @@ class ArgParse {
   char *prundir = nullptr;
   char *params_regex = nullptr;
   bool analysis_flag = false;
-  int res_flag = 0;
+  bool is_restart = false;
   int param_flag = 0;
   int mesh_flag = 0;
   int wtlim = 0;

--- a/src/argument_parser.hpp
+++ b/src/argument_parser.hpp
@@ -1,4 +1,8 @@
 //========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2021-2025 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
 // (C) (or copyright) 2021-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -71,21 +71,19 @@ void Driver::PreExecute() {
       pinput->GetOrAddBoolean("parthenon/job", "check_orphans", true,
                               "Print a warning if any parameters are in the input deck "
                               "but not used in the code. Only active for new runs.");
-  bool force_check_orphans =
-      pinput->GetOrAddBoolean("parthenon/job", "force_check_orphans", false,
-                              "Print a warning if any parameters are in the input deck "
-                              "but not used in the code. Forces this output on restart.");
+  bool force_check_orphans = pinput->GetOrAddBoolean(
+      "parthenon/job", "force_check_orphans", false,
+      "Print a warning if any parameters are in the input deck "
+      "but not used in the code. Forces this output even on restart.");
   // Output a text file of all parameters at this point
   // Optionally also dump to console
   DumpInputParameters();
 
   if (Globals::my_rank == 0) {
-    if ((Globals::is_restart && force_check_orphans) ||
-        (!Globals::is_restart && check_orphans)) {
+    if (force_check_orphans || (!Globals::is_restart && check_orphans)) {
       pinput->CheckOrphans();
     }
-    if (check_orphans && !Globals::is_restart)
-      std::cout << "# Variables in use:\n" << *(pmesh->resolved_packages) << std::endl;
+    std::cout << "# Variables in use:\n" << *(pmesh->resolved_packages) << std::endl;
     std::cout << std::endl;
     std::cout << "Setup complete, executing driver...\n" << std::endl;
   }

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -67,17 +67,25 @@ void Driver::DumpInputParameters() {
 }
 
 void Driver::PreExecute() {
-  bool check_orphans = pinput->GetOrAddBoolean(
-      "parthenon/job", "check_orphans", !Globals::is_restart,
-      "Print a warning if any parameters are in the input deck but not used in the code. "
-      "Defaults to true for new runs and false for restarts");
+  bool check_orphans =
+      pinput->GetOrAddBoolean("parthenon/job", "check_orphans", true,
+                              "Print a warning if any parameters are in the input deck "
+                              "but not used in the code. Only active for new runs.");
+  bool force_check_orphans =
+      pinput->GetOrAddBoolean("parthenon/job", "force_check_orphans", false,
+                              "Print a warning if any parameters are in the input deck "
+                              "but not used in the code. Forces this output on restart.");
   // Output a text file of all parameters at this point
   // Optionally also dump to console
   DumpInputParameters();
 
   if (Globals::my_rank == 0) {
-    if (check_orphans) pinput->CheckOrphans();
-    std::cout << "# Variables in use:\n" << *(pmesh->resolved_packages) << std::endl;
+    if ((Globals::is_restart && force_check_orphans) ||
+        (!Globals::is_restart && check_orphans)) {
+      pinput->CheckOrphans();
+    }
+    if (check_orphans && !Globals::is_restart)
+      std::cout << "# Variables in use:\n" << *(pmesh->resolved_packages) << std::endl;
     std::cout << std::endl;
     std::cout << "Setup complete, executing driver...\n" << std::endl;
   }

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -67,20 +67,19 @@ void Driver::DumpInputParameters() {
 }
 
 void Driver::PreExecute() {
-  bool check_orphans =
-      pinput->GetOrAddBoolean("parthenon/job", "check_orphans", true,
-                              "Print a warning if any parameters are in the input deck "
-                              "but not used in the code. Only active for new runs.");
-  bool force_check_orphans = pinput->GetOrAddBoolean(
-      "parthenon/job", "force_check_orphans", false,
-      "Print a warning if any parameters are in the input deck "
-      "but not used in the code. Forces this output even on restart.");
+  std::string check_orphans = pinput->GetOrAddString(
+      "parthenon/job", "check_orphans", "initially",
+      std::vector<std::string>{"always", "initially", "never"},
+      "Print a warning if any parameters are in the input deck but not used in the code. "
+      "By default this check is performed for new runs, but can also be enabled for "
+      "restarts or completely disabled.");
   // Output a text file of all parameters at this point
   // Optionally also dump to console
   DumpInputParameters();
 
   if (Globals::my_rank == 0) {
-    if (force_check_orphans || (!Globals::is_restart && check_orphans)) {
+    if ((check_orphans == "always") ||
+        (!Globals::is_restart && (check_orphans == "initially"))) {
       pinput->CheckOrphans();
     }
     std::cout << "# Variables in use:\n" << *(pmesh->resolved_packages) << std::endl;

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -68,8 +68,9 @@ void Driver::DumpInputParameters() {
 
 void Driver::PreExecute() {
   bool check_orphans = pinput->GetOrAddBoolean(
-      "parthenon/job", "check_orphans", true,
-      "print a warning if any parameters are in the input deck but not used in the code");
+      "parthenon/job", "check_orphans", !Globals::is_restart,
+      "Print a warning if any parameters are in the input deck but not used in the code. "
+      "Defaults to true for new runs and false for restarts");
   // Output a text file of all parameters at this point
   // Optionally also dump to console
   DumpInputParameters();

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -1,6 +1,6 @@
 //========================================================================================
-// Athena++ astrophysical MHD code
-// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Parthenon performance portable AMR framework
+// Copyright(C) 2020-2025 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
 // (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
@@ -32,8 +32,9 @@ namespace Globals {
 int nghost;
 
 // all of these global variables are set at the start of main():
-int my_rank; // MPI rank of this process
-int nranks;  // total number of MPI ranks
+int my_rank;     // MPI rank of this process
+int nranks;      // total number of MPI ranks
+bool is_restart; // Whether this simulation is restarted from a checkpoint file
 
 // sparse configuration values that are needed in various places
 SparseConfig sparse_config;

--- a/src/globals.cpp
+++ b/src/globals.cpp
@@ -32,9 +32,8 @@ namespace Globals {
 int nghost;
 
 // all of these global variables are set at the start of main():
-int my_rank;     // MPI rank of this process
-int nranks;      // total number of MPI ranks
-bool is_restart; // Whether this simulation is restarted from a checkpoint file
+int my_rank; // MPI rank of this process
+int nranks;  // total number of MPI ranks
 
 // sparse configuration values that are needed in various places
 SparseConfig sparse_config;

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -38,7 +38,6 @@ struct SparseConfig {
 };
 
 extern int my_rank, nranks, nghost;
-extern bool is_restart;
 
 extern SparseConfig sparse_config;
 

--- a/src/globals.hpp
+++ b/src/globals.hpp
@@ -1,6 +1,6 @@
 //========================================================================================
-// Athena++ astrophysical MHD code
-// Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+// Parthenon performance portable AMR framework
+// Copyright(C) 2020-2025 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
 // (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
@@ -38,6 +38,7 @@ struct SparseConfig {
 };
 
 extern int my_rank, nranks, nghost;
+extern bool is_restart;
 
 extern SparseConfig sparse_config;
 

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -58,25 +58,19 @@ void Params::ReadFromHDF5AllParamsOfType(const std::string &prefix,
                                          const HDF5::H5G &group) {
   for (auto &[key, pparam] : myParams_) {
     if (std::type_index(pparam->type()) == std::type_index(typeid(T)) &&
-        IsRestartable(key)) {
-      auto mutability = myMutable_.at(key);
+        GetMutability(key) == Mutability::Restart) {
       auto typed_ptr = std::any_cast<T>(pparam.get());
       auto &val = *typed_ptr;
       std::string fullpath = prefix + "/" + key;
-      if (mutability == Mutability::Restart) {
+      try {
         HDF5::HDF5ReadAttribute(group, fullpath, val);
         Update(key, val);
-      } else if (mutability == Mutability::MaybeRestart) {
-        try {
-          HDF5::HDF5ReadAttribute(group, fullpath, val);
-          Update(key, val);
-        } catch (std::runtime_error e) {
-          if (Globals::my_rank == 0) {
-            std::stringstream ss;
-            ss << "Failed to load parameter " << fullpath
-               << " from the restart file! Using default value." << std::endl;
-            PARTHENON_WARN(ss);
-          }
+      } catch (std::runtime_error e) {
+        if (Globals::my_rank == 0) {
+          std::stringstream ss;
+          ss << "Failed to load parameter " << fullpath
+             << " from the restart file! Using default value." << std::endl;
+          PARTHENON_WARN(ss);
         }
       }
     }

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -66,6 +66,7 @@ void Params::ReadFromHDF5AllParamsOfType(const std::string &prefix,
         HDF5::HDF5ReadAttribute(group, fullpath, val);
         Update(key, val);
       } catch (std::runtime_error e) {
+        // TODO(JMM/PG) Add failed load list of "fail/needs fix" list
         if (Globals::my_rank == 0) {
           std::stringstream ss;
           ss << "Failed to load parameter " << fullpath

--- a/src/interface/params.cpp
+++ b/src/interface/params.cpp
@@ -11,10 +11,12 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+#include <sstream>
 #include <string>
 
 #include "utils/error_checking.hpp"
 
+#include "globals.hpp"
 #include "kokkos_abstraction.hpp"
 #include "parthenon_arrays.hpp"
 
@@ -55,13 +57,28 @@ template <typename T>
 void Params::ReadFromHDF5AllParamsOfType(const std::string &prefix,
                                          const HDF5::H5G &group) {
   for (auto &[key, pparam] : myParams_) {
-    auto mutability = myMutable_.at(key);
     if (std::type_index(pparam->type()) == std::type_index(typeid(T)) &&
-        mutability == Mutability::Restart) {
+        IsRestartable(key)) {
+      auto mutability = myMutable_.at(key);
       auto typed_ptr = std::any_cast<T>(pparam.get());
       auto &val = *typed_ptr;
-      HDF5::HDF5ReadAttribute(group, prefix + "/" + key, val);
-      Update(key, val);
+      std::string fullpath = prefix + "/" + key;
+      if (mutability == Mutability::Restart) {
+        HDF5::HDF5ReadAttribute(group, fullpath, val);
+        Update(key, val);
+      } else if (mutability == Mutability::MaybeRestart) {
+        try {
+          HDF5::HDF5ReadAttribute(group, fullpath, val);
+          Update(key, val);
+        } catch (std::runtime_error e) {
+          if (Globals::my_rank == 0) {
+            std::stringstream ss;
+            ss << "Failed to load parameter " << fullpath
+               << " from the restart file! Using default value." << std::endl;
+            PARTHENON_WARN(ss);
+          }
+        }
+      }
     }
   }
 }

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -39,7 +39,12 @@ class Params {
   // Immutable is default. Mutable is it can be updated at runtime.
   // Restart is a subset of mutable. Param not only can be updated at
   // runtime, but should be read from the restart file upon restart.
-  enum class Mutability : int { Immutable = 0, Mutable = 1, Restart = 2 };
+  enum class Mutability : int {
+    Immutable = 0,
+    Mutable = 1,
+    Restart = 2,
+    MaybeRestart = 3
+  };
 
   Params() {}
 
@@ -66,7 +71,7 @@ class Params {
   void Update(const std::string &key, T value) {
     PARTHENON_REQUIRE_THROWS((hasKey(key)), "Key " + key + "missing.");
     // immutable casts to false all others cast to true
-    PARTHENON_REQUIRE_THROWS(static_cast<bool>(myMutable_.at(key)),
+    PARTHENON_REQUIRE_THROWS(IsMutable(key),
                              "Parameter " + key + " must be marked as mutable");
     PARTHENON_REQUIRE_THROWS(std::type_index(myParams_.at(key)->type()) ==
                                  std::type_index(typeid(T)),
@@ -128,6 +133,16 @@ class Params {
       keys.push_back(x.first);
     }
     return keys;
+  }
+
+  auto GetMutability(const std::string &key) const { return myMutable_.at(key); }
+  bool IsMutable(const std::string &key) const {
+    return static_cast<bool>(myMutable_.at(key));
+  }
+  bool IsRestartable(const std::string &key) const {
+    auto mutability = myMutable_.at(key);
+    return (mutability == Mutability::Restart) ||
+           (mutability == Mutability::MaybeRestart);
   }
 
   // void Params::

--- a/src/interface/params.hpp
+++ b/src/interface/params.hpp
@@ -39,12 +39,7 @@ class Params {
   // Immutable is default. Mutable is it can be updated at runtime.
   // Restart is a subset of mutable. Param not only can be updated at
   // runtime, but should be read from the restart file upon restart.
-  enum class Mutability : int {
-    Immutable = 0,
-    Mutable = 1,
-    Restart = 2,
-    MaybeRestart = 3
-  };
+  enum class Mutability : int { Immutable = 0, Mutable = 1, Restart = 2 };
 
   Params() {}
 
@@ -138,11 +133,6 @@ class Params {
   auto GetMutability(const std::string &key) const { return myMutable_.at(key); }
   bool IsMutable(const std::string &key) const {
     return static_cast<bool>(myMutable_.at(key));
-  }
-  bool IsRestartable(const std::string &key) const {
-    auto mutability = myMutable_.at(key);
-    return (mutability == Mutability::Restart) ||
-           (mutability == Mutability::MaybeRestart);
   }
 
   // void Params::

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -64,7 +64,7 @@ namespace parthenon {
 Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
            base_constructor_selector_t)
     : // public members:
-      modified(true), is_restart(false),
+      modified(true),
       adaptive(pin->GetOrAddString("parthenon/mesh", "refinement", "none",
                                    std::vector<std::string>{"none", "static", "adaptive"},
                                    "mesh refinement mode") == "adaptive"
@@ -246,7 +246,6 @@ Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, Packages_t &packages,
 Mesh::Mesh(ParameterInput *pin, ApplicationInput *app_in, RestartReader &rr,
            Packages_t &packages, int mesh_test)
     : Mesh(pin, app_in, packages, hyper_rectangular_constructor_selector_t()) {
-  is_restart = true;
   std::stringstream msg;
 
   // mesh test

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -121,7 +121,6 @@ class Mesh {
 
   // data
   bool modified;
-  bool is_restart;
   RegionSize mesh_size;
   RegionSize base_block_size;
 

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -145,12 +145,13 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       bool next_n_exists = pin->DoesParameterExist(op.block_name, "next_n");
       if (next_time_exists) {
         Real next_time = pin->GetReal(op.block_name, "next_time");
-        (*plast_times)[iinput] = next_time - dt;
+        (*plast_times)[iinput] = dt < 0 ? 0.0 : next_time - dt;
         pin->RemoveParameter(op.block_name, "next_time");
       }
       if (next_n_exists) {
         int next_n = pin->GetInteger(op.block_name, "next_n");
-        (*plast_ns)[iinput] = next_n - dn;
+
+        (*plast_ns)[iinput] = dn < 0 ? 0 : next_n - dn;
         pin->RemoveParameter(op.block_name, "next_n");
       }
       if (next_time_exists || next_n_exists) {

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -140,7 +140,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
 
     // JMM: Backwards compatibility hack. Don't allow this unless
     // we're restarting from a legacy file format.
-    if (pm->is_restart) {
+    if (parthenon::Globals::is_restart) {
       bool next_time_exists = pin->DoesParameterExist(op.block_name, "next_time");
       bool next_n_exists = pin->DoesParameterExist(op.block_name, "next_n");
       if (next_time_exists) {
@@ -185,7 +185,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
         signaling number. However, I think the flag is less fraught.
       */
       if (dt >= 0) {
-        // TODO(JMM): Should this be a check for pmesh->is_restart instead?
+        // TODO(JMM): Should this be a check for Globals::is_restart instead?
         if (op.last_time > std::numeric_limits<Real>::lowest()) {
           op.next_time = op.last_time + dt;
         } else {
@@ -193,7 +193,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
         }
       }
       if (dn >= 0) {
-        // TODO(JMM): Should this be a check for pmesh->is_restart instead?
+        // TODO(JMM): Should this be a check for Globals::is_restart instead?
         if (op.last_n > std::numeric_limits<int>::lowest()) {
           op.next_n = op.last_n + dn;
         } else {

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -140,7 +140,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
 
     // JMM: Backwards compatibility hack. Don't allow this unless
     // we're restarting from a legacy file format.
-    if (Globals::is_restart) { // should this be pmesh->is_restart?
+    if (pm->is_restart) {
       bool next_time_exists = pin->DoesParameterExist(op.block_name, "next_time");
       bool next_n_exists = pin->DoesParameterExist(op.block_name, "next_n");
       if (next_time_exists) {

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -138,6 +138,27 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       (*pactive)[iinput] = true;
     }
 
+    // JMM: Backwards compatibility hack. Don't allow this unless
+    // we're restarting from a legacy file format.
+    if (Globals::is_restart) { // should this be pmesh->is_restart?
+      bool next_time_exists = pin->DoesParameterExist(op.block_name, "next_time");
+      bool next_n_exists = pin->DoesParameterExist(op.block_name, "next_n");
+      if (next_time_exists) {
+        Real next_time = pin->GetReal(op.block_name, "next_time");
+        (*plast_times)[iinput] = next_time - dt;
+        pin->RemoveParameter(op.block_name, "next_time");
+      }
+      if (next_n_exists) {
+        int next_n = pin->GetInteger(op.block_name, "next_n");
+        (*plast_ns)[iinput] = next_n - dn;
+        pin->RemoveParameter(op.block_name, "next_n");
+      }
+      if (next_time_exists || next_n_exists) {
+        (*pfile_numbers)[iinput] = pin->GetOrAddInteger(op.block_name, "file_number", 0);
+        pin->RemoveParameter(op.block_name, "file_number");
+      }
+    }
+
     PARTHENON_REQUIRE_THROWS(!(dt >= 0.0 && dn >= 0),
                              "dt and dn are enabled for the same output block, which "
                              "is not supported. Please set at most one value >= 0.");

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "globals.hpp"
 #include "interface/state_descriptor.hpp"
 #include "outputs/outputs_package.hpp"
 #include "parameter_input.hpp"
@@ -53,21 +54,6 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       std::string outn = pib->block_name.substr(16); // 6 because counting starts at 0!
       std::string block_name = pib->block_name;
 
-      if (pin->DoesParameterExist(block_name, "next_time")) {
-        std::stringstream msg;
-        msg << "You have used the next_time parameter in the " << block_name
-            << " output block. This parameter is deprecated. Instead change"
-            << " the output cadence with dt." << std::endl;
-        PARTHENON_THROW(msg);
-      }
-      if (pin->DoesParameterExist(block_name, "next_n")) {
-        std::stringstream msg;
-        msg << "You have used the next_n parameter in the " << block_name
-            << " output block. This parameter is deprecated. Instead change"
-            << " the output cadence with dn." << std::endl;
-        PARTHENON_THROW(msg);
-      }
-
       // these are used for book-keeping
       block_names.push_back(block_name);
       block_numbers.push_back(atoi(outn.c_str()));
@@ -81,14 +67,30 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
       // is that we want to ensure a first output is performed.
       last_times.push_back(std::numeric_limits<Real>::lowest());
       last_ns.push_back(std::numeric_limits<int>::lowest());
+
+      bool next_time_exists = pin->DoesParameterExist(block_name, "next_time");
+      bool next_n_exists = pin->DoesParameterExist(block_name, "next_n");
+      if (next_time_exists || next_n_exists) {
+        std::stringstream msg;
+        msg << "You have used the next_time or next_n parameter in the " << block_name
+            << " output block. This parameter is deprecated. Instead change"
+            << " the output cadence with dt or dn." << std::endl;
+        if (Globals::is_restart) {
+          if (Globals::my_rank == 0) {
+            PARTHENON_WARN(msg);
+          }
+        } else {
+          PARTHENON_THROW(msg);
+        }
+      }
     }
   }
   pkg->AddParam("block_names", block_names);
   pkg->AddParam("block_numbers", block_numbers);
-  pkg->AddParam("active", active, Params::Mutability::Restart);
-  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::Restart);
-  pkg->AddParam("last_times", last_times, Params::Mutability::Restart);
-  pkg->AddParam("last_ns", last_ns, Params::Mutability::Restart);
+  pkg->AddParam("active", active, Params::Mutability::MaybeRestart);
+  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::MaybeRestart);
+  pkg->AddParam("last_times", last_times, Params::Mutability::MaybeRestart);
+  pkg->AddParam("last_ns", last_ns, Params::Mutability::MaybeRestart);
 
   return pkg;
 }

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -34,7 +34,7 @@ namespace parthenon {
 
 namespace OutputsPackage {
 
-std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
+std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, const bool is_restart) {
   auto pkg = std::make_shared<StateDescriptor>("Outputs");
 
   std::string basename = pin->GetOrAddString("parthenon/job", "problem_id", "parthenon",
@@ -75,7 +75,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
         msg << "You have used the next_time or next_n parameter in the " << block_name
             << " output block. This parameter is deprecated. Instead change"
             << " the output cadence with dt or dn." << std::endl;
-        if (Globals::is_restart) {
+        if (is_restart) {
           if (Globals::my_rank == 0) {
             msg << "The parameters will automatically be updated internally and the "
                    "warning should not be shown for subsequent "

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -34,7 +34,7 @@ namespace parthenon {
 
 namespace OutputsPackage {
 
-std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, const bool is_restart) {
+std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto pkg = std::make_shared<StateDescriptor>("Outputs");
 
   std::string basename = pin->GetOrAddString("parthenon/job", "problem_id", "parthenon",
@@ -75,7 +75,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, const bool is_r
         msg << "You have used the next_time or next_n parameter in the " << block_name
             << " output block. This parameter is deprecated. Instead change"
             << " the output cadence with dt or dn." << std::endl;
-        if (is_restart) {
+        if (parthenon::Globals::is_restart) {
           if (Globals::my_rank == 0) {
             msg << "The parameters will automatically be updated internally and the "
                    "warning should not be shown for subsequent "

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -77,6 +77,9 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
             << " the output cadence with dt or dn." << std::endl;
         if (Globals::is_restart) {
           if (Globals::my_rank == 0) {
+            msg << "The parameters will automatically be updated internally and the "
+                   "warning should not be shown for subsequent "
+                   "restarts.\n";
             PARTHENON_WARN(msg);
           }
         } else {
@@ -87,10 +90,10 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   }
   pkg->AddParam("block_names", block_names);
   pkg->AddParam("block_numbers", block_numbers);
-  pkg->AddParam("active", active, Params::Mutability::MaybeRestart);
-  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::MaybeRestart);
-  pkg->AddParam("last_times", last_times, Params::Mutability::MaybeRestart);
-  pkg->AddParam("last_ns", last_ns, Params::Mutability::MaybeRestart);
+  pkg->AddParam("active", active, Params::Mutability::Restart);
+  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::Restart);
+  pkg->AddParam("last_times", last_times, Params::Mutability::Restart);
+  pkg->AddParam("last_ns", last_ns, Params::Mutability::Restart);
 
   return pkg;
 }

--- a/src/outputs/outputs_package.hpp
+++ b/src/outputs/outputs_package.hpp
@@ -31,7 +31,7 @@ class StateDescriptor;
 
 namespace OutputsPackage {
 
-std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
+std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, bool is_restart);
 
 } // namespace OutputsPackage
 } // namespace parthenon

--- a/src/outputs/outputs_package.hpp
+++ b/src/outputs/outputs_package.hpp
@@ -31,7 +31,7 @@ class StateDescriptor;
 
 namespace OutputsPackage {
 
-std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin, bool is_restart);
+std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 
 } // namespace OutputsPackage
 } // namespace parthenon

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -585,9 +585,11 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                   local_count, global_count, pl_xfer, H5P_DEFAULT);
     }
 
-    // If swarm does not contain the default id object, generate a sequential
-    // one for vis called "id" (to differentiate between the default one)
-    if (swinfo.var_info.count(swarm_position::id::name()) == 0) {
+    // If swarm does not contain the default id object nor a custom one called "id",
+    // generate a sequential one for vis called "id" (to differentiate between the default
+    // one)
+    if (swinfo.var_info.count(swarm_position::id::name()) == 0 &&
+        swinfo.var_info.count("id") == 0) {
       std::vector<int> ids(swinfo.global_count);
       std::iota(std::begin(ids), std::end(ids), swinfo.global_offset);
       local_offset[0] = swinfo.global_offset;

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -73,6 +73,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
                                       const SignalHandler::OutputSignal signal) {
   using namespace HDF5;
   using namespace OutputUtils;
+  // modify HDF5 error handling to throw an error
+  H5Eset_auto(H5E_DEFAULT, aborting_error_handler, NULL);
 
   if constexpr (WRITE_SINGLE_PRECISION) {
     Kokkos::Profiling::pushRegion("PHDF5::WriteOutputFileSinglePrec");

--- a/src/outputs/parthenon_hdf5.hpp
+++ b/src/outputs/parthenon_hdf5.hpp
@@ -67,6 +67,12 @@
 namespace parthenon {
 namespace HDF5 {
 
+inline herr_t aborting_error_handler(hid_t stack, void *client_data) {
+  H5Eprint2(stack, stderr);
+  PARTHENON_THROW("HDF5 error detected! Erroring out\n");
+  return -1;
+}
+
 hid_t GenerateFileAccessProps();
 H5G MakeGroup(hid_t file, const std::string &name);
 

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -249,9 +249,10 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
         ParticleVariableRef(pxdmf, varname, varinfo, swmname, hdfFile,
                             swminfo.global_count);
       }
-      // Write info for default (auto-generated) "id"s in case there's not native id field
-      // for the given swarm.
-      if (swminfo.var_info.count(swarm_position::id::name()) == 0) {
+      // Write info for default (auto-generated) "id"s in case there's no native id field
+      // for the given swarm nor a custom "id" field.
+      if (swminfo.var_info.count(swarm_position::id::name()) == 0 &&
+          swminfo.var_info.count("id") == 0) {
         auto swid = SwarmVarInfo(1, 1, 1, 1, 1, 0, "Int", false);
         ParticleVariableRef(pxdmf, "id", swid, swmname, hdfFile, swminfo.global_count);
       }

--- a/src/outputs/restart.hpp
+++ b/src/outputs/restart.hpp
@@ -130,6 +130,8 @@ class RestartReader {
 
   virtual void ReadParams(const std::string &name, Params &p) = 0;
 
+  [[nodiscard]] virtual bool VariableExists(const std::string &name) const = 0;
+
   // closes out the restart file
   // perhaps belongs in a destructor?
   void Close();

--- a/src/outputs/restart_hdf5.cpp
+++ b/src/outputs/restart_hdf5.cpp
@@ -50,6 +50,8 @@ RestartReaderHDF5::RestartReaderHDF5(const char *filename) : filename_(filename)
       << "is required for restarts" << std::endl;
   PARTHENON_FAIL(msg);
 #else  // HDF5 enabled
+  // modify HDF5 error handling to throw an error
+  H5Eset_auto(H5E_DEFAULT, HDF5::aborting_error_handler, NULL);
   // Open the HDF file in read only mode
   fh_ = H5F::FromHIDCheck(H5Fopen(filename, H5F_ACC_RDONLY, H5P_DEFAULT));
   params_group_ = H5G::FromHIDCheck(H5Oopen(fh_, "Params", H5P_DEFAULT));

--- a/src/outputs/restart_hdf5.hpp
+++ b/src/outputs/restart_hdf5.hpp
@@ -229,8 +229,13 @@ class RestartReaderHDF5 : public RestartReader {
   void ReadParams(const std::string &name, Params &p) override;
 
   [[nodiscard]] bool VariableExists(const std::string &name) const override {
+#ifdef ENABLE_HDF5
     // make sure dataset exists
     return PARTHENON_HDF5_CHECK(H5Oexists_by_name(fh_, name.c_str(), H5P_DEFAULT));
+#else
+    PARTHENON_FAIL("Restart functionality is not available because HDF5 is disabled");
+    return false;
+#endif // ENABLE_HDF5
   }
   // closes out the restart file
   // perhaps belongs in a destructor?

--- a/src/outputs/restart_hdf5.hpp
+++ b/src/outputs/restart_hdf5.hpp
@@ -228,6 +228,10 @@ class RestartReaderHDF5 : public RestartReader {
 
   void ReadParams(const std::string &name, Params &p) override;
 
+  [[nodiscard]] bool VariableExists(const std::string &name) const override {
+    // make sure dataset exists
+    return PARTHENON_HDF5_CHECK(H5Oexists_by_name(fh_, name.c_str(), H5P_DEFAULT));
+  }
   // closes out the restart file
   // perhaps belongs in a destructor?
   void Close();

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -940,7 +940,12 @@ void ParameterInput::RemoveParameter(const std::string &block, const std::string
   bool deleted = false;
   for (InputLine *pl = pb->pline; pl != nullptr; pl = pl->pnext) {
     if (name.compare(pl->param_name) == 0) {
-      plast->pnext = pl->pnext;
+      // if head of list
+      if (plast == pb->pline) {
+        pb->pline = pl->pnext;
+      } else {
+        plast->pnext = pl->pnext;
+      }
       delete pl;
       deleted = true;
       break;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -934,6 +934,28 @@ std::string ParameterInput::SetString(const std::string &block, const std::strin
   return value;
 }
 
+void ParameterInput::RemoveParameter(const std::string &block, const std::string &name) {
+  InputBlock *pb = GetPtrToBlock(block);
+  InputLine *plast = pb->pline;
+  bool deleted = false;
+  for (InputLine *pl = pb->pline; pl != nullptr; pl = pl->pnext) {
+    if (name.compare(pl->param_name) == 0) {
+      plast->pnext = pl->pnext;
+      delete pl;
+      deleted = true;
+      break;
+    }
+    plast = pl;
+  }
+  if (deleted) {
+    auto key = std::make_pair(block, name);
+    auto it = queries_.find(key);
+    if (it != queries_.end()) {
+      queries_.erase(it);
+    }
+  }
+}
+
 void ParameterInput::CheckRequired(const std::string &block, const std::string &name) {
   bool missing = true;
   if (DoesParameterExist(block, name)) {

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -275,6 +275,7 @@ class ParameterInput {
     SetQueryDependency_(block, name, ref);
     return ret;
   }
+  void RemoveParameter(const std::string &block, const std::string &name);
   void CheckRequired(const std::string &block, const std::string &name);
   void CheckDesired(const std::string &block, const std::string &name);
   void CheckOrphans() const;

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -457,11 +457,12 @@ class ParameterInput {
             // the new default and move on.
             record.default_value = defval.value();
             record.default_value_str = record.ToString(defval.value());
-          } else {
+          } else if (record.origin_type != QueryRecord::OriginType::Input) {
             // JMM: Forbid setting a default value after requesting but
             // allow requesting without a default if a default has
             // already been set.  I know this is unpleasantly stateful,
             // but we do this in a few places in the code.
+            // PG: but only trigger if input does not contain the info
             std::stringstream msg;
             msg << "Input parameter " << block << "/" << name
                 << " called previously without a default value and now called with one."

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -72,8 +72,6 @@ ParthenonStatus ParthenonManager::ParthenonInitEnv(int argc, char *argv[]) {
   Globals::nranks = 1;
 #endif // MPI_PARALLEL
 
-  Globals::is_restart = IsRestart();
-
   Kokkos::initialize(argc, argv);
 
   // pgrete: This is a hack to disable allocation tracking until the Kokkos
@@ -98,7 +96,7 @@ ParthenonStatus ParthenonManager::ParthenonInitEnv(int argc, char *argv[]) {
 
   // Populate the ParameterInput object.
   // If restart, then ParameterInput in the restart file takes precedence.
-  if (arg.res_flag != 0) {
+  if (arg.is_restart) {
     // Read input from restart file
     if (fs::path(arg.restart_filename).extension() == ".rhdf") {
       restartReader = std::make_unique<RestartReaderHDF5>(arg.restart_filename);
@@ -115,7 +113,7 @@ ParthenonStatus ParthenonManager::ParthenonInitEnv(int argc, char *argv[]) {
   // If an input file was provided
   if (arg.input_filename != nullptr) {
     // Modify info read from restart file
-    if (arg.res_flag != 0) {
+    if (arg.is_restart) {
       IOWrapper infile;
       infile.Open(arg.input_filename, IOWrapper::FileMode::read);
       pinput->LoadFromFile(infile);
@@ -186,10 +184,10 @@ void ParthenonManager::ParthenonInitPackagesAndMesh(
   auto packages = ProcessPackages(pinput);
   // always add the Refinement package
   packages.Add(Refinement::Initialize(pinput.get()));
-  packages.Add(OutputsPackage::Initialize(pinput.get()));
+  packages.Add(OutputsPackage::Initialize(pinput.get(), arg.is_restart));
   if (forest_def) {
     pmesh = std::make_unique<Mesh>(pinput.get(), app_input.get(), packages, *forest_def);
-  } else if (arg.res_flag == 0) {
+  } else if (!arg.is_restart) {
     pmesh =
         std::make_unique<Mesh>(pinput.get(), app_input.get(), packages, arg.mesh_flag);
   } else {
@@ -234,7 +232,7 @@ void ParthenonManager::ParthenonInitPackagesAndMesh(
     pinput->SetString("parthenon/job", "output_params_block_regex", arg.params_regex);
   }
 
-  pmesh->Initialize(!IsRestart(), pinput.get(), app_input.get());
+  pmesh->Initialize(!arg.is_restart, pinput.get(), app_input.get());
 
   ChangeRunDir(arg.prundir);
 }

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -89,6 +89,8 @@ ParthenonStatus ParthenonManager::ParthenonInitEnv(int argc, char *argv[]) {
   } else if (arg_status == ArgStatus::complete) {
     return ParthenonStatus::complete;
   }
+  // Now that the input is parsed we can pass the info to globals
+  Globals::is_restart = arg.is_restart;
 
   // Set up the signal handler
   SignalHandler::SignalHandlerInit();
@@ -184,7 +186,7 @@ void ParthenonManager::ParthenonInitPackagesAndMesh(
   auto packages = ProcessPackages(pinput);
   // always add the Refinement package
   packages.Add(Refinement::Initialize(pinput.get()));
-  packages.Add(OutputsPackage::Initialize(pinput.get(), arg.is_restart));
+  packages.Add(OutputsPackage::Initialize(pinput.get()));
   if (forest_def) {
     pmesh = std::make_unique<Mesh>(pinput.get(), app_input.get(), packages, *forest_def);
   } else if (!arg.is_restart) {

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -345,6 +345,7 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
       continue;
     }
     // Read relevant data from the hdf file, this works for dense and sparse variables
+    // because sparse variables are currently densely written for HDF5.
     try {
       resfile.ReadBlocks(label, myBlocks, v_info, tmp, file_output_format_ver);
       // Variable does exist but could not be read. So we definitely want to fail here.

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -22,6 +22,7 @@
 #include <exception>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -334,17 +335,25 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
     const auto fill_size = v_info.FillSize(theDomain);
     const auto &label = v_info.label;
 
+    auto var_missing_on_disk = !resfile.VariableExists(label);
     if (Globals::my_rank == 0) {
-      std::cout << "Var: " << label << ":" << vlen << std::endl;
+      std::cout << "Var: " << label << ":" << vlen
+                << (var_missing_on_disk ? " missing on disk\n" : "\n");
+    }
+    if (var_missing_on_disk) {
+      // TODO(JMM/PG) Add failed load list of "fail/needs fix" list
+      continue;
     }
     // Read relevant data from the hdf file, this works for dense and sparse variables
     try {
       resfile.ReadBlocks(label, myBlocks, v_info, tmp, file_output_format_ver);
+      // Variable does exist but could not be read. So we definitely want to fail here.
     } catch (std::exception &ex) {
-      std::cout << "[" << Globals::my_rank << "] WARNING: Failed to read variable "
-                << label << " from restart file:" << std::endl
-                << ex.what() << std::endl;
-      continue;
+      std::stringstream msg;
+      msg << "[" << Globals::my_rank << "] WARNING: Failed to read variable " << label
+          << " from restart file:" << std::endl
+          << ex.what() << std::endl;
+      PARTHENON_THROW(msg);
     }
 
     size_t index = 0;

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -392,8 +392,14 @@ void ParthenonManager::RestartPackages(Mesh &rm, RestartReader &resfile) {
   auto swarms = (mb.meshblock_data.Get()->GetSwarmData())->GetSwarmsByFlag(flags);
   for (auto &swarm : swarms) {
     auto swarmname = swarm->label();
+    auto var_missing_on_disk = !resfile.VariableExists(swarmname);
     if (Globals::my_rank == 0) {
-      std::cout << "Swarm: " << swarmname << std::endl;
+      std::cout << "Swarm: " << swarmname
+                << (var_missing_on_disk ? " missing on disk\n" : "\n");
+    }
+    if (var_missing_on_disk) {
+      // TODO(JMM/PG) Add failed load list of "fail/needs fix" list
+      continue;
     }
     std::vector<std::size_t> counts, offsets;
     std::size_t count_on_rank =

--- a/src/parthenon_manager.hpp
+++ b/src/parthenon_manager.hpp
@@ -30,6 +30,7 @@
 #include "mesh/mesh.hpp"
 #include "outputs/restart.hpp"
 #include "parameter_input.hpp"
+#include "utils/error_checking.hpp"
 #include "utils/utils.hpp"
 
 namespace parthenon {
@@ -68,21 +69,29 @@ class ParthenonManager {
     std::vector<T> dataVec;
     for (const auto &var : pswarm->GetVariableVector<T>()) {
       const std::string &varname = var->label();
-      std::cout << "SwarmVar: " << varname << std::endl;
       const auto &m = var->metadata();
       auto arrdims = m.GetArrayDims(pswarm->GetBlockPointer(), false);
+
+      auto var_missing_on_disk =
+          !restartReader->VariableExists(swarmname + "/SwarmVars/" + varname);
+      if (Globals::my_rank == 0) {
+        std::cout << "SwarmVar: " << varname
+                  << (var_missing_on_disk ? " missing on disk\n" : "\n");
+      }
+      if (var_missing_on_disk) {
+        // TODO(JMM/PG) Add failed load list of "fail/needs fix" list
+        continue;
+      }
 
       try {
         restartReader->ReadSwarmVar(swarmname, varname, count_on_rank, offset, m,
                                     dataVec);
       } catch (std::exception &ex) {
-        std::cout << StringPrintf("[%d] WARNING: Failed to read Swarm %s Variable %s "
-                                  "from restart file:\n%s",
-                                  Globals::my_rank, swarmname.c_str(), varname.c_str(),
-                                  ex.what())
-                  << std::endl;
-        // TODO(JMM/PG) Add failed load list of "fail/needs fix" list
-        continue;
+        // Variable does exist but could not be read. So we definitely want to fail here.
+        PARTHENON_THROW(StringPrintf("[%d] WARNING: Failed to read Swarm %s Variable %s "
+                                     "from restart file:\n%s",
+                                     Globals::my_rank, swarmname.c_str(), varname.c_str(),
+                                     ex.what()));
       }
 
       // Only safe because swarm starts completely defragged.

--- a/src/parthenon_manager.hpp
+++ b/src/parthenon_manager.hpp
@@ -44,7 +44,6 @@ class ParthenonManager {
   ParthenonInitPackagesAndMesh(std::optional<forest::ForestDefinition> forest_def = {});
   ParthenonStatus ParthenonFinalize();
 
-  bool IsRestart() { return (arg.restart_filename == nullptr ? false : true); }
   static Packages_t ProcessPackagesDefault(std::unique_ptr<ParameterInput> &pin);
   void RestartPackages(Mesh &rm, RestartReader &resfile);
 

--- a/src/parthenon_manager.hpp
+++ b/src/parthenon_manager.hpp
@@ -81,6 +81,7 @@ class ParthenonManager {
                                   Globals::my_rank, swarmname.c_str(), varname.c_str(),
                                   ex.what())
                   << std::endl;
+        // TODO(JMM/PG) Add failed load list of "fail/needs fix" list
         continue;
       }
 

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -184,10 +184,9 @@ TEST_CASE("Test deleting parameters from ParameterInput", "[ParameterInput]") {
     ss << "<block1>" << std::endl
        << "var1 = 0   # comment" << std::endl
        << "<block2>" << std::endl
-       << "var2 = 2"
-       << std::endl
+       << "var2 = 2" << std::endl;
 
-              std::istringstream s(ss.str());
+    std::istringstream s(ss.str());
     in.LoadFromStream(s);
 
     THEN("block1/var1 exists") { REQUIRE(in.DoesParameterExist("block1", "var1")); }

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -176,3 +176,25 @@ TEST_CASE("Parameter inputs can be hashed and hashing provides useful sanity che
     }
   }
 }
+
+TEST_CASE("Test deleting parameters from ParameterInput", "[ParameterInput]") {
+  GIVEN("A ParameterInput object already populated") {
+    ParameterInput in;
+    std::stringstream ss;
+    ss << "<block1>" << std::endl
+       << "var1 = 0   # comment" << std::endl
+       << "<block2>" << std::endl
+       << "var2 = 2"
+       << std::endl
+
+              std::istringstream s(ss.str());
+    in.LoadFromStream(s);
+
+    THEN("block1/var1 exists") { REQUIRE(in.DoesParameterExist("block1", "var1")); }
+
+    WHEN("We delete a parameter") {
+      in.RemoveParameter("block1", "var1");
+      THEN("It no longer exists") { REQUIRE(!in.DoesParameterExist("block1", "var1")); }
+    }
+  }
+}

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -183,6 +183,7 @@ TEST_CASE("Test deleting parameters from ParameterInput", "[ParameterInput]") {
     std::stringstream ss;
     ss << "<block1>" << std::endl
        << "var1 = 0   # comment" << std::endl
+       << "var2 = 0   # comment" << std::endl
        << "<block2>" << std::endl
        << "var2 = 2" << std::endl;
 
@@ -194,6 +195,7 @@ TEST_CASE("Test deleting parameters from ParameterInput", "[ParameterInput]") {
     WHEN("We delete a parameter") {
       in.RemoveParameter("block1", "var1");
       THEN("It no longer exists") { REQUIRE(!in.DoesParameterExist("block1", "var1")); }
+      THEN("And others still do") { REQUIRE(in.DoesParameterExist("block1", "var2")); }
     }
   }
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes
- allow override of default (in code) input parameters when parameters are set from the command line
- allows restarts with new `Metadata::Restart` variables/fields/params.  Will add manual fixing machinery in separate PR, see issue #1300
- allow restarts with missing output package (transition from `next_xxx` input to `last_xxx` output package)
- allows to enable a custom `id` field for swarms
- potential future `last_xxx` entries (when output was soft disabled with negative `dt` or `dn`) -- edge case
- remove `pmesh->is_restart` in favor of `Globals::is_restart`
- make `Globals::is_restart` work properly

Adds
- Interface to remove variables from `pinput`

### "API" breaking
- `is_restart` `Mesh` member has been removed. Please use `Globals::is_restart` now.

Fixes #1235 #1293 #1298

Supersedes #1294 #1296

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [x] Change is breaking (API, behavior, ...)
  - [x] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [x] PR is marked as breaking
  - [x] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
