### PR TITLE
Add control over whether to include/exclude an output on final signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1331]](https://github.com/parthenon-hpc-lab/parthenon/pull/1331) Add control over whether to include/exclude an output on final signal
 - [[PR 1330]](https://github.com/parthenon-hpc-lab/parthenon/pull/1330) Add userspace mechanisms to control number of comm buffers allocated
 - [[PR 1319]](https://github.com/parthenon-hpc-lab/parthenon/pull/1319) Add common scratch variable utilities
 - [[PR 1326]](https://github.com/parthenon-hpc-lab/parthenon/pull/1326) Thread initial swarm pool size into userspace via metadata

--- a/src/outputs/output_parameters.hpp
+++ b/src/outputs/output_parameters.hpp
@@ -45,6 +45,7 @@ struct OutputParameters {
   std::string file_basename;
   int file_number_width;
   bool file_label_final;
+  bool include_in_final;
   bool analysis_flag; // write this output for analysis/postprocessing restarts
   std::string file_id;
   std::vector<std::string> variables;

--- a/src/outputs/outputs.cpp
+++ b/src/outputs/outputs.cpp
@@ -213,6 +213,9 @@ Outputs::Outputs(Mesh *pm, ParameterInput *pin, SimTime *tm) {
     op.file_label_final = pin->GetOrAddBoolean(
         op.block_name, "use_final_label", true,
         "final output will use the word final instead of a number for its index");
+    op.include_in_final =
+        pin->GetOrAddBoolean(op.block_name, "include_in_final", true,
+                             "include output when triggered on final signal");
     char define_id[10];
     std::snprintf(define_id, sizeof(define_id), "out%d",
                   op.block_number); // default id="outN"
@@ -441,7 +444,8 @@ void Outputs::MakeOutputs(Mesh *pm, ParameterInput *pin, SimTime *tm,
             (tm->nlim > 0 && tm->ncycle >= tm->nlim))) ||
           // or by manual triggers
           (signal == SignalHandler::OutputSignal::now) ||
-          (signal == SignalHandler::OutputSignal::final) ||
+          (signal == SignalHandler::OutputSignal::final &&
+           ptype->output_params.include_in_final) ||
           (signal == SignalHandler::OutputSignal::analysis &&
            ptype->output_params.analysis_flag)))) {
       if (first && ptype->output_params.file_type != "hst") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I came across the "issue" that a large number of output blocks contributed significantly to the wallclock time on gracefully exiting the simulation.
I didn't need all these outputs as I only needed the restart output.
This quick hack allows to select which outputs to include.
I don't think it hurts (as it's a small fix) but raises a potentially separate question/discussion: should we differentiate between simulation that shutdown because of running into the wallclock limit `-t ...` versus simulations that shutdown because they're "complete" (by running into `tlim` or `nlim`).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
