### PR TITLE
[TRIVIAL] clean up annoying warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - [[PR 1284]](https://github.com/parthenon-hpc-lab/parthenon/pull/1284) Fix some parameter types, move `DumpInputParameters` to `Driver`
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1335]](https://github.com/parthenon-hpc-lab/parthenon/pull/1335) Clean up annoying warnings in AMR criteria
 - [[PR 1321]](https://github.com/parthenon-hpc-lab/parthenon/pull/1321) Reorganize docs into chapters
 - [[PR 1316]](https://github.com/parthenon-hpc-lab/parthenon/pull/1316) Update Cuda CI container (main change g++-13 to fix asan bug)
 - [[PR 1292]](https://github.com/parthenon-hpc-lab/parthenon/pull/1292) Remove shared ptr cycle and add a destructor for reductions

--- a/src/amr_criteria/amr_criteria.cpp
+++ b/src/amr_criteria/amr_criteria.cpp
@@ -17,6 +17,7 @@
 #include <string>
 
 #include "amr_criteria/refinement_package.hpp"
+#include "globals.hpp"
 #include "interface/meshblock_data.hpp"
 #include "interface/variable.hpp"
 #include "mesh/mesh.hpp"
@@ -60,14 +61,11 @@ AMRCriteria::AMRCriteria(ParameterInput *pin, std::string &block_name)
   max_level =
       pin->GetOrAddInteger(block_name, "max_level", global_max_level,
                            "maximum level this refinement criterion will achieve");
-  if (max_level > global_max_level) {
+  if ((max_level > global_max_level) && (Globals::my_rank == 0)) {
     std::cerr << "WARNING: max_level in " << block_name
               << " exceeds numlevel (the global maximum number of levels) set in "
-                 "<parthenon/mesh>."
-              << std::endl
-              << std::endl
-              << "Setting max_level = numlevel, but this may not be what you want."
-              << std::endl
+                 "<parthenon/mesh>.\n"
+              << "\tSetting max_level = numlevel, but this may not be what you want.\n"
               << std::endl;
     max_level = global_max_level;
   }

--- a/src/amr_criteria/amr_criteria.cpp
+++ b/src/amr_criteria/amr_criteria.cpp
@@ -14,6 +14,7 @@
 
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <string>
 
 #include "amr_criteria/refinement_package.hpp"
@@ -30,8 +31,9 @@ AMRCriteria::AMRCriteria(ParameterInput *pin, std::string &block_name)
   field =
       pin->GetOrAddString(block_name, "field", "NO FIELD WAS SET", "Field to refine on");
   if (field == "NO FIELD WAS SET") {
-    std::cerr << "Error in " << block_name << ": no field set" << std::endl;
-    exit(1);
+    std::stringstream msg;
+    msg << "Error in " << block_name << ": no field set" << std::endl;
+    PARTHENON_THROW(msg);
   }
   if (pin->DoesParameterExist(block_name, "tensor_ijk")) {
     auto index = pin->GetVector<int>(block_name, "tensor_ijk");
@@ -62,11 +64,13 @@ AMRCriteria::AMRCriteria(ParameterInput *pin, std::string &block_name)
       pin->GetOrAddInteger(block_name, "max_level", global_max_level,
                            "maximum level this refinement criterion will achieve");
   if ((max_level > global_max_level) && (Globals::my_rank == 0)) {
-    std::cerr << "WARNING: max_level in " << block_name
-              << " exceeds numlevel (the global maximum number of levels) set in "
-                 "<parthenon/mesh>.\n"
-              << "\tSetting max_level = numlevel, but this may not be what you want.\n"
-              << std::endl;
+    std::stringstream msg;
+    msg << "max_level in " << block_name
+        << " exceeds numlevel (the global maximum number of levels) set in "
+           "<parthenon/mesh>. Setting max_level = numlevel, but this may not be what you "
+           "want."
+        << std::endl;
+    PARTHENON_WARN(msg);
     max_level = global_max_level;
   }
 }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This warning was printed out once per MPI rank. On a lot of ranks, it was very annoying. This makes it just print once and also switches to our error handling macros.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
