### PR TITLE
Fix imports in parthenon_tools + phdf_diff logic

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install parthenon_tools
         run: |
-          pip install --user scripts/python/packages/parthenon_tools
+          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
 
       - name: Setup cache for gold standard
         uses: actions/cache@v3
@@ -154,7 +154,7 @@ jobs:
 
       - name: Install parthenon_tools
         run: |
-          pip install --user scripts/python/packages/parthenon_tools
+          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
 
       - name: Setup cache for gold standard
         uses: actions/cache@v3

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -42,10 +42,6 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Install parthenon_tools
-        run: |
-          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
-
       - name: Setup cache for gold standard
         uses: actions/cache@v3
         with:
@@ -82,8 +78,6 @@ jobs:
           export ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1
           export UBSAN_OPTIONS=print_stacktrace=0
           export LSAN_OPTIONS=detect_leaks=0
-          # make sure parthenon tools is in our python path
-          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L performance -LE perf-reg
 
       # run regression tests
@@ -96,8 +90,6 @@ jobs:
           export ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1
           export UBSAN_OPTIONS=print_stacktrace=0
           export LSAN_OPTIONS=detect_leaks=0
-          # make sure parthenon tools is in our python path
-          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       # Test Ascent integration (only most complex setup with MPI and on device)
@@ -152,10 +144,6 @@ jobs:
         with:
           submodules: 'true'
 
-      - name: Install parthenon_tools
-        run: |
-          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
-
       - name: Setup cache for gold standard
         uses: actions/cache@v3
         with:
@@ -179,16 +167,12 @@ jobs:
         if: ${{ matrix.parallel == 'serial' }}
         run: |
           cd build
-          # make sure parthenon tools is in our python path
-          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L performance -LE perf-reg
 
       # run regression tests
       - name: Regression tests
         run: |
           cd build
-          # make sure parthenon tools is in our python path
-          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install parthenon_tools
         run: |
-          pip install scripts/python/packages/parthenon_tools
+          pip install --user scripts/python/packages/parthenon_tools
 
       - name: Setup cache for gold standard
         uses: actions/cache@v3
@@ -82,6 +82,8 @@ jobs:
           export ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1
           export UBSAN_OPTIONS=print_stacktrace=0
           export LSAN_OPTIONS=detect_leaks=0
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L performance -LE perf-reg
 
       # run regression tests
@@ -94,6 +96,8 @@ jobs:
           export ASAN_OPTIONS=abort_on_error=1:fast_unwind_on_malloc=1
           export UBSAN_OPTIONS=print_stacktrace=0
           export LSAN_OPTIONS=detect_leaks=0
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       # Test Ascent integration (only most complex setup with MPI and on device)
@@ -150,7 +154,7 @@ jobs:
 
       - name: Install parthenon_tools
         run: |
-          pip install scripts/python/packages/parthenon_tools
+          pip install --user scripts/python/packages/parthenon_tools
 
       - name: Setup cache for gold standard
         uses: actions/cache@v3
@@ -175,12 +179,16 @@ jobs:
         if: ${{ matrix.parallel == 'serial' }}
         run: |
           cd build
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L performance -LE perf-reg
 
       # run regression tests
       - name: Regression tests
         run: |
           cd build
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -L regression -L ${{ matrix.parallel }} -LE perf-reg --timeout 3600
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -42,6 +42,10 @@ jobs:
         with:
           submodules: 'true'
 
+      - name: Install parthenon_tools
+        run: |
+          pip install scripts/python/packages/parthenon_tools
+
       - name: Setup cache for gold standard
         uses: actions/cache@v3
         with:
@@ -143,6 +147,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+
+      - name: Install parthenon_tools
+        run: |
+          pip install scripts/python/packages/parthenon_tools
 
       - name: Setup cache for gold standard
         uses: actions/cache@v3

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -32,6 +32,10 @@ jobs:
       run: |
         brew install openmpi hdf5-mpi adios2 || true
 
+    - name: Install parthenon_tools
+      run: |
+        pip install scripts/python/packages/parthenon_tools
+
     - name: Configure
       run: cmake -B build -DCMAKE_BUILD_TYPE=Release
 

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -86,6 +86,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+      - name: Install parthenon_tools
+        run: |
+          pip install scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           cmake -B build \
@@ -148,6 +151,9 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: 'true'
+      - name: Install parthenon_tools
+        run: |
+          pip install scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           git config --global --add safe.directory $(pwd)

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -88,7 +88,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install scripts/python/packages/parthenon_tools
+          pip install --user scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           cmake -B build \
@@ -101,6 +101,8 @@ jobs:
           cd build
           # Pick GPU with most available memory
           export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -R regression_mpi_test:output_hdf5
       # Test example with swarms
       - name: particle-leapfrog
@@ -109,6 +111,8 @@ jobs:
           cd build
           # Pick GPU with most available memory
           export CUDA_VISIBLE_DEVICES=$(nvidia-smi --query-gpu=memory.free,index --format=csv,nounits,noheader | sort -nr | head -1 | awk '{ print $NF }')
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -R regression_mpi_test:particle_leapfrog
 
       # Now testing if there are no hidden memcopies between host and device.
@@ -153,7 +157,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install scripts/python/packages/parthenon_tools
+          pip install --user scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           git config --global --add safe.directory $(pwd)
@@ -167,12 +171,16 @@ jobs:
         run: |
           cmake --build build -t advection-example
           cd build
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -R regression_mpi_test:output_hdf5
       # Test example with swarms
       - name: particle-leapfrog
         run: |
           cmake --build build -t particle-leapfrog
           cd build
+          # make sure parthenon tools is in our python path
+          export PYTHONPATH="$PYTHONPATH:$(python -m site --user-site)"
           ctest -R regression_mpi_test:particle_leapfrog
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -88,7 +88,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install --user scripts/python/packages/parthenon_tools
+          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           cmake -B build \
@@ -157,7 +157,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install --user scripts/python/packages/parthenon_tools
+          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           git config --global --add safe.directory $(pwd)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1307]](https://github.com/parthenon-hpc-lab/parthenon/pull/1307) Fix imports in parthenon tools + phdf_diff logic
 - [[PR 1310]](https://github.com/parthenon-hpc-lab/parthenon/pull/1310) Fix logic causing issues for restarts with varying output blocks (introduced in #1266)
 - [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, `is_restart`)
 - [[PR 1303]](https://github.com/parthenon-hpc-lab/parthenon/pull/1303) Guard against block_list access when nmb==0

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
@@ -98,7 +98,7 @@ def compare_analytic(
     """
 
     try:
-        import phdf
+        from parthenon_tools import phdf
     except ModuleNotFoundError:
         print("Couldn't find module to read Parthenon hdf5 files.")
         return False
@@ -114,7 +114,6 @@ def compare_analytic(
     # Check all components for which an analytic version exists
     all_ok = True
     for component in analytic_components.keys():
-
         # Compute the analytic component at Z,Y,X
         analytic_component = analytic_components[component](Z, Y, X, datafile.Time)
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
@@ -98,7 +98,7 @@ def compare_analytic(
     """
 
     try:
-        from parthenon_tools import phdf
+        from . import phdf
     except ModuleNotFoundError:
         print("Couldn't find module to read Parthenon hdf5 files.")
         return False

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
@@ -98,7 +98,7 @@ def compare_analytic(
     """
 
     try:
-        from . import phdf
+        from parthenon_tools import phdf
     except ModuleNotFoundError:
         print("Couldn't find module to read Parthenon hdf5 files.")
         return False

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
@@ -98,10 +98,13 @@ def compare_analytic(
     """
 
     try:
-        from parthenon_tools import phdf
+        import phdf
     except ModuleNotFoundError:
-        print("Couldn't find module to read Parthenon hdf5 files.")
-        return False
+        try:
+            parthenon_tools import phdf
+        except ModuleNotFoundError:
+            print("Couldn't find module to read Parthenon hdf5 files.")
+            return False
 
     datafile = phdf.phdf(filename)
 

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/compare_analytic.py
@@ -101,7 +101,7 @@ def compare_analytic(
         import phdf
     except ModuleNotFoundError:
         try:
-            parthenon_tools import phdf
+            from parthenon_tools import phdf
         except ModuleNotFoundError:
             print("Couldn't find module to read Parthenon hdf5 files.")
             return False

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -18,7 +18,10 @@ import re
 import os
 import logging
 import numpy as np
-from parthenon_tools.phdf import phdf
+try:
+    from phdf import phdf
+except ModuleNotFoundError:
+    from parthenon_tools.phdf import phdf
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -18,7 +18,7 @@ import re
 import os
 import logging
 import numpy as np
-from parthenon_tools.phdf import phdf
+from .phdf import phdf
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -18,7 +18,7 @@ import re
 import os
 import logging
 import numpy as np
-from .phdf import phdf
+from parthenon_tools.phdf import phdf
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -18,6 +18,7 @@ import re
 import os
 import logging
 import numpy as np
+
 try:
     from phdf import phdf
 except ModuleNotFoundError:

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/movie2d.py
@@ -18,7 +18,7 @@ import re
 import os
 import logging
 import numpy as np
-from phdf import phdf
+from parthenon_tools.phdf import phdf
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -389,7 +389,7 @@ def compare(
     # **************
     # import Reader
     # **************
-    from .phdf import phdf
+    from parthenon_tools.phdf import phdf
 
     # **************
     # Reader Help

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -389,7 +389,7 @@ def compare(
     # **************
     # import Reader
     # **************
-    from parthenon_tools.phdf import phdf
+    from .phdf import phdf
 
     # **************
     # Reader Help

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -389,7 +389,10 @@ def compare(
     # **************
     # import Reader
     # **************
-    from parthenon_tools.phdf import phdf
+    try:
+        from phdf import phdf
+    except ModuleNotFoundError:
+        from parthenon_tools.phdf import phdf
 
     # **************
     # Reader Help

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -389,7 +389,7 @@ def compare(
     # **************
     # import Reader
     # **************
-    from phdf import phdf
+    from parthenon_tools.phdf import phdf
 
     # **************
     # Reader Help

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py
@@ -316,7 +316,7 @@ def compare_metadata(f0, f1, quiet=False, one=False, check_input=False, tol=1.0e
                 # Compute norm error, check against tolerance
                 err_val = np.abs(val0 - val1)
                 err_mag = np.linalg.norm(err_val)
-                if err_mag > tol:
+                if tol < err_mag:
                     no_meta_variables_diff = False
                     if not quiet:
                         print("")
@@ -526,7 +526,7 @@ def compare(
         err_max = err_mag.max()
 
         # Check if the error of any block exceeds the tolerance
-        if err_max > tol:
+        if tol < err_max:
             no_diffs = False
             var_no_diffs = False
 
@@ -542,7 +542,7 @@ def compare(
                 bad_idxs = bad_idx.reshape((1, *bad_idx.shape))
             else:
                 # Print all differences exceeding maximum
-                bad_idxs = np.argwhere(err_mag > tol)
+                bad_idxs = np.argwhere(tol < err_mag)
 
             for bad_idx in bad_idxs:
                 bad_idx = tuple(bad_idx)

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
@@ -22,7 +22,7 @@ sys.path.insert(
     0, "../external/parthenon/scripts/python/packages/parthenon_tools/parthenon_tools"
 )
 import h5py
-from parthenon_tools.compute_asymmetry import compute_asymmetry
+from .compute_asymmetry import compute_asymmetry
 
 parser = ArgumentParser(
     prog="report_asymmetry.py",

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
@@ -19,7 +19,7 @@ from argparse import ArgumentParser
 import os, re
 
 import h5py
-from .compute_asymmetry import compute_asymmetry
+from parthenon_tools.compute_asymmetry import compute_asymmetry
 
 parser = ArgumentParser(
     prog="report_asymmetry.py",

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
@@ -19,6 +19,7 @@ from argparse import ArgumentParser
 import os, re
 
 import h5py
+
 try:
     from compute_asymmetry import compute_asymmetry
 except ModuleNotFoundError:

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
@@ -22,7 +22,7 @@ sys.path.insert(
     0, "../external/parthenon/scripts/python/packages/parthenon_tools/parthenon_tools"
 )
 import h5py
-from compute_asymmetry import compute_asymmetry
+from parthenon_tools.compute_asymmetry import compute_asymmetry
 
 parser = ArgumentParser(
     prog="report_asymmetry.py",

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/report_asymmetry.py
@@ -19,7 +19,10 @@ from argparse import ArgumentParser
 import os, re
 
 import h5py
-from parthenon_tools.compute_asymmetry import compute_asymmetry
+try:
+    from compute_asymmetry import compute_asymmetry
+except ModuleNotFoundError:
+    from parthenon_tools.compute_asymmetry import compute_asymmetry
 
 parser = ArgumentParser(
     prog="report_asymmetry.py",


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

When installing `parthenon_tools` I found I needed to have the directory in my `PYTHONPATH` or none of the internal import statements would work, getting things like
```
python -m parthenon_tools.phdf_diff build/tst/regression/outputs/restart/gold.out0.00002.rhdf build/tst/regression/outputs/restart/silver.out0.00002.rhdf
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/adamreyes/Documents/research/repos/github/parthenon-hpc/parthenon/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py", line 604, in <module>
    ret = compare(
        files,
    ...<6 lines>...
        relative,
    )
  File "/Users/adamreyes/Documents/research/repos/github/parthenon-hpc/parthenon/scripts/python/packages/parthenon_tools/parthenon_tools/phdf_diff.py", line 392, in compare
    from phdf import phdf
ModuleNotFoundError: No module named 'phdf'
```

This PR changes the imports to absolute,
```
from .phdf import phdf
```

Additionally I've inverted the tolerance checks in `phdf_diff` so that NaNs in any of the data will result in a test failure.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
