### PR TITLE
Fix logic causing issues for restarts with varying output blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1310]](https://github.com/parthenon-hpc-lab/parthenon/pull/1310) Fix logic causing issues for restarts with varying output blocks (introduced in #1266)
 - [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, `is_restart`)
 - [[PR 1303]](https://github.com/parthenon-hpc-lab/parthenon/pull/1303) Guard against block_list access when nmb==0
 - [[PR 1291]](https://github.com/parthenon-hpc-lab/parthenon/pull/1291) Fix provenance for downstream codes 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,9 @@ include(cmake/Lint.cmake)
 
 
 # regression test reference data
-set(REGRESSION_GOLD_STANDARD_VER 27 CACHE STRING "Version of gold standard to download and use")
+set(REGRESSION_GOLD_STANDARD_VER 28 CACHE STRING "Version of gold standard to download and use")
 set(REGRESSION_GOLD_STANDARD_HASH
-  "SHA512=9a1285612fe8a99861630232b1ca2cb382711b45863f9aad99fcb5e25d6daaba6c18158058c73ac61d4df3b78aee987a8f86ecf7eb61717c7932d1ef6651d100"
+  "SHA512=5755189763f00d68a942d20216a9e875bf4379102398f811754f271978792319eef76cb7dd30743c0c2cd7c5a56f082874e34c05f536805d434033c98c384628"
   CACHE STRING "Hash of default gold standard file to download")
 option(REGRESSION_GOLD_STANDARD_SYNC "Automatically sync gold standard files." ON)
 

--- a/doc/sphinx/src/generated/diffusion-parth-table.csv
+++ b/doc/sphinx/src/generated/diffusion-parth-table.csv
@@ -1,7 +1,6 @@
 block,parameters,type,default,description
 "parthenon/job","output_params_and_exit","bool","0","output a description of all input parameters accessed and quit"
 "parthenon/job","output_params_block_regex","string","(.*)","when outputting input parameters, this selects which input blocks to output; all are output by default"
-"parthenon/job","problem_id","string","parthenon","prefix for output files"
 "parthenon/job","run_only_analysis","bool","",""
 "","","","",""
 "parthenon/loadbalancing","balancer","string","default","load balancing strategy"

--- a/src/outputs/output_parameters.hpp
+++ b/src/outputs/output_parameters.hpp
@@ -41,7 +41,6 @@ struct OutputParameters {
   OutputParameters() = default;
 
   int block_number = 0;
-  int contiguous_block_index;
   std::string block_name;
   std::string file_basename;
   int file_number_width;

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -103,20 +103,26 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
 
   // loop over "parthenon/output" blocks located in params
   auto pkg = pm->packages.Get("Outputs");
-  const auto &block_names = pkg->Param<std::vector<std::string>>("block_names");
-  const auto &block_numbers = pkg->Param<std::vector<int>>("block_numbers");
-  auto *pactive = pkg->MutableParam<std::vector<bool>>("active");
-  auto *pfile_numbers = pkg->MutableParam<std::vector<int>>("file_numbers");
-  auto *plast_times = pkg->MutableParam<std::vector<Real>>("last_times");
-  auto *plast_ns = pkg->MutableParam<std::vector<int>>("last_ns");
-  for (int iinput = 0; iinput < block_names.size(); ++iinput) {
+  // loop over input block names.  Find those that start with "parthenon/output", read
+  // parameters, and construct a vector of output types.
+  // PG: It could be discussed if we should work based on a vector that is initialized in
+  // the outpus packages (as before), but I don't think it's bad practice to work on
+  // `pinput` again here as we're actually processing (potentially even modifying)
+  // `pinput`.
+  for (InputBlock *pib = pin->pfirst_block; pib != nullptr; pib = pib->pnext) {
+    if (pib->block_name.compare(0, 16, "parthenon/output") != 0) {
+      continue;
+    }
     std::shared_ptr<OutputType> pnew_type; // the new output we will create
     bool restart = false;                  // we track restart outputs separately so we
                                            // need this temp variable to check
     OutputParameters op;                   // define temporary OutputParameters struct
-    op.block_name = block_names[iinput];
-    op.block_number = block_numbers[iinput];
-    op.contiguous_block_index = iinput;
+    op.block_name = pib->block_name;
+    const auto outn_str = pib->block_name.substr(16); // 16 because counting starts at 0!
+    op.block_number = atoi(outn_str.c_str());
+    auto *pfile_number = pkg->MutableParam<int>(outn_str + "/file_number");
+    auto *plast_time = pkg->MutableParam<Real>(outn_str + "/last_time");
+    auto *plast_n = pkg->MutableParam<int>(outn_str + "/last_n");
 
     Real dt = 0.0; // default value == 0 means that initial data is written by default
     int dn = -1;
@@ -132,10 +138,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     }
     // if this output is "soft-disabled" (negative value) skip processing
     if (dt < 0.0 && dn < 0) {
-      (*pactive)[iinput] = false;
       continue;
-    } else {
-      (*pactive)[iinput] = true;
     }
 
     // JMM: Backwards compatibility hack. Don't allow this unless
@@ -145,17 +148,17 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       bool next_n_exists = pin->DoesParameterExist(op.block_name, "next_n");
       if (next_time_exists) {
         Real next_time = pin->GetReal(op.block_name, "next_time");
-        (*plast_times)[iinput] = dt < 0 ? 0.0 : next_time - dt;
+        *plast_time = dt < 0 ? 0.0 : next_time - dt;
         pin->RemoveParameter(op.block_name, "next_time");
       }
       if (next_n_exists) {
         int next_n = pin->GetInteger(op.block_name, "next_n");
 
-        (*plast_ns)[iinput] = dn < 0 ? 0 : next_n - dn;
+        *plast_n = dn < 0 ? 0 : next_n - dn;
         pin->RemoveParameter(op.block_name, "next_n");
       }
       if (next_time_exists || next_n_exists) {
-        (*pfile_numbers)[iinput] = pin->GetOrAddInteger(op.block_name, "file_number", 0);
+        *pfile_number = pin->GetOrAddInteger(op.block_name, "file_number", 0);
         pin->RemoveParameter(op.block_name, "file_number");
       }
     }
@@ -165,8 +168,8 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
                              "is not supported. Please set at most one value >= 0.");
 
     // set time of last output, time between outputs
-    op.last_time = (*plast_times)[iinput];
-    op.last_n = (*plast_ns)[iinput];
+    op.last_time = *plast_time;
+    op.last_n = *plast_n;
     if (tm != nullptr) {
       op.dt = dt;
       op.dn = dn;
@@ -203,7 +206,7 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     }
 
     // set file number, basename, id, and format
-    op.file_number = std::max((*pfile_numbers)[iinput], 0);
+    op.file_number = std::max(*pfile_number, 0);
     op.file_basename = pin->GetOrAddString("parthenon/job", "problem_id", "parthenon",
                                            "prefix for output files");
     op.file_number_width = pin->GetOrAddInteger(op.block_name, "file_number_width", 5);
@@ -282,8 +285,8 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     if (op.file_type == "hst") {
       // Do not use GetOrAddVector because it will pollute the input parameters for
       // restarts
-      if (pin->DoesParameterExist(block_names[iinput], "packages")) {
-        op.packages = pin->GetVector<std::string>(block_names[iinput], "packages");
+      if (pin->DoesParameterExist(op.block_name, "packages")) {
+        op.packages = pin->GetVector<std::string>(op.block_name, "packages");
       } else {
         op.packages = std::vector<std::string>();
       }
@@ -293,35 +296,39 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     if ((op.file_type != "hst") && (op.file_type != "rst") &&
         (op.file_type != "corehdf5") && (op.file_type != "ascent") &&
         (op.file_type != "histogram")) {
-      op.variables = pin->GetOrAddVector<std::string>(block_names[iinput], "variables",
-                                                      std::vector<std::string>(),
-                                                      "variables to output");
+      // Do not use GetOrAddVector because it will pollute the input parameters for
+      // restarts
+      if (pin->DoesParameterExist(op.block_name, "variables")) {
+        op.variables = pin->GetVector<std::string>(op.block_name, "variables");
+      } else {
+        op.variables = std::vector<std::string>();
+      }
       // JMM: If the requested var isn't present for a given swarm,
       // it is simply not output.
       op.swarms.clear(); // Not sure this is needed
-      if (pin->DoesParameterExist(block_names[iinput], "swarms")) {
-        std::vector<std::string> swarmnames = pin->GetVector<std::string>(
-            block_names[iinput], "swarms", "swarms to output");
+      if (pin->DoesParameterExist(op.block_name, "swarms")) {
+        std::vector<std::string> swarmnames =
+            pin->GetVector<std::string>(op.block_name, "swarms", "swarms to output");
         std::size_t nswarms = swarmnames.size();
-        if ((pin->DoesParameterExist(block_names[iinput], "swarm_variables")) &&
+        if ((pin->DoesParameterExist(op.block_name, "swarm_variables")) &&
             (nswarms > 1)) {
           std::stringstream msg;
-          msg << "The swarm_variables field is set in the block '" << block_names[iinput]
+          msg << "The swarm_variables field is set in the block '" << op.block_name
               << "' however, there are " << nswarms << " swarms."
               << " All swarms will be assumed to request the vars listed in "
                  "swarm_variables.";
           PARTHENON_WARN(msg);
         }
         for (const auto &swname : swarmnames) {
-          if (pin->DoesParameterExist(block_names[iinput], "swarm_variables")) {
+          if (pin->DoesParameterExist(op.block_name, "swarm_variables")) {
             auto varnames =
-                pin->GetVector<std::string>(block_names[iinput], "swarm_variables",
+                pin->GetVector<std::string>(op.block_name, "swarm_variables",
                                             "swarm variables to output for all swarms");
             op.swarms[swname].insert(varnames.begin(), varnames.end());
           }
-          if (pin->DoesParameterExist(block_names[iinput], swname + "_variables")) {
+          if (pin->DoesParameterExist(op.block_name, swname + "_variables")) {
             auto varnames = pin->GetVector<std::string>(
-                block_names[iinput], swname + "_variables",
+                op.block_name, swname + "_variables",
                 "swarm variables to output for a specific swarm");
             op.swarms[swname].insert(varnames.begin(), varnames.end());
           }
@@ -393,7 +400,6 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
       output_types_.push_back(pnew_type);
     }
   }
-
   // check there were no more than one restart file requested
   if (num_rst_outputs > 1) {
     msg << "### FATAL ERROR in Outputs constructor" << std::endl
@@ -459,10 +465,11 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
 void OutputType::UpdateNextOutput_(Mesh *pm, SimTime *tm) {
   output_params.file_number++;
   auto pkg = pm->packages.Get("Outputs");
-  auto *pfile_numbers = pkg->MutableParam<std::vector<int>>("file_numbers");
-  auto *plast_times = pkg->MutableParam<std::vector<Real>>("last_times");
-  auto *plast_ns = pkg->MutableParam<std::vector<int>>("last_ns");
-  (*pfile_numbers)[output_params.contiguous_block_index] = output_params.file_number;
+  const auto outn_str = std::to_string(output_params.block_number);
+  auto *pfile_number = pkg->MutableParam<int>(outn_str + "/file_number");
+  auto *plast_time = pkg->MutableParam<Real>(outn_str + "/last_time");
+  auto *plast_n = pkg->MutableParam<int>(outn_str + "/last_n");
+  *pfile_number = output_params.file_number;
   if (tm != nullptr) {
     // JMM: Do NOT use the current time to update these, as that can
     // cause drift because timestep is not guaranteed to align with
@@ -470,8 +477,8 @@ void OutputType::UpdateNextOutput_(Mesh *pm, SimTime *tm) {
     // time.
     output_params.last_n = output_params.next_n;
     output_params.last_time = output_params.next_time;
-    (*plast_ns)[output_params.contiguous_block_index] = output_params.last_n;
-    (*plast_times)[output_params.contiguous_block_index] = output_params.last_time;
+    *plast_n = output_params.last_n;
+    *plast_time = output_params.last_time;
     if (output_params.dt > 0.0) {
       output_params.next_time += output_params.dt;
     }

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -72,7 +72,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
           PARTHENON_THROW(msg);
         }
       }
-      // It should be safe here to jsut use outn as output blocks are unique
+      // It should be safe here to just use outn as output blocks are unique
       pkg->AddParam(outn + "/file_number", file_number, Params::Mutability::Restart);
       pkg->AddParam(outn + "/last_time", last_time, Params::Mutability::Restart);
       pkg->AddParam(outn + "/last_n", last_n, Params::Mutability::Restart);

--- a/src/outputs/outputs_package.cpp
+++ b/src/outputs/outputs_package.cpp
@@ -37,36 +37,22 @@ namespace OutputsPackage {
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   auto pkg = std::make_shared<StateDescriptor>("Outputs");
 
-  std::string basename = pin->GetOrAddString("parthenon/job", "problem_id", "parthenon",
-                                             "prefix for output files");
-  std::vector<std::string> block_names;
-  std::vector<int> block_numbers;
-
-  std::vector<bool> active;
-  std::vector<int> file_numbers;
-  std::vector<Real> last_times;
-  std::vector<int> last_ns;
-
-  // loop over input block names.  Find those that start with "parthenon/output", read
-  // parameters, and construct singly linked list of OutputTypes.
+  // loop over input block names.  Find those that start with "parthenon/output" and
+  // add/initialize `Params` for further processing (so that they're available to be read
+  // from restart files or are cleanly initialized).
   for (InputBlock *pib = pin->pfirst_block; pib != nullptr; pib = pib->pnext) {
     if (pib->block_name.compare(0, 16, "parthenon/output") == 0) {
-      std::string outn = pib->block_name.substr(16); // 6 because counting starts at 0!
+      std::string outn = pib->block_name.substr(16); // 16 because counting starts at 0!
       std::string block_name = pib->block_name;
 
-      // these are used for book-keeping
-      block_names.push_back(block_name);
-      block_numbers.push_back(atoi(outn.c_str()));
-
       // These will be updated later or restarted from
-      active.push_back(false);
-      file_numbers.push_back(0);
+      int file_number = 0;
 
       // JMM: Limits to indicate these haven't been set yet. The reason
       // to set these to a "signal" number, rather than to start_time
       // is that we want to ensure a first output is performed.
-      last_times.push_back(std::numeric_limits<Real>::lowest());
-      last_ns.push_back(std::numeric_limits<int>::lowest());
+      auto last_time = std::numeric_limits<Real>::lowest();
+      auto last_n = std::numeric_limits<int>::lowest();
 
       bool next_time_exists = pin->DoesParameterExist(block_name, "next_time");
       bool next_n_exists = pin->DoesParameterExist(block_name, "next_n");
@@ -86,14 +72,12 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
           PARTHENON_THROW(msg);
         }
       }
+      // It should be safe here to jsut use outn as output blocks are unique
+      pkg->AddParam(outn + "/file_number", file_number, Params::Mutability::Restart);
+      pkg->AddParam(outn + "/last_time", last_time, Params::Mutability::Restart);
+      pkg->AddParam(outn + "/last_n", last_n, Params::Mutability::Restart);
     }
   }
-  pkg->AddParam("block_names", block_names);
-  pkg->AddParam("block_numbers", block_numbers);
-  pkg->AddParam("active", active, Params::Mutability::Restart);
-  pkg->AddParam("file_numbers", file_numbers, Params::Mutability::Restart);
-  pkg->AddParam("last_times", last_times, Params::Mutability::Restart);
-  pkg->AddParam("last_ns", last_ns, Params::Mutability::Restart);
 
   return pkg;
 }

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -80,7 +80,7 @@ if (ENABLE_HDF5)
   list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
   list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/fine_advection/fine_advection-example \
     --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/restart_fine/parthinput.restart_fine \
-    --num_steps 2")
+    --num_steps 3")
   list(APPEND EXTRA_TEST_LABELS "")
 
   # Calculate pi example

--- a/tst/regression/test_suites/restart_fine/parthinput.restart_fine
+++ b/tst/regression/test_suites/restart_fine/parthinput.restart_fine
@@ -60,3 +60,10 @@ derefine_tol = 0.03
 <parthenon/output0>
 file_type = rst
 dt = 0.05
+
+# Following output block is used for testing against dynamically
+# added output block output1
+<parthenon/output2>
+file_type = hdf5
+dt = 0.25
+variables = advection.C

--- a/tst/regression/test_suites/restart_fine/restart_fine.py
+++ b/tst/regression/test_suites/restart_fine/restart_fine.py
@@ -33,11 +33,22 @@ class TestCase(utils.test_case.TestCaseAbs):
         # run baseline (to the very end)
         if step == 1:
             parameters.driver_cmd_line_args = ["parthenon/job/problem_id=gold"]
-        else:
+        elif step == 2:
             parameters.driver_cmd_line_args = [
                 "-r",
                 "gold.out0.00004.rhdf",
                 "parthenon/job/problem_id=silver",
+            ]
+        # check that we can dynamically enable outputs
+        else:
+            parameters.driver_cmd_line_args = [
+                "-r",
+                "gold.out0.00005.rhdf",
+                "parthenon/job/problem_id=bronze",
+                "parthenon/output1/file_type=hdf5",
+                "parthenon/output1/dt=0.05",
+                "parthenon/output1/last_time=0.25",
+                "parthenon/output1/variables=advection.C,advection.D,advection.phi_0,advection.phi_fine"
             ]
         return parameters
 
@@ -68,6 +79,23 @@ class TestCase(utils.test_case.TestCaseAbs):
             if delta != 0:
                 print(
                     "ERROR: Found difference between gold and silver output '%s'."
+                    % name
+                )
+                return False
+            delta = compare(
+                [
+                    "bronze.out1.%s.phdf" % name,
+                    "{}.out0.{}.rhdf".format(base, name),
+                ],
+                # no need for metadata as the dynamically added output will cause
+                # different metadata and we're just interested in the right data
+                # being there.
+                one=True, check_metadata=False,
+            )
+
+            if delta != 0:
+                print(
+                    "ERROR: Found difference between gold and bronze output '%s'."
                     % name
                 )
                 return False

--- a/tst/regression/test_suites/restart_fine/restart_fine.py
+++ b/tst/regression/test_suites/restart_fine/restart_fine.py
@@ -46,9 +46,9 @@ class TestCase(utils.test_case.TestCaseAbs):
                 "gold.out0.00005.rhdf",
                 "parthenon/job/problem_id=bronze",
                 "parthenon/output1/file_type=hdf5",
-                "parthenon/output1/dt=0.05",
+                "parthenon/output1/dt=0.25",
                 "parthenon/output1/last_time=0.25",
-                "parthenon/output1/variables=advection.C,advection.D,advection.phi_0,advection.phi_fine"
+                "parthenon/output1/variables=advection.C",
             ]
         return parameters
 
@@ -85,12 +85,13 @@ class TestCase(utils.test_case.TestCaseAbs):
             delta = compare(
                 [
                     "bronze.out1.%s.phdf" % name,
-                    "{}.out0.{}.rhdf".format(base, name),
+                    "{}.out2.{}.phdf".format(base, name),
                 ],
                 # no need for metadata as the dynamically added output will cause
                 # different metadata and we're just interested in the right data
                 # being there.
-                one=True, check_metadata=False,
+                one=True,
+                check_metadata=False,
             )
 
             if delta != 0:


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Fixes #1309 by replacing the vector with unique params.

Note that the current tests are failing because the variables in the `bronze` (dynamically added) and `silver` output differ.
The former contains the `advection.phi_fine_restricted` variable as the it's a regex match for `advection.phi` triggered in the logic to add vars by name, whereas it's absent in `silver` because the silver output is a `restart` output, which currently ignores the `variables` parameter altogether.
I always wanted to support adding additional variables to restart output.
Any objections to this?

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
