### PR TITLE
Update Docker Cuda image due to asan issues with g++-11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,11 @@
 // devcontainer.json
     {
       "name": "parthenon-dev",
-      "image": "ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-ascent",
+      "image": "ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd",
+      // Somehow required to make GPUs work inside docker on the CI machine.
+      // Just passing the runtime and/or --gpus=all works initially but then
+      // the GPU disappears in the active container.
+      "runArgs": ["--privileged"],
       "hostRequirements": {
         "cpus": 4
       },
@@ -19,17 +23,21 @@
             "swyddfa.esbonio",
             "tomoki1207.pdf",
             "ms-vscode.cmake-tools",
-            "ms-vsliveshare.vsliveshare"
+            "ms-vsliveshare.vsliveshare",
+            "xaver.clang-format",
+            "ms-python.black-formatter"
         ]
         }
       },
       "remoteEnv": {
-        "PATH": "${containerEnv:PATH}:/usr/local/hdf5/parallel/bin",
+        "PATH": "${containerEnv:PATH}:/home/ci/.local/bin:/usr/local/hdf5/parallel/bin",
         "OMPI_MCA_opal_warn_on_missing_libcuda": "0"
       },
       //"remoteUser": "ubuntu",
       // we need to manually checkout the submodules,
       // but VSCode may try to configure CMake before they are fully checked-out.
       // workaround TBD
-      "postCreateCommand": "git submodule update --init"
+      "postCreateCommand": {
+        "git" : "git submodule update --init"
+      }
     }

--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -27,7 +27,7 @@ jobs:
         parallel: ['serial', 'mpi']
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd
     env:
       CMAKE_GENERATOR: Ninja
     steps:

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -34,7 +34,7 @@ jobs:
         parallel: ['serial', 'mpi']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd
       # map to local user id on CI  machine to allow writing to build cache
       options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:

--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -94,7 +94,9 @@ jobs:
 
       # Test Ascent integration (only most complex setup with MPI and on device)
       - name: Ascent tests
-        if: ${{ matrix.parallel == 'mpi' && matrix.device == 'cuda' }}
+        #if: ${{ matrix.parallel == 'mpi' && matrix.device == 'cuda' }}
+        # disable until build works again, see https://github.com/Alpine-DAV/ascent/issues/1614
+        if: false
         run: |
           cmake -B build-ascent \
             -DCMAKE_BUILD_TYPE=Release \
@@ -123,7 +125,7 @@ jobs:
             build/CMakeFiles/CMakeOutput.log
             build/tst/regression/outputs/advection_convergence*/advection-errors.dat
             build/tst/regression/outputs/advection_convergence*/advection-errors.png
-            example/advection/ascent_render_57.png
+            #            example/advection/ascent_render_57.png
           retention-days: 3
 
   perf-and-regression-amdgpu:

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -157,7 +157,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install scripts/python/packages/parthenon_tools
+          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           git config --global --add safe.directory $(pwd)

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -88,7 +88,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
+          pip install scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           cmake -B build \
@@ -157,7 +157,7 @@ jobs:
           submodules: 'true'
       - name: Install parthenon_tools
         run: |
-          pip install --user --break-system-packages scripts/python/packages/parthenon_tools
+          pip install scripts/python/packages/parthenon_tools
       - name: Configure
         run: |
           git config --global --add safe.directory $(pwd)

--- a/.github/workflows/ci-short.yml
+++ b/.github/workflows/ci-short.yml
@@ -22,7 +22,7 @@ jobs:
   style:
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd
       # map to local user id on CI  machine to allow writing to build cache
       options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
@@ -47,7 +47,7 @@ jobs:
         device: ['cuda', 'host']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd
       # map to local user id on CI  machine to allow writing to build cache
       options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:
@@ -79,7 +79,7 @@ jobs:
         device: ['cuda', 'host']
     runs-on: [self-hosted, A100]
     container:
-      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-ascent
+      image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd
       # map to local user id on CI  machine to allow writing to build cache
       options: --user 1001 --cap-add CAP_SYS_PTRACE --shm-size="8g" --ulimit memlock=134217728
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@
 - [[PR 1284]](https://github.com/parthenon-hpc-lab/parthenon/pull/1284) Fix some parameter types, move `DumpInputParameters` to `Driver`
 
 ### Infrastructure (changes irrelevant to downstream codes)
-- [[PR 1292]](https://github.com/parthenon-hpc-lab/parthenon/pull/1292_ Remove shared ptr cycle and add a destructor for reductions
+- [[PR 1316]](https://github.com/parthenon-hpc-lab/parthenon/pull/1316) Update Cuda CI container (main change g++-13 to fix asan bug)
+- [[PR 1292]](https://github.com/parthenon-hpc-lab/parthenon/pull/1292) Remove shared ptr cycle and add a destructor for reductions
 - [[PR 1281]](https://github.com/parthenon-hpc-lab/parthenon/pull/1281) Move params implementation to std::any
 - [[PR 1268]](https://github.com/parthenon-hpc-lab/parthenon/pull/1268) Adds build information to phdf output
 - [[PR 1162]](https://github.com/parthenon-hpc-lab/parthenon/pull/1162) Update CI container to Cuda 12.8

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -1,35 +1,41 @@
-FROM nvidia/cuda:12.8.0-devel-ubuntu24.04
+FROM nvidia/cuda:12.8.1-devel-ubuntu24.04
 
+# nodejs for running interactive action with `act`
 RUN apt-get clean && apt-get update -y && \
-    DEBIAN_FRONTEND="noninteractive" TZ=America/New_York apt-get install -y --no-install-recommends git python3-minimal libpython3-stdlib bc hwloc wget openssh-client python3-numpy python3-h5py python3-matplotlib python3-scipy python3-pip lcov curl cuda-nsight-systems-12-6 cmake ninja-build libpython3-dev gcc-11 g++-11 emacs nvi sphinx-doc python3-sphinx-rtd-theme python3-sphinxcontrib.bibtex python3-sphinx-copybutton && \
-    update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 10 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 10
+    DEBIAN_FRONTEND="noninteractive" TZ=America/New_York apt-get install -y --no-install-recommends git python3-minimal libpython3-stdlib bc hwloc wget openssh-client python3-pip lcov curl cuda-nsight-systems-12-8 cmake ninja-build libpython3-dev emacs nvi python3-venv nodejs
 
 RUN g++ --version
 
-RUN pip3 install unyt --break-system-packages
+RUN python3 -m venv /opt/venv
 
-RUN pip3 install blosc2 --break-system-packages
+ENV VIRTUAL_ENV=/opt/venv
+
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN pip3 install yt numpy scipy matplotlib h5py sphinx-copybutton sphinx sphinxcontrib.bibtex sphinx-rtd-theme
+
+RUN pip3 install unyt
+
+RUN pip3 install blosc2
 
 # for Codespaces/VSCode Sphinx support
-RUN pip3 install esbonio --break-system-packages
+RUN pip3 install esbonio
 
-# h5py from the repo is incompatible with the default numpy 2.1.0
-# Downgrading is not the cleanest solution, but it works...
-# see https://stackoverflow.com/questions/78634235/numpy-dtype-size-changed-may-indicate-binary-incompatibility-expected-96-from
-RUN pip3 install numpy==1.26.4 --break-system-packages
+# current formatting standard
+RUN pip3 install clang-format==11.0.1
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list
 
+# libclang-rt-20-dev for asan support with clang++
 RUN apt-get clean && apt-get update -y && \
-    DEBIAN_FRONTEND="noninteractive" TZ=America/New_York apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev clangd-20 libstdc++-14-dev && \
+    DEBIAN_FRONTEND="noninteractive" TZ=America/New_York apt-get install -y --no-install-recommends clang-20 llvm-20 libomp-20-dev clangd-20 libclang-rt-20-dev libstdc++-14-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN cd /tmp && \
-    wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-4.1.4.tar.bz2 && \
-    tar xjf openmpi-4.1.4.tar.bz2 && \
-    cd openmpi-4.1.4 && \
+    wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.bz2 && \
+    tar xjf openmpi-5.0.8.tar.bz2 && \
+    cd openmpi-5.0.8 && \
     ./configure --prefix=/opt/openmpi --disable-mpi-fortran --disable-oshmem --with-cuda && \
     make -j16 && \
     make install && \
@@ -69,26 +75,28 @@ RUN mkdir /tmp/build-openpmd && cd /tmp/build-openpmd && \
     cd / && \
     rm -rf /tmp/build-openpmd
 
-RUN mkdir /tmp/build-ascent
+# no need to prepend as PYTHONPATH doesn't exist yet
+ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages
 
-COPY ascent_build.patch /tmp/build-ascent
+# Create symlink for clangd
+RUN ln -s /usr/bin/clangd-20 /usr/bin/clangd
 
-## NOTE: with enable_cuda=ON, you need a Docker VM with a LARGE amount of RAM (at least 15 GB RAM, 4 GB swap)
-
-# commit version is dev branch on 2025-04-10
-RUN cd /tmp/build-ascent && \
-    wget https://github.com/Alpine-DAV/ascent/archive/4da1379.tar.gz && \
-    tar xzf 4da1379.tar.gz -C . --strip-components=1 && \
-    wget https://github.com/LLNL/blt/archive/refs/tags/v0.6.2.tar.gz && \
-    tar xzf v0.6.2.tar.gz -C ./src/blt --strip-components=1 && \
-    cd ./scripts/build_ascent && \
-    patch -p1 build_ascent.sh /tmp/build-ascent/ascent_build.patch && \
-    env enable_cuda=ON enable_mpi=ON build_hdf5=false build_silo=false bash build_ascent.sh && \
-    cd / && \
-    rm -rf /tmp/build-ascent
-
-# Technically not necessary (as we installed the api above) but makes it easier for package discovery
-RUN env openPMD_USE_MPI=ON python3 -m pip install openpmd-api --no-binary openpmd-api --break-system-packages
+# PG giving up on Ascent for now
+# https://github.com/Alpine-DAV/ascent/issues/1614
+#RUN mkdir /tmp/build-ascent
+#
+#COPY ascent_build.patch /tmp/build-ascent
+#
+### NOTE: with enable_cuda=ON, you need a Docker VM with a LARGE amount of RAM (at least 15 GB RAM, 4 GB swap)
+#
+#RUN cd /tmp/build-ascent && \
+#    wget https://github.com/Alpine-DAV/ascent/releases/download/v0.9.5/ascent-v0.9.5-src-with-blt.tar.gz && \
+#    tar xzf ascent-v0.9.5-src-with-blt.tar.gz -C . --strip-components=1 && \
+#    cd ./scripts/build_ascent && \
+#    patch -p1 build_ascent.sh /tmp/build-ascent/ascent_build.patch && \
+#    env enable_cuda=ON enable_mpi=ON build_hdf5=false build_silo=false bash build_ascent.sh && \
+#    cd / && \
+#    rm -rf /tmp/build-ascent
 
 # create new user
 RUN groupadd -g 109 render

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -105,6 +105,9 @@ RUN ln -s /opt/venv/bin/esbonio /usr/bin/esbonio
 RUN groupadd -g 109 render
 RUN useradd --create-home --shell /bin/bash -G render,sudo ci
 
+# make venv user owned so that pip install works
+RUN chown -R ci /opt/venv
+
 USER ci
 
 WORKDIR /home/ci

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -36,7 +36,7 @@ RUN cd /tmp && \
     wget https://download.open-mpi.org/release/open-mpi/v5.0/openmpi-5.0.8.tar.bz2 && \
     tar xjf openmpi-5.0.8.tar.bz2 && \
     cd openmpi-5.0.8 && \
-    ./configure --prefix=/opt/openmpi --disable-mpi-fortran --disable-oshmem --with-cuda && \
+    ./configure --prefix=/opt/openmpi --disable-mpi-fortran --disable-oshmem --with-cuda=/usr/local/cuda --with-cuda-libdir=/usr/local/cuda/lib64/stubs && \
     make -j16 && \
     make install && \
     cd / && \
@@ -80,6 +80,9 @@ ENV PYTHONPATH=/usr/local/lib/python3.12/site-packages
 
 # Create symlink for clangd
 RUN ln -s /usr/bin/clangd-20 /usr/bin/clangd
+
+# Create symlink for esbonio
+RUN ln -s /opt/venv/bin/esbonio /usr/bin/esbonio
 
 # PG giving up on Ascent for now
 # https://github.com/Alpine-DAV/ascent/issues/1614

--- a/scripts/docker/ascent_build.patch
+++ b/scripts/docker/ascent_build.patch
@@ -1,36 +1,26 @@
---- build_ascent.sh	2024-08-29 21:00:24.000000000 +0000
-+++ build_ascent_parthenon.sh	2024-08-30 09:55:58.976365723 +0000
-@@ -21,6 +21,8 @@
- # Build Options
- ##############################################################################
+diff --git a/scripts/build_ascent/build_ascent.sh b/scripts/build_ascent/build_ascent.sh
+index 57efbf8d..b4500f1f 100755
+--- a/scripts/build_ascent/build_ascent.sh
++++ b/scripts/build_ascent/build_ascent.sh
+@@ -33,7 +35,7 @@ enable_mpicc="${enable_mpicc:=OFF}"
+ enable_find_mpi="${enable_find_mpi:=ON}"
+ enable_tests="${enable_tests:=OFF}"
+ enable_verbose="${enable_verbose:=ON}"
+-build_jobs="${build_jobs:=6}"
++build_jobs="${build_jobs:=16}"
+ build_config="${build_config:=Release}"
+ build_shared_libs="${build_shared_libs:=ON}"
  
-+export MAKEFLAGS="--output-sync=target"
-+
- # shared options
- enable_cuda="${enable_cuda:=OFF}"
- enable_hip="${enable_hip:=OFF}"
- 
-@@ -126,8 +128,8 @@
- root_dir=$(ospath ${root_dir})
- root_dir=$(abs_path ${root_dir})
- script_dir=$(abs_path "$(dirname "${BASH_SOURCE[0]}")")
--build_dir=$(ospath ${root_dir}/build)
--source_dir=$(ospath ${root_dir}/source)
-+build_dir=$(ospath build)
-+source_dir=$(ospath source)
- 
- 
- # root_dir is where we will build and install
-@@ -140,7 +142,7 @@
+@@ -145,7 +147,7 @@ cd ${root_dir}
  
  # install_dir is where we will install
  # override with `prefix` env var
 -install_dir="${install_dir:=$root_dir/install}"
 +install_dir=/usr/local
  
- echo "*** prefix:       ${root_dir}" 
+ echo "*** prefix:       ${root_dir}"
  echo "*** build root:   ${build_dir}"
-@@ -231,7 +233,7 @@
+@@ -245,7 +247,7 @@ hdf5_middle_version=1.14.1
  hdf5_short_version=1.14
  hdf5_src_dir=$(ospath ${source_dir}/hdf5-${hdf5_version})
  hdf5_build_dir=$(ospath ${build_dir}/hdf5-${hdf5_version}/)
@@ -39,12 +29,3 @@
  hdf5_tarball=$(ospath ${source_dir}/hdf5-${hdf5_version}.tar.gz)
  
  # build only if install doesn't exist
-@@ -650,7 +650,7 @@ fi # if enable_hip || enable_sycl
- ################
- # VTK-m
- ################
--vtkm_version=v2.2.0
-+vtkm_version=v2.3.0
- vtkm_src_dir=$(ospath ${source_dir}/vtk-m-${vtkm_version})
- vtkm_build_dir=$(ospath ${build_dir}/vtk-m-${vtkm_version})
- vtkm_install_dir=$(ospath ${install_dir}/vtk-m-${vtkm_version}/)


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In https://github.com/parthenon-hpc-lab/parthenon/pull/1192 we observed failing diffusion tests for the host-mpi config.
I tracked this down to the asan build for which the performance of this test got successive worse with every cycle, e.g.,
```
cycle=18 time=1.3732910156250000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.82e+02 wsec_total=1.34e+01 wsec_step=1.06e+00
cycle=19 time=1.4495849609375000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.89e+02 wsec_total=1.45e+01 wsec_step=1.05e+00
cycle=20 time=1.5258789062500000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.57e+02 wsec_total=1.56e+01 wsec_step=1.12e+00
cycle=21 time=1.6021728515625000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.44e+02 wsec_total=1.67e+01 wsec_step=1.15e+00
cycle=22 time=1.6784667968750000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.35e+02 wsec_total=1.79e+01 wsec_step=1.18e+00
cycle=23 time=1.7547607421875000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.34e+02 wsec_total=1.91e+01 wsec_step=1.18e+00
cycle=24 time=1.8310546875000000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.08e+02 wsec_total=2.03e+01 wsec_step=1.25e+00
cycle=25 time=1.9073486328125000e-03 dt=7.6293945312500000e-05 zone-cycles/wsec_step=4.05e+02 wsec_total=2.16e+01 wsec_step=1.27e+00
```
resulting the test not passing with the 1 hour timeout.
This is also an issue with `develop` (so that the cycles got slower) but not to the degree that the timeout was caught.
I was not able to reproduce this with neither g++13 (the default in the Docker version) nor with clang++-20.

Thus, I updated the docker image to not install g++11 (not even sure why we installed/used it in the first place).
However, the downside is that I was not able to successfully build Ascent any more (again...).
Given current time constraints and because no one really uses Ascent as moment to my knowledge, I decided to just disable the tests for now hoping that the Ascent devs can give some hints why a basically standard build fails.

While updating the image I also cleaned it up/improved it a bit, i.e.,
- now using the latest OpenMPI version 5.05
- using a virtual env for python packages
- installed the correct clang-format version we currently use for formatting
- installed yt
- installed nodejs (which is required to run GitHub Actions locally with `act`)

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
