### PR TITLE
Refactor AMR conditions to survive sparse varaibles, fix blocks < ranks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1318]](https://github.com/parthenon-hpc-lab/parthenon/pull/1318) Fix AMR criteria for sparse variables and re-fix blocks < ranks
 - [[PR 1288]](https://github.com/parthenon-hpc-lab/parthenon/pull/1288) Fix restriction bug for non-cartesian coordinates and make poisson_gmg example work for curvilinear coordinates
 - [[PR 1307]](https://github.com/parthenon-hpc-lab/parthenon/pull/1307) Fix imports in parthenon tools + phdf_diff logic
 - [[PR 1310]](https://github.com/parthenon-hpc-lab/parthenon/pull/1310) Fix logic causing issues for restarts with varying output blocks (introduced in #1266)

--- a/src/amr_criteria/refinement_package.cpp
+++ b/src/amr_criteria/refinement_package.cpp
@@ -118,28 +118,32 @@ void FirstDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::strin
       bnds.je,
       KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
         Real maxd = 0.;
-        par_reduce_inner(
-            inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
-            [&](const int i, Real &maxder) {
-              Real scale = std::abs(pack(b, var, k, j, i));
-              Real d = 0.5 *
-                       std::abs((pack(b, var, k, j, i + 1) - pack(b, var, k, j, i - 1))) /
-                       (scale + TINY_NUMBER);
-              maxder = (d > maxder ? d : maxder);
-              if (ndim > 1) {
-                d = 0.5 *
-                    std::abs((pack(b, var, k, j + 1, i) - pack(b, var, k, j - 1, i))) /
+        bool on_block = (pack.GetSize(b, PackIdx(0)) > 0);
+        if (on_block) {
+          par_reduce_inner(
+              inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
+              [&](const int i, Real &maxder) {
+                Real scale = std::abs(pack(b, var, k, j, i));
+                Real d =
+                    0.5 *
+                    std::abs((pack(b, var, k, j, i + 1) - pack(b, var, k, j, i - 1))) /
                     (scale + TINY_NUMBER);
                 maxder = (d > maxder ? d : maxder);
-              }
-              if (ndim > 2) {
-                d = 0.5 *
-                    std::abs((pack(b, var, k + 1, j, i) - pack(b, var, k - 1, j, i))) /
-                    (scale + TINY_NUMBER);
-                maxder = (d > maxder ? d : maxder);
-              }
-            },
-            Kokkos::Max<Real>(maxd));
+                if (ndim > 1) {
+                  d = 0.5 *
+                      std::abs((pack(b, var, k, j + 1, i) - pack(b, var, k, j - 1, i))) /
+                      (scale + TINY_NUMBER);
+                  maxder = (d > maxder ? d : maxder);
+                }
+                if (ndim > 2) {
+                  d = 0.5 *
+                      std::abs((pack(b, var, k + 1, j, i) - pack(b, var, k - 1, j, i))) /
+                      (scale + TINY_NUMBER);
+                  maxder = (d > maxder ? d : maxder);
+                }
+              },
+              Kokkos::Max<Real>(maxd));
+        }
         auto tags_access = scatter_tags.access();
         auto flag = AmrTag::same;
         if (maxd > refine_criteria && pack.GetLevel(b, 0, 0, 0) < max_level)
@@ -170,25 +174,28 @@ void SecondDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::stri
       bnds.je,
       KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
         Real maxd = 0.;
-        par_reduce_inner(
-            inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
-            [&](const int i, Real &maxder) {
-              Real aqt = std::abs(pack(b, var, k, j, i)) + TINY_NUMBER;
-              Real qavg = 0.5 * (pack(b, var, k, j, i + 1) + pack(b, var, k, j, i - 1));
-              Real d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
-              maxder = (d > maxder ? d : maxder);
-              if (ndim > 1) {
-                qavg = 0.5 * (pack(b, var, k, j + 1, i) + pack(b, var, k, j - 1, i));
-                d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
+        bool on_block = (pack.GetSize(b, PackIdx(0)) > 0);
+        if (on_block) {
+          par_reduce_inner(
+              inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
+              [&](const int i, Real &maxder) {
+                Real aqt = std::abs(pack(b, var, k, j, i)) + TINY_NUMBER;
+                Real qavg = 0.5 * (pack(b, var, k, j, i + 1) + pack(b, var, k, j, i - 1));
+                Real d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
                 maxder = (d > maxder ? d : maxder);
-              }
-              if (ndim > 2) {
-                qavg = 0.5 * (pack(b, var, k + 1, j, i) + pack(b, var, k - 1, j, i));
-                d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
-                maxder = (d > maxder ? d : maxder);
-              }
-            },
-            Kokkos::Max<Real>(maxd));
+                if (ndim > 1) {
+                  qavg = 0.5 * (pack(b, var, k, j + 1, i) + pack(b, var, k, j - 1, i));
+                  d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
+                  maxder = (d > maxder ? d : maxder);
+                }
+                if (ndim > 2) {
+                  qavg = 0.5 * (pack(b, var, k + 1, j, i) + pack(b, var, k - 1, j, i));
+                  d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
+                  maxder = (d > maxder ? d : maxder);
+                }
+              },
+              Kokkos::Max<Real>(maxd));
+        }
         auto tags_access = scatter_tags.access();
         auto flag = AmrTag::same;
         if (maxd > refine_criteria && pack.GetLevel(b, 0, 0, 0) < max_level)
@@ -220,14 +227,17 @@ void Magnitude(const AMRBounds &bnds, MeshData<Real> *md, const std::string &fie
       KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
         // JMM: sign = 1  if you want to refine on mag > threshold
         //      sign = -1 if you want to regine on mag < threshold
-        Real maxval;
-        par_reduce_inner(
-            inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
-            [&](const int i, Real &r) {
-              Real val = sign * pack(b, var, k, j, i);
-              r = std::max(r, val);
-            },
-            Kokkos::Max<Real>(maxval));
+        Real maxval = 0;
+        bool on_block = (pack.GetSize(b, PackIdx(0)) > 0);
+        if (on_block) {
+          par_reduce_inner(
+              inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
+              [&](const int i, Real &r) {
+                Real val = sign * pack(b, var, k, j, i);
+                r = std::max(r, val);
+              },
+              Kokkos::Max<Real>(maxval));
+        }
         auto tags_access = scatter_tags.access();
         auto flag = AmrTag::same;
         if (maxval > sign * refine_criteria && pack.GetLevel(b, 0, 0, 0) < max_level)

--- a/src/amr_criteria/refinement_package.cpp
+++ b/src/amr_criteria/refinement_package.cpp
@@ -98,14 +98,15 @@ AmrTag CheckAllRefinement(MeshBlockData<Real> *rc, const AmrTag &level) {
   return delta_level;
 }
 
-void FirstDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::string &field,
-                     const int &idx, ParArray1D<AmrTag> &amr_tags,
-                     const Real refine_criteria_, const Real derefine_criteria_,
-                     const int max_level_) {
+template <typename InnerLoop_t>
+void CheckRefinementLoop(const AMRBounds &bnds, MeshData<Real> *md,
+                         const std::string &field, const int &idx,
+                         ParArray1D<AmrTag> &amr_tags, const Real refine_criteria_,
+                         const Real derefine_criteria_, const int max_level_,
+                         const InnerLoop_t &&inner_loop, const Real sign = 1.0) {
   const auto desc = MakePackDescriptor(md, {field});
   auto pack = desc.GetPack(md);
   const int ndim = md->GetMeshPointer()->ndim;
-  const int nvars = pack.GetMaxNumberOfVars();
 
   const Real refine_criteria = refine_criteria_;
   const Real derefine_criteria = derefine_criteria_;
@@ -117,125 +118,12 @@ void FirstDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::strin
       PARTHENON_AUTO_LABEL, 0, 0, 0, pack.GetNBlocks() - 1, bnds.ks, bnds.ke, bnds.js,
       bnds.je,
       KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
-        Real maxd = 0.;
-        bool on_block = (pack.GetSize(b, PackIdx(0)) > 0);
-        if (on_block) {
-          par_reduce_inner(
-              inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
-              [&](const int i, Real &maxder) {
-                Real scale = std::abs(pack(b, var, k, j, i));
-                Real d =
-                    0.5 *
-                    std::abs((pack(b, var, k, j, i + 1) - pack(b, var, k, j, i - 1))) /
-                    (scale + TINY_NUMBER);
-                maxder = (d > maxder ? d : maxder);
-                if (ndim > 1) {
-                  d = 0.5 *
-                      std::abs((pack(b, var, k, j + 1, i) - pack(b, var, k, j - 1, i))) /
-                      (scale + TINY_NUMBER);
-                  maxder = (d > maxder ? d : maxder);
-                }
-                if (ndim > 2) {
-                  d = 0.5 *
-                      std::abs((pack(b, var, k + 1, j, i) - pack(b, var, k - 1, j, i))) /
-                      (scale + TINY_NUMBER);
-                  maxder = (d > maxder ? d : maxder);
-                }
-              },
-              Kokkos::Max<Real>(maxd));
-        }
-        auto tags_access = scatter_tags.access();
-        auto flag = AmrTag::same;
-        if (maxd > refine_criteria && pack.GetLevel(b, 0, 0, 0) < max_level)
-          flag = AmrTag::refine;
-        if (maxd < derefine_criteria) flag = AmrTag::derefine;
-        tags_access(b).update(flag);
-      });
-  amr_tags.ContributeScatter(scatter_tags);
-}
-
-void SecondDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::string &field,
-                      const int &idx, ParArray1D<AmrTag> &amr_tags,
-                      const Real refine_criteria_, const Real derefine_criteria_,
-                      const int max_level_) {
-  const auto desc = MakePackDescriptor(md, {field});
-  auto pack = desc.GetPack(md);
-  const int ndim = md->GetMeshPointer()->ndim;
-  const int nvars = pack.GetMaxNumberOfVars();
-
-  const Real refine_criteria = refine_criteria_;
-  const Real derefine_criteria = derefine_criteria_;
-  const int max_level = max_level_;
-  const int var = idx;
-  // get a scatterview for the tags that will use Kokkos::Max as the reduction operation
-  auto scatter_tags = amr_tags.ToScatterView<Kokkos::Experimental::ScatterMax>();
-  par_for_outer(
-      PARTHENON_AUTO_LABEL, 0, 0, 0, pack.GetNBlocks() - 1, bnds.ks, bnds.ke, bnds.js,
-      bnds.je,
-      KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
-        Real maxd = 0.;
-        bool on_block = (pack.GetSize(b, PackIdx(0)) > 0);
-        if (on_block) {
-          par_reduce_inner(
-              inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
-              [&](const int i, Real &maxder) {
-                Real aqt = std::abs(pack(b, var, k, j, i)) + TINY_NUMBER;
-                Real qavg = 0.5 * (pack(b, var, k, j, i + 1) + pack(b, var, k, j, i - 1));
-                Real d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
-                maxder = (d > maxder ? d : maxder);
-                if (ndim > 1) {
-                  qavg = 0.5 * (pack(b, var, k, j + 1, i) + pack(b, var, k, j - 1, i));
-                  d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
-                  maxder = (d > maxder ? d : maxder);
-                }
-                if (ndim > 2) {
-                  qavg = 0.5 * (pack(b, var, k + 1, j, i) + pack(b, var, k - 1, j, i));
-                  d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
-                  maxder = (d > maxder ? d : maxder);
-                }
-              },
-              Kokkos::Max<Real>(maxd));
-        }
-        auto tags_access = scatter_tags.access();
-        auto flag = AmrTag::same;
-        if (maxd > refine_criteria && pack.GetLevel(b, 0, 0, 0) < max_level)
-          flag = AmrTag::refine;
-        if (maxd < derefine_criteria) flag = AmrTag::derefine;
-        tags_access(b).update(flag);
-      });
-  amr_tags.ContributeScatter(scatter_tags);
-}
-
-void Magnitude(const AMRBounds &bnds, MeshData<Real> *md, const std::string &field,
-               const int &idx, ParArray1D<AmrTag> &amr_tags, const Real sign,
-               const Real refine_criteria_, const Real derefine_criteria_,
-               const int max_level_) {
-  const auto desc = MakePackDescriptor(md, {field});
-  auto pack = desc.GetPack(md);
-  const int ndim = md->GetMeshPointer()->ndim;
-  const int nvars = pack.GetMaxNumberOfVars();
-
-  const Real refine_criteria = refine_criteria_;
-  const Real derefine_criteria = derefine_criteria_;
-  const int max_level = max_level_;
-  const int var = idx;
-  // get a scatterview for the tags that will use Kokkos::Max as the reduction operation
-  auto scatter_tags = amr_tags.ToScatterView<Kokkos::Experimental::ScatterMax>();
-  par_for_outer(
-      PARTHENON_AUTO_LABEL, 0, 0, 0, pack.GetNBlocks() - 1, bnds.ks, bnds.ke, bnds.js,
-      bnds.je,
-      KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
-        // JMM: sign = 1  if you want to refine on mag > threshold
-        //      sign = -1 if you want to regine on mag < threshold
         Real maxval = 0;
-        bool on_block = (pack.GetSize(b, PackIdx(0)) > 0);
+        bool on_block = (pack.GetUpperBound(b) >= 0);
         if (on_block) {
           par_reduce_inner(
               inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,
-              [&](const int i, Real &r) {
-                Real val = sign * pack(b, var, k, j, i);
-                r = std::max(r, val);
-              },
+              [=](const int i, Real &r) { inner_loop(pack, ndim, b, var, k, j, i, r); },
               Kokkos::Max<Real>(maxval));
         }
         auto tags_access = scatter_tags.access();
@@ -246,6 +134,70 @@ void Magnitude(const AMRBounds &bnds, MeshData<Real> *md, const std::string &fie
         tags_access(b).update(flag);
       });
   amr_tags.ContributeScatter(scatter_tags);
+}
+
+void FirstDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::string &field,
+                     const int &idx, ParArray1D<AmrTag> &amr_tags,
+                     const Real refine_criteria_, const Real derefine_criteria_,
+                     const int max_level_) {
+  CheckRefinementLoop(
+      bnds, md, field, idx, amr_tags, refine_criteria_, derefine_criteria_, max_level_,
+      KOKKOS_LAMBDA(auto pack, const int ndim, const int b, const int var, const int k,
+                    const int j, const int i, Real &maxder) {
+        Real scale = std::abs(pack(b, var, k, j, i));
+        Real d = 0.5 * std::abs((pack(b, var, k, j, i + 1) - pack(b, var, k, j, i - 1))) /
+                 (scale + TINY_NUMBER);
+        maxder = (d > maxder ? d : maxder);
+        if (ndim > 1) {
+          d = 0.5 * std::abs((pack(b, var, k, j + 1, i) - pack(b, var, k, j - 1, i))) /
+              (scale + TINY_NUMBER);
+          maxder = (d > maxder ? d : maxder);
+        }
+        if (ndim > 2) {
+          d = 0.5 * std::abs((pack(b, var, k + 1, j, i) - pack(b, var, k - 1, j, i))) /
+              (scale + TINY_NUMBER);
+          maxder = (d > maxder ? d : maxder);
+        }
+      });
+}
+
+void SecondDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::string &field,
+                      const int &idx, ParArray1D<AmrTag> &amr_tags,
+                      const Real refine_criteria_, const Real derefine_criteria_,
+                      const int max_level_) {
+  CheckRefinementLoop(
+      bnds, md, field, idx, amr_tags, refine_criteria_, derefine_criteria_, max_level_,
+      KOKKOS_LAMBDA(auto pack, const int ndim, const int b, const int var, const int k,
+                    const int j, const int i, Real &maxder) {
+        Real aqt = std::abs(pack(b, var, k, j, i)) + TINY_NUMBER;
+        Real qavg = 0.5 * (pack(b, var, k, j, i + 1) + pack(b, var, k, j, i - 1));
+        Real d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
+        maxder = (d > maxder ? d : maxder);
+        if (ndim > 1) {
+          qavg = 0.5 * (pack(b, var, k, j + 1, i) + pack(b, var, k, j - 1, i));
+          d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
+          maxder = (d > maxder ? d : maxder);
+        }
+        if (ndim > 2) {
+          qavg = 0.5 * (pack(b, var, k + 1, j, i) + pack(b, var, k - 1, j, i));
+          d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
+          maxder = (d > maxder ? d : maxder);
+        }
+      });
+}
+
+void Magnitude(const AMRBounds &bnds, MeshData<Real> *md, const std::string &field,
+               const int &idx, ParArray1D<AmrTag> &amr_tags, const Real sign,
+               const Real refine_criteria_, const Real derefine_criteria_,
+               const int max_level_) {
+  CheckRefinementLoop(
+      bnds, md, field, idx, amr_tags, refine_criteria_, derefine_criteria_, max_level_,
+      KOKKOS_LAMBDA(auto pack, const int ndim, const int b, const int var, const int k,
+                    const int j, const int i, Real &r) {
+        Real val = sign * pack(b, var, k, j, i);
+        r = std::max(r, val);
+      },
+      sign);
 }
 
 void SetRefinement_(MeshBlockData<Real> *rc,

--- a/src/amr_criteria/refinement_package.cpp
+++ b/src/amr_criteria/refinement_package.cpp
@@ -123,7 +123,7 @@ void CheckRefinementLoop(const AMRBounds &bnds, MeshData<Real> *md,
       PARTHENON_AUTO_LABEL, 0, 0, 0, nblocks - 1, bnds.ks, bnds.ke, bnds.js, bnds.je,
       KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
         Real maxval = 0;
-        bool on_block = (pack.GetUpperBound(b) >= 0);
+        bool on_block = (pack.GetUpperBound(b) >= var);
         if (on_block) {
           par_reduce_inner(
               inner_loop_pattern_ttr_tag, team_member, bnds.is, bnds.ie,

--- a/src/amr_criteria/refinement_package.cpp
+++ b/src/amr_criteria/refinement_package.cpp
@@ -146,8 +146,8 @@ void FirstDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::strin
                      const int max_level_) {
   CheckRefinementLoop(
       bnds, md, field, idx, amr_tags, refine_criteria_, derefine_criteria_, max_level_,
-      KOKKOS_LAMBDA(auto pack, const int ndim, const int b, const int var, const int k,
-                    const int j, const int i, Real &maxder) {
+      KOKKOS_LAMBDA(SparsePack<> pack, const int ndim, const int b, const int var,
+                    const int k, const int j, const int i, Real &maxder) {
         Real scale = std::abs(pack(b, var, k, j, i));
         Real d = 0.5 * std::abs((pack(b, var, k, j, i + 1) - pack(b, var, k, j, i - 1))) /
                  (scale + TINY_NUMBER);
@@ -171,8 +171,8 @@ void SecondDerivative(const AMRBounds &bnds, MeshData<Real> *md, const std::stri
                       const int max_level_) {
   CheckRefinementLoop(
       bnds, md, field, idx, amr_tags, refine_criteria_, derefine_criteria_, max_level_,
-      KOKKOS_LAMBDA(auto pack, const int ndim, const int b, const int var, const int k,
-                    const int j, const int i, Real &maxder) {
+      KOKKOS_LAMBDA(SparsePack<> pack, const int ndim, const int b, const int var,
+                    const int k, const int j, const int i, Real &maxder) {
         Real aqt = std::abs(pack(b, var, k, j, i)) + TINY_NUMBER;
         Real qavg = 0.5 * (pack(b, var, k, j, i + 1) + pack(b, var, k, j, i - 1));
         Real d = std::abs(qavg - pack(b, var, k, j, i)) / (std::abs(qavg) + aqt);
@@ -196,8 +196,8 @@ void Magnitude(const AMRBounds &bnds, MeshData<Real> *md, const std::string &fie
                const int max_level_) {
   CheckRefinementLoop(
       bnds, md, field, idx, amr_tags, refine_criteria_, derefine_criteria_, max_level_,
-      KOKKOS_LAMBDA(auto pack, const int ndim, const int b, const int var, const int k,
-                    const int j, const int i, Real &r) {
+      KOKKOS_LAMBDA(SparsePack<> pack, const int ndim, const int b, const int var,
+                    const int k, const int j, const int i, Real &r) {
         Real val = sign * pack(b, var, k, j, i);
         r = std::max(r, val);
       },

--- a/src/amr_criteria/refinement_package.cpp
+++ b/src/amr_criteria/refinement_package.cpp
@@ -112,11 +112,15 @@ void CheckRefinementLoop(const AMRBounds &bnds, MeshData<Real> *md,
   const Real derefine_criteria = derefine_criteria_;
   const int max_level = max_level_;
   const int var = idx;
+
+  const std::size_t nblocks = pack.GetNBlocks();
+  if (nblocks < 1) return;
+
   // get a scatterview for the tags that will use Kokkos::Max as the reduction operation
   auto scatter_tags = amr_tags.ToScatterView<Kokkos::Experimental::ScatterMax>();
+
   par_for_outer(
-      PARTHENON_AUTO_LABEL, 0, 0, 0, pack.GetNBlocks() - 1, bnds.ks, bnds.ke, bnds.js,
-      bnds.je,
+      PARTHENON_AUTO_LABEL, 0, 0, 0, nblocks - 1, bnds.ks, bnds.ke, bnds.js, bnds.je,
       KOKKOS_LAMBDA(team_mbr_t team_member, const int b, const int k, const int j) {
         Real maxval = 0;
         bool on_block = (pack.GetUpperBound(b) >= 0);

--- a/src/amr_criteria/refinement_package.hpp
+++ b/src/amr_criteria/refinement_package.hpp
@@ -53,7 +53,6 @@ void Magnitude(const AMRBounds &bnds, MeshData<Real> *md, const std::string &fie
                const int &idx, ParArray1D<AmrTag> &amr_tags, const Real sign,
                const Real refine_criteria_, const Real derefine_criteria_,
                const int max_level_);
-
 } // namespace Refinement
 } // namespace parthenon
 #endif // AMR_CRITERIA_REFINEMENT_PACKAGE_HPP_

--- a/src/amr_criteria/refinement_package.hpp
+++ b/src/amr_criteria/refinement_package.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -667,6 +667,11 @@ void Mesh::BuildTagMapAndBoundaryBuffers() {
 
 void Mesh::CommunicateBoundaries(std::string md_name,
                                  const std::vector<std::string> &fields) {
+  // JMM: The tasking logic isn't robust against blocks < ranks, which
+  // we may have at this point, so if there's no blocks on this rank,
+  // just quit out and continue
+  if (GetNumMeshBlocksThisRank(Globals::my_rank) < 1) return;
+
   const int num_partitions = DefaultNumPartitions();
 
   TaskCollection tc;

--- a/tst/regression/CMakeLists.txt
+++ b/tst/regression/CMakeLists.txt
@@ -118,6 +118,12 @@ if (ENABLE_HDF5)
     --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/advection_outflow/parthinput.advection_outflow")
   list(APPEND EXTRA_TEST_LABELS "")
 
+  list(APPEND TEST_DIRS advection_undersubscribed)
+  list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
+  list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \
+    --driver_input ${CMAKE_CURRENT_SOURCE_DIR}/test_suites/advection_undersubscribed/parthinput.advection_undersubscribed")
+  list(APPEND EXTRA_TEST_LABELS "")
+
   list(APPEND TEST_DIRS bvals)
   list(APPEND TEST_PROCS ${NUM_MPI_PROC_TESTING})
   list(APPEND TEST_ARGS "--driver ${PROJECT_BINARY_DIR}/example/advection/advection-example \

--- a/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
+++ b/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
@@ -1,9 +1,9 @@
 # ========================================================================================
 # Parthenon performance portable AMR framework
-# Copyright(C) 2020-2024 The Parthenon collaboration
+# Copyright(C) 2020-2025 The Parthenon collaboration
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
+++ b/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
@@ -42,7 +42,7 @@ class TestCase(utils.test_case.TestCaseAbs):
                 dx = (f["Locations/x"][:, 1:] - f["Locations/x"][:, :-1])[:, 0]
                 dy = (f["Locations/y"][:, 1:] - f["Locations/y"][:, :-1])[:, 0]
                 vol = dx * dy
-                vol_sumn = (vols[:, None, None] * f["advected"][:, 0, 0, ...]).sum()
+                vol_sum = (vols[:, None, None] * f["advected"][:, 0, 0, ...]).sum()
         except:
             print("Couldn't open dump file or read all fields")
             return False

--- a/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
+++ b/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
@@ -1,0 +1,57 @@
+# ========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2020-2024 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+# ========================================================================================
+# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+#
+# This program was produced under U.S. Government contract 89233218CNA000001 for Los
+# Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+# for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+# in the program are reserved by Triad National Security, LLC, and the U.S. Department
+# of Energy/National Nuclear Security Administration. The Government is granted for
+# itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+# license in this material to reproduce, prepare derivative works, distribute copies to
+# the public, perform publicly and display publicly, and to permit others to do so.
+# ========================================================================================
+
+# Modules
+import sys
+import utils.test_case
+
+# To prevent littering up imported folders with .pyc files or __pycache_ folder
+sys.dont_write_bytecode = True
+
+
+class TestCase(utils.test_case.TestCaseAbs):
+    def Prepare(self, parameters, step):
+        parameters.coverage_status = "both"
+        return parameters
+
+    def Analyse(self, parameters):
+        try:
+            import h5py
+        except ModuleNotFoundError:
+            print("Couldn't find module h5py.")
+            return False
+
+        vol_sum = 0
+        vol_sum_true = 0.07080078125
+        try:
+            with h5py.File("undersubscribed.out0.final.phdf", "r") as f:
+                dx = (f["Locations/x"][:, 1:] - f["Locations/x"][:, :-1])[:, 0]
+                dy = (f["Locations/y"][:, 1:] - f["Locations/y"][:, :-1])[:, 0]
+                vol = dx * dy
+                vol_sumn = (vols[:, None, None] * f["advected"][:, 0, 0, ...]).sum()
+        except:
+            print("Couldn't open dump file or read all fields")
+            return False
+
+        if np.abs(vol_sum - vol_sum_true) > 1e-10:
+            print(
+                "Sum of advected field not correct. Measured = {:14e}, True = {:14e}".format(
+                    vol_sum, vol_sum_true
+                )
+            )
+            return False
+        return True

--- a/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
+++ b/tst/regression/test_suites/advection_undersubscribed/advection_undersubscribed.py
@@ -34,6 +34,11 @@ class TestCase(utils.test_case.TestCaseAbs):
         except ModuleNotFoundError:
             print("Couldn't find module h5py.")
             return False
+        try:
+            import numpy as np
+        except ModuleNotFoundError:
+            print("Couldn't find module numpy")
+            return False
 
         vol_sum = 0
         vol_sum_true = 0.07080078125
@@ -42,7 +47,7 @@ class TestCase(utils.test_case.TestCaseAbs):
                 dx = (f["Locations/x"][:, 1:] - f["Locations/x"][:, :-1])[:, 0]
                 dy = (f["Locations/y"][:, 1:] - f["Locations/y"][:, :-1])[:, 0]
                 vol = dx * dy
-                vol_sum = (vols[:, None, None] * f["advected"][:, 0, 0, ...]).sum()
+                vol_sum = (vol[:, None, None] * f["advected"][:, 0, 0, ...]).sum()
         except:
             print("Couldn't open dump file or read all fields")
             return False

--- a/tst/regression/test_suites/advection_undersubscribed/parthinput.advection_undersubscribed
+++ b/tst/regression/test_suites/advection_undersubscribed/parthinput.advection_undersubscribed
@@ -1,0 +1,68 @@
+# ========================================================================================
+#  Athena++ astrophysical MHD code
+#  Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
+#  Licensed under the 3-clause BSD License, see LICENSE file for details
+# ========================================================================================
+#  (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+#
+#  This program was produced under U.S. Government contract 89233218CNA000001 for Los
+#  Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+#  for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+#  in the program are reserved by Triad National Security, LLC, and the U.S. Department
+#  of Energy/National Nuclear Security Administration. The Government is granted for
+#  itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+#  license in this material to reproduce, prepare derivative works, distribute copies to
+#  the public, perform publicly and display publicly, and to permit others to do so.
+# ========================================================================================
+
+<parthenon/job>
+problem_id = undersubscribed
+
+<parthenon/mesh>
+refinement = adaptive
+numlevel = 2
+
+nx1 = 64
+x1min = -0.5
+x1max = 0.5
+ix1_bc = periodic
+ox1_bc = periodic
+
+nx2 = 64
+x2min = -0.5
+x2max = 0.5
+ix2_bc = periodic
+ox2_bc = periodic
+
+nx3 = 1
+x3min = -0.5
+x3max = 0.5
+ix3_bc = outflow
+ox3_bc = outflow
+
+<parthenon/meshblock>
+nx1 = 64
+nx2 = 32
+nx3 = 1
+
+<parthenon/time>
+nlim = 4
+#tlim = 0.5
+integrator = rk2
+
+<Advection>
+cfl = 0.45
+vx = 1.0
+vy = 1.0
+vz = 0.0
+profile = hard_sphere
+
+refine_tol = 0.3    # control the package specific refinement tagging function
+derefine_tol = 0.03
+compute_error = false
+num_vars = 1 # number of variables in variable vector
+
+<parthenon/output0>
+file_type = hdf5
+dt = 0.5
+variables = advected, my_derived_var

--- a/tst/regression/test_suites/advection_undersubscribed/parthinput.advection_undersubscribed
+++ b/tst/regression/test_suites/advection_undersubscribed/parthinput.advection_undersubscribed
@@ -1,4 +1,8 @@
 # ========================================================================================
+# Parthenon performance portable AMR framework
+# Copyright(C) 2020-2025 The Parthenon collaboration
+# Licensed under the 3-clause BSD License, see LICENSE file for details
+# ========================================================================================
 #  Athena++ astrophysical MHD code
 #  Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 #  Licensed under the 3-clause BSD License, see LICENSE file for details


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In riot we recently tried to refine on a sparse variable, and found that the refinement conditions in parthenon are not robust to a variable being absent. I also noticed that initialization with blocks < ranks on the base mesh is broken again.

I fix both in this MR, and also refactor the AMR criteria to be a little cleaner. Finally, I add a new regression test to check that the code runs when blocks < ranks. It starts with 2 blocks, but the MPI test runs with more, so it should catch that problem going forward.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
