### PR TITLE
Allow nmax_pool to be set by metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1326]](https://github.com/parthenon-hpc-lab/parthenon/pull/1326) Thread initial swarm pool size into userspace via metadata
 - [[PR 1320]](https://github.com/parthenon-hpc-lab/parthenon/pull/1320) 1D Contour plotting
 - [[PR 1315]](https://github.com/parthenon-hpc-lab/parthenon/pull/1315) Add user specifiable BCs to solvers
 - [[PR 1192]](https://github.com/parthenon-hpc-lab/parthenon/pull/1192) Coalesced buffer communication

--- a/doc/sphinx/src/particles.rst
+++ b/doc/sphinx/src/particles.rst
@@ -39,6 +39,13 @@ by the associated ``MeshBlock``. The ``MeshBlock`` is pointed to by ``Swarm::pmy
 ``MeshBlockData`` pointed to by the ``b`` index within a ``MeshData``.  We currently only
 permit ``Swarm``s to be retrieved from ``"base"`` ``MeshBlockData`` and ``MeshData``.
 
+.. note::
+
+   Swarms manage a "pool" of particles. Memory is reserved for this
+   pool in a greedy fashion. When more particles are required, the
+   pool is expanded. You can set the default initial number of
+   particles that the reservation holds for a given swarm by calling
+   ``metadata.SetInitialSwarmPoolReservation(nparticles);``.
 
 The ``Swarm`` is a host-side object, but some of its data members are
 required for device- side compution. To access this data, a

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -375,6 +375,9 @@ class Metadata {
   std::shared_ptr<Metadata> flux_metadata;
 
  public:
+  // TODO(JMM): I'm not sure where this should go...
+  static constexpr const std::size_t SWARM_DEFAULT_NMAX_POOL = 3;
+
   // Static routines
   static MetadataFlag AddUserFlag(const std::string &name);
   static bool FlagNameExists(const std::string &flagname);
@@ -601,6 +604,9 @@ class Metadata {
     return component_labels_;
   }
 
+  void SetInitialSwarmPoolReservation(const std::size_t s) { swarm_nmax_pool_ = s; }
+  std::size_t InitialSwarmPoolReservation() const noexcept { return swarm_nmax_pool_; }
+
  private:
   /// the attribute flags that are set for the class
   refinement::RefinementFunctions_t refinement_funcs_;
@@ -613,6 +619,7 @@ class Metadata {
   parthenon::Real allocation_threshold_;
   parthenon::Real deallocation_threshold_;
   parthenon::Real default_value_;
+  std::size_t swarm_nmax_pool_ = SWARM_DEFAULT_NMAX_POOL;
 
   /// if flag is true set bit, clears otherwise
   void DoBit(MetadataFlag bit, bool flag) {

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.cpp
+++ b/src/interface/swarm.cpp
@@ -67,7 +67,8 @@ SwarmDeviceContext Swarm::GetDeviceContext() const {
   return context;
 }
 
-Swarm::Swarm(const std::string &label, const Metadata &metadata, const int nmax_pool_in)
+Swarm::Swarm(const std::string &label, const Metadata &metadata,
+             const std::size_t nmax_pool_in)
     : label_(label), m_(metadata), nmax_pool_(nmax_pool_in), mask_("mask", nmax_pool_),
       marked_for_removal_("mfr", nmax_pool_),
       empty_indices_("empty_indices_", nmax_pool_),

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -92,7 +92,8 @@ class Swarm {
   }
 
  public:
-  Swarm(const std::string &label, const Metadata &metadata, const int nmax_pool_in);
+  Swarm(const std::string &label, const Metadata &metadata,
+        const std::size_t nmax_pool_in);
   Swarm(const std::string &label, const Metadata &metadata)
       : Swarm(label, metadata, metadata.InitialSwarmPoolReservation()) {}
 

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/swarm.hpp
+++ b/src/interface/swarm.hpp
@@ -92,7 +92,9 @@ class Swarm {
   }
 
  public:
-  Swarm(const std::string &label, const Metadata &metadata, const int nmax_pool_in = 3);
+  Swarm(const std::string &label, const Metadata &metadata, const int nmax_pool_in);
+  Swarm(const std::string &label, const Metadata &metadata)
+      : Swarm(label, metadata, metadata.InitialSwarmPoolReservation()) {}
 
   ~Swarm() = default;
 
@@ -272,7 +274,7 @@ class Swarm {
   int num_active_ = 0;
   std::string label_;
   Metadata m_;
-  int nmax_pool_;
+  std::size_t nmax_pool_;
   std::string info_;
   std::tuple<ParticleVariableVector<int>, ParticleVariableVector<Real>,
              ParticleVariableVector<std::uint64_t>>

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -99,11 +99,14 @@ TEST_CASE("Swarm memory management", "[Swarm][MPI]") {
   }
   meshblock->pmy_mesh = mesh.get();
   Metadata m;
-  auto swarm = std::make_shared<Swarm>("test swarm", m, NUMINIT);
+  m.SetInitialSwarmPoolReservation(NUMINIT);
+  auto swarm = std::make_shared<Swarm>("test swarm", m);
   swarm->SetBlockPointer(meshblock);
   auto swarm_d = swarm->GetDeviceContext();
   REQUIRE(swarm->GetNumActive() == 0);
   REQUIRE(swarm->GetMaxActiveIndex() == Swarm::inactive_max_active_index);
+  auto mask = swarm->GetMask();
+  REQUIRE(mask.size() == NUMINIT);
   ParArrayND<int> failures_d("Number of failures", 1);
   meshblock->par_for(
       "Reset", 0, 0, KOKKOS_LAMBDA(const int n) { failures_d(n) = 0; });


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR threads to userspace the initial size of the reservation of a swarm pool (i.e., the number of particles it can hold). This doesn't change functionality, as the pool grows greedily, but it can be useful because it will require fewer malloc calls as particle counts grow and the pool grows greedily. You can now set it with

```C++
metadata.SetInitialSwarmPoolReservation(n);
```

I also change this reservation size internally to be a `std::size_t` instead of an `int`, which I think it should be anyway. As suggested/requested by the Artemis/Jaybenne team. Ping @adamdempsey90.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
