### PR TITLE
Make VariableExists logic in HDF5 restart reader work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ### Fixed (not changing behavior/API/variables/...)
 - [[PR 1317]](https://github.com/parthenon-hpc-lab/parthenon/pull/1317) Make VariableExits logic in HDF5 restart reader work
+- [[PR 1288]](https://github.com/parthenon-hpc-lab/parthenon/pull/1288) Fix restriction bug for non-cartesian coordinates and make poisson_gmg example work for curvilinear coordinates
 - [[PR 1307]](https://github.com/parthenon-hpc-lab/parthenon/pull/1307) Fix imports in parthenon tools + phdf_diff logic
 - [[PR 1310]](https://github.com/parthenon-hpc-lab/parthenon/pull/1310) Fix logic causing issues for restarts with varying output blocks (introduced in #1266)
 - [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, `is_restart`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
-- [[PR 1288]](https://github.com/parthenon-hpc-lab/parthenon/pull/1288) Fix restriction bug for non-cartesian coordinates and make poisson_gmg example work for curvilinear coordinates
+- [[PR 1317]](https://github.com/parthenon-hpc-lab/parthenon/pull/1317) Make VariableExits logic in HDF5 restart reader work
 - [[PR 1307]](https://github.com/parthenon-hpc-lab/parthenon/pull/1307) Fix imports in parthenon tools + phdf_diff logic
 - [[PR 1310]](https://github.com/parthenon-hpc-lab/parthenon/pull/1310) Fix logic causing issues for restarts with varying output blocks (introduced in #1266)
 - [[PR 1297]](https://github.com/parthenon-hpc-lab/parthenon/pull/1297) Backward compatibility fixes (`last_/next_` output package, restart with new `Restart` vars, `is_restart`)

--- a/src/outputs/restart_hdf5.hpp
+++ b/src/outputs/restart_hdf5.hpp
@@ -28,6 +28,7 @@
 #include <hdf5.h>
 
 #include "interface/metadata.hpp"
+#include "outputs/parthenon_hdf5.hpp"
 #include "outputs/parthenon_hdf5_types.hpp"
 
 using namespace parthenon::HDF5;
@@ -231,7 +232,12 @@ class RestartReaderHDF5 : public RestartReader {
   [[nodiscard]] bool VariableExists(const std::string &name) const override {
 #ifdef ENABLE_HDF5
     // make sure dataset exists
-    return PARTHENON_HDF5_CHECK(H5Oexists_by_name(fh_, name.c_str(), H5P_DEFAULT));
+    // disabling error handling/printing as we take care of it
+    H5Eset_auto(H5E_DEFAULT, NULL, NULL);
+    auto status = H5Oexists_by_name(fh_, name.c_str(), H5P_DEFAULT);
+    // reenable HDF5 error handling to throw an error
+    H5Eset_auto(H5E_DEFAULT, aborting_error_handler, NULL);
+    return status > 0;
 #else
     PARTHENON_FAIL("Restart functionality is not available because HDF5 is disabled");
     return false;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

The logic inside `VariableExits` didn't properly work as an exception was thrown that was not caught.
Instead of catching the exception the return status of the HDF5 lib function is now being used.
Also the check has to be updated to `>0` as negative values are returned in the function fails (e.g., because the hierarchy could not be traversed).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
