### PR TITLE
[Trivial]: eliminate warnings from ViewOfViewAlloc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1327]](https://github.com/parthenon-hpc-lab/parthenon/pull/1327) Eliminate warnings from ViewOfViewAlloc
 - [[PR 1328]](https://github.com/parthenon-hpc-lab/parthenon/pull/1328) Add more useful error message for task list timeout
 - [[PR 1324]](https://github.com/parthenon-hpc-lab/parthenon/pull/1324) Fix SMR error check at initialization
 - [[PR 1318]](https://github.com/parthenon-hpc-lab/parthenon/pull/1318) Fix AMR criteria for sparse variables and re-fix blocks < ranks

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -727,9 +727,8 @@ template <typename T = DevMemSpace>
 auto ViewOfViewAlloc(const std::string &label) {
   if constexpr (std::is_same_v<T, HostMemSpace>) {
     return Kokkos::view_alloc(Kokkos::SequentialHostInit, label);
-  } else {
-    return Kokkos::view_alloc(label);
   }
+  return Kokkos::view_alloc(label);
 }
 
 // Returns a host mirror view with the `SequentialHostInit` property for proper

--- a/src/kokkos_abstraction.hpp
+++ b/src/kokkos_abstraction.hpp
@@ -723,12 +723,16 @@ par_reduce_inner(InnerLoopPatternTTR, team_mbr_t team_member, const int il, cons
 // on the host. If the ViewOfViews in on the device, then `SequentialHostInit` should be
 // passed when calling `create_mirror_view`, which is automatically handled by the
 // create_view_of_view_mirror() function below.
+// JMM: Replaced if constexpr with template specialization to quiet
+// clang-based compiler warnings. Clang didn't likat the return
+// statement was in an if constexpr/else block.
 template <typename T = DevMemSpace>
 auto ViewOfViewAlloc(const std::string &label) {
-  if constexpr (std::is_same_v<T, HostMemSpace>) {
-    return Kokkos::view_alloc(Kokkos::SequentialHostInit, label);
-  }
   return Kokkos::view_alloc(label);
+}
+template <>
+inline auto ViewOfViewAlloc<HostMemSpace>(const std::string &label) {
+  return Kokkos::view_alloc(Kokkos::SequentialHostInit, label);
 }
 
 // Returns a host mirror view with the `SequentialHostInit` property for proper


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

nvhpc and clang builds warn on this function because the return statement is in an `else`. I just remove the else.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
