### PR TITLE
[trivial] more useful error message for timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1328]](https://github.com/parthenon-hpc-lab/parthenon/pull/1328) Add more useful error message for task list timeout
 - [[PR 1324]](https://github.com/parthenon-hpc-lab/parthenon/pull/1324) Fix SMR error check at initialization
 - [[PR 1318]](https://github.com/parthenon-hpc-lab/parthenon/pull/1318) Fix AMR criteria for sparse variables and re-fix blocks < ranks
 - [[PR 1317]](https://github.com/parthenon-hpc-lab/parthenon/pull/1317) Make VariableExits logic in HDF5 restart reader work

--- a/src/tasks/thread_pool.hpp
+++ b/src/tasks/thread_pool.hpp
@@ -36,7 +36,7 @@ namespace impl {
 inline void print_timeout_warning_message(std::chrono::seconds max_time) {
   if (Globals::my_rank == 0) {
     std::stringstream msg;
-    msg << "\nA given task list took longer than the current max number of\n"
+    msg << "\nA given task collection took longer than the current max number of\n"
         << "\t" << max_time.count() << " seconds to complete and terminated.\n"
         << "\tIf this long duration is intended, change the timeout by updating\n"
         << "\tthe parameter parthenon/mesh/task_collection_timeout_in_seconds\n"

--- a/src/tasks/thread_pool.hpp
+++ b/src/tasks/thread_pool.hpp
@@ -37,7 +37,7 @@ inline void print_timeout_warning_message(std::chrono::seconds max_time) {
   if (Globals::my_rank == 0) {
     std::stringstream msg;
     msg << "A given task list took longer than the current max number of\n"
-        << max_time.count() << " seconds to complete and program terminated.\n"
+        << max_time.count() << " seconds to complete and terminated.\n"
         << "If this long duration is intended, change the timeout by updating\n"
         << "the parameter parthenon/mesh/task_collection_timeout_in_seconds\n"
         << "to a larger value. You may also wish to run on more resources.";

--- a/src/tasks/thread_pool.hpp
+++ b/src/tasks/thread_pool.hpp
@@ -21,13 +21,30 @@
 #include <memory>
 #include <mutex>
 #include <queue>
+#include <sstream>
 #include <thread>
 #include <utility>
 #include <vector>
 
+#include "utils/error_checking.hpp"
+
 namespace parthenon {
 
 class TaskList;
+
+namespace impl {
+inline void print_timeout_warning_message(std::chrono::seconds max_time) {
+  if (Globals::my_rank == 0) {
+    std::stringstream msg;
+    msg << "A given task list took longer than the current max number of\n"
+        << max_time.count() << " seconds to complete and program terminated.\n"
+        << "If this long duration is intended, change the timeout by updating\n"
+        << "the parameter parthenon/mesh/task_collection_timeout_in_seconds\n"
+        << "to a larger value. You may also wish to run on more resources.";
+    PARTHENON_WARN(msg);
+  }
+}
+} // namespace impl
 
 template <typename T>
 class ThreadQueue {
@@ -81,7 +98,10 @@ class ThreadQueue {
       complete = false;
       waiting = false;
     }
-    if (timeout) signal_kill();
+    if (timeout) {
+      impl::print_timeout_warning_message(max_time);
+      signal_kill();
+    }
     return timeout;
   }
 
@@ -224,7 +244,10 @@ class SerialPool {
         if (ret == TaskStatus::fail) overall = TaskStatus::fail;
       }
       queue.pop();
-      if (timeout_check()) return TaskStatus::fail;
+      if (timeout_check()) {
+        impl::print_timeout_warning_message(timeout_duration);
+        return TaskStatus::fail;
+      }
     }
     return overall;
   }

--- a/src/tasks/thread_pool.hpp
+++ b/src/tasks/thread_pool.hpp
@@ -36,11 +36,11 @@ namespace impl {
 inline void print_timeout_warning_message(std::chrono::seconds max_time) {
   if (Globals::my_rank == 0) {
     std::stringstream msg;
-    msg << "A given task list took longer than the current max number of\n"
-        << max_time.count() << " seconds to complete and terminated.\n"
-        << "If this long duration is intended, change the timeout by updating\n"
-        << "the parameter parthenon/mesh/task_collection_timeout_in_seconds\n"
-        << "to a larger value. You may also wish to run on more resources.";
+    msg << "\nA given task list took longer than the current max number of\n"
+        << "\t" << max_time.count() << " seconds to complete and terminated.\n"
+        << "\tIf this long duration is intended, change the timeout by updating\n"
+        << "\tthe parameter parthenon/mesh/task_collection_timeout_in_seconds\n"
+        << "\tto a larger value. You may also wish to run on more resources.";
     PARTHENON_WARN(msg);
   }
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

MR #1244 added task collection timeouts. There was much discussion in issue #1282 about what the default value should be and we settled on 5 minutes. What we didn't talk about is what it should look like. Currently, since the pool just returns task status failure, we get a cryptic "task did not complete" message. This MR adds a brief message explaining the error and what to do about it before the code crashes out.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
