### PR TITLE
(Semi-)Compiled input decks

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "external/kokkos"]
 	path = external/Kokkos
 	url = https://github.com/kokkos/kokkos.git
+[submodule "external/rummy"]
+	path = external/rummy
+	url = https://github.com/lanl/rummy.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,6 +404,22 @@ set(CMAKE_INSTALL_INCLUDEDIR "${CMAKE_INSTALL_INCLUDEDIR}/parthenon")
 set(DOC_GEN_PATH "${CMAKE_SOURCE_DIR}/doc/sphinx/src/generated" CACHE STRING
   "Path to save generated data for docs.")
 
+find_package(Rummy QUIET)
+
+if (NOT Rummy_FOUND)
+  # If Rummy is not found, instead use the git submodule
+  if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/external/rummy/single_include)
+    # Unable to find the header files for Rummy or they don't exist
+    message(STATUS "Downloading Rummy submodule.")
+
+    # Clone the submodule
+    execute_process(COMMAND git submodule update --init --force -- external/rummy WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+  endif()
+
+  add_subdirectory(external/rummy)
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/external/rummy/contrib")
+endif()
+
 add_subdirectory(src)
 add_subdirectory(example)
 add_subdirectory(benchmarks)

--- a/example/advection/parthinput.advection
+++ b/example/advection/parthinput.advection
@@ -16,29 +16,29 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = advection
+problem_id = "advection"
 
 <parthenon/mesh>
-refinement = adaptive
+refinement = "adaptive"
 numlevel = 3
 
 nx1 = 64
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 64
 x2min = -0.5
 x2max = 0.5
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 1
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 16
@@ -48,7 +48,7 @@ nx3 = 1
 <parthenon/time>
 nlim = -1
 tlim = 1.0
-integrator = rk2
+integrator = "rk2"
 ncycle_out_mesh = -10000
 
 <Advection>
@@ -56,7 +56,7 @@ cfl = 0.45
 vx = 1.0
 vy = 1.0
 vz = 1.0
-profile = hard_sphere
+profile = "hard_sphere"
 
 refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
@@ -66,28 +66,28 @@ vec_size = 1 # size of each variable
 fill_derived = false # whether to fill one-copy test vars
 
 <parthenon/output1>
-file_type = rst
+file_type = "rst"
 dt = 0.05
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = advected, advected_1, & # comments are ok
-            one_minus_advected, &
-            one_minus_advected_sq, & # on every (& characters are ok in comments)
-            one_minus_sqrt_one_minus_advected_sq, & # line
-            my_derived_var
+variables = "advected", "advected_1", & # comments are ok
+            "one_minus_advected", &
+            "one_minus_advected_sq", & # on every (& characters are ok in comments)
+            "one_minus_sqrt_one_minus_advected_sq", & # line
+            "my_derived_var"
 
 <parthenon/output3>
-file_type = hst
+file_type = "hst"
 dt = 0.05
 
 <parthenon/output4>
-file_type = hst
+file_type = "hst"
 dt = 0.1
-packages = advection_app
+packages = "advection_app"
 
 <parthenon/output5>
-file_type = ascent
+file_type = "ascent"
 dt = -0.05   # soft disabled by default, as Ascent is an optional dependency
-actions_file = custom_ascent_actions.yaml
+actions_file = "custom_ascent_actions.yaml"

--- a/example/boundary_exchange/parthinput.example
+++ b/example/boundary_exchange/parthinput.example
@@ -12,10 +12,10 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = boundary_exchange
+problem_id = "boundary_exchange"
 
 <parthenon/mesh>
-refinement = static
+refinement = "static"
 numlevel = 1
 # The structure of the mesh is built in main as a forest
 
@@ -29,6 +29,6 @@ nx2 = 4
 nx3 = 1
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 ghost_zones = true
-variables = morton_num
+variables = "morton_num"

--- a/example/calculate_pi/parthinput.example
+++ b/example/calculate_pi/parthinput.example
@@ -16,23 +16,23 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = pi_calculator
+problem_id = "pi_calculator"
 
 <parthenon/mesh>
-refinement = adaptive
+refinement = "adaptive"
 numlevel = 5
 
 nx1 = 64
 x1min = -2.0
 x1max = 2.0
-ix1_bc = outflow
-ox1_bc = outflow
+ix1_bc = "outflow"
+ox1_bc = "outflow"
 
 nx2 = 64
 x2min = -2.0
 x2max = 2.0
-ix2_bc = outflow
-ox2_bc = outflow
+ix2_bc = "outflow"
+ox2_bc = "outflow"
 
 nx3 = 1
 x3min = -0.5
@@ -48,8 +48,8 @@ nx2 = 8
 nx3 = 1
 
 <parthenon/refinement0>
-field = in_or_out               # the name of the variable we want to refine on
-method = derivative_order_1     # selects the first derivative method
+field = "in_or_out"               # the name of the variable we want to refine on
+method = "derivative_order_1"     # selects the first derivative method
 refine_tol = 0.5                # tag for refinement if |(dfield/dx)/field| > refine_tol
 derefine_tol = 0.05             # tag for derefinement if |(dfield/dx)/field| < derefine_tol
 max_level = 2                   # if set, limits refinement level from this criteria to no greater than max_level
@@ -59,5 +59,5 @@ radius = 1.5
 use_sparse = 0 # Set to 1 to use sparse variables
 
 <parthenon/output0>
-file_type = hdf5
-variables = in_or_out
+file_type = "hdf5"
+variables = "in_or_out"

--- a/example/diffusion/parthinput.diffusion
+++ b/example/diffusion/parthinput.diffusion
@@ -16,29 +16,29 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = diffusion
+problem_id = "diffusion"
 
 <parthenon/mesh>
-refinement = static
+refinement = "static"
 multigrid = true 
 
 nx1 = 64
 x1min = -1.0
 x1max = 1.0
-ix1_bc = outflow 
-ox1_bc = outflow
+ix1_bc = "outflow" 
+ox1_bc = "outflow"
 
 nx2 = 64
 x2min = -1.0
 x2max = 1.0
-ix2_bc = outflow
-ox2_bc = outflow
+ix2_bc = "outflow"
+ox2_bc = "outflow"
 
 nx3 = 1
 x3min = 0.0
 x3max = 1.0
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 32
@@ -48,25 +48,25 @@ nx3 = 1
 <parthenon/time>
 nlim = -1
 tlim = 0.02
-integrator = rk1
+integrator = "rk1"
 #ncycle_out_mesh = -10000
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.0001
-variables = diffusion.u
+variables = "diffusion.u"
 ghost_zones = false
 
 <parthenon/static_refinement0> 
 x1min = -0.15
-x1max = +0.15
+x1max = 0.15
 x2min = -0.15
-x2max = +0.15
+x2max = 0.15
 level = 3
 
 <diffusion>
 #solver = BiCGSTAB # or MG
-solver = MG
+solver = "MG"
 flux_correct = true
 diagonal_alpha = 1.0
 cfl = 10.0
@@ -82,5 +82,5 @@ precondition = true
 max_iterations = 20
 residual_tolerance = 1.e-9
 print_per_step = true
-smoother = SRJ2
+smoother = "SRJ2"
 do_FAS = true

--- a/example/fine_advection/parthinput.advection
+++ b/example/fine_advection/parthinput.advection
@@ -12,29 +12,29 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = advection
+problem_id = "advection"
 
 <parthenon/mesh>
-refinement = adaptive
+refinement = "adaptive"
 numlevel = 3
 
 nx1 = 64
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 64
 x2min = -0.5
 x2max = 0.5
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 1
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 16
@@ -44,7 +44,7 @@ nx3 = 1
 <parthenon/time>
 nlim = -1
 tlim = 1.0
-integrator = rk2
+integrator = "rk2"
 ncycle_out_mesh = -10000
 
 <Advection>
@@ -52,7 +52,7 @@ cfl = 0.45
 vx = 1.0
 vy = 1.0
 vz = 1.0
-profile = hard_sphere
+profile = "hard_sphere"
 
 refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
@@ -65,10 +65,10 @@ do_fine_advection = true
 do_CT_advection = true
 
 <parthenon/output1>
-file_type = rst
+file_type = "rst"
 dt = 0.05
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = advection.scalar, advection.scalar_fine_restricted
+variables = "advection.scalar", "advection.scalar_fine_restricted"

--- a/example/particle_leapfrog/parthinput.particle_leapfrog
+++ b/example/particle_leapfrog/parthinput.particle_leapfrog
@@ -16,28 +16,28 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = particles
+problem_id = "particles"
 
 <parthenon/mesh>
-refinement = static
+refinement = "static"
 
 nx1 = 16
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 16
 x2min = -0.5
 x2max = 0.5
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 16
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 8
@@ -56,18 +56,18 @@ x3max = 0
 <parthenon/time>
 tlim = 1.0
 nlim = 100000
-integrator = rk1
+integrator = "rk1"
 
 <Particles>
 cfl = 0.3
 disable = false
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-swarms = my_particles
-my_particles_variables = id, v, vv
+swarms = "my_particles"
+my_particles_variables = "id", "v", "vv"
 
 <parthenon/output1>
-file_type = rst
+file_type = "rst"
 dt = 1.0

--- a/example/particle_tracers/parthinput.particle_tracers
+++ b/example/particle_tracers/parthinput.particle_tracers
@@ -12,28 +12,28 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = particle_tracers
+problem_id = "particle_tracers"
 
 <parthenon/mesh>
-refinement = none
+refinement = "none"
 
 nx1 = 64
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 64
 x2min = -0.5
 x2max = 0.5
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 1
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 16
@@ -43,23 +43,23 @@ nx3 = 1
 <parthenon/time>
 tlim = 1.0
 nlim = 100000
-integrator = rk1
+integrator = "rk1"
 
 <Background>
 cfl = 0.3
 v = 1.0
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = advected, tracer_deposition
+variables = "advected", "tracer_deposition"
 
 <Tracers>
 num_tracers = 10000
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = advected
-swarms = tracers
-swarm_variables = id
+variables = "advected"
+swarms = "tracers"
+swarm_variables = "id"

--- a/example/particles/parthinput.particles
+++ b/example/particles/parthinput.particles
@@ -16,47 +16,47 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = particles
+problem_id = "particles"
 
 <parthenon/mesh>
-refinement = none
+refinement = "none"
 
 nx1 = 16
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 16
 x2min = -0.5
 x2max = 0.5
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 1
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 8
 nx2 = 8
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 1.e1
-variables = particle_deposition
+variables = "particle_deposition"
 
 <parthenon/time>
 tlim = 1.e2
-integrator = rk1
+integrator = "rk1"
 
 <Particles>
 num_particles = 10
 particle_speed = 1.0
 rng_seed = 23487
 const_dt = 0.5
-deposition_method = per_cell
+deposition_method = "per_cell"
 destroy_particles_frac = 0.1
 defrag_threshold = 0.9

--- a/example/poisson/parthinput.poisson
+++ b/example/poisson/parthinput.poisson
@@ -16,27 +16,27 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = poisson
+problem_id = "poisson"
 
 <parthenon/mesh>
 
 nx1 = 64
 x1min = -1.0
 x1max = 1.0
-ix1_bc = outflow
-ox1_bc = outflow
+ix1_bc = "outflow"
+ox1_bc = "outflow"
 
 nx2 = 64
 x2min = -1.0
 x2max = 1.0
-ix2_bc = outflow
-ox2_bc = outflow
+ix2_bc = "outflow"
+ox2_bc = "outflow"
 
 nx3 = 1
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 16
@@ -50,9 +50,9 @@ nx3 = 1
 #ncycle_out_mesh = -10000
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = potential, density
+variables = "potential", "density"
 
 <poisson>
 max_iterations = 100000

--- a/example/poisson_gmg/parthinput.poisson
+++ b/example/poisson_gmg/parthinput.poisson
@@ -16,29 +16,29 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = poisson
+problem_id = "poisson"
 
 <parthenon/mesh>
-refinement = static
+refinement = "static"
 multigrid = true 
 
 nx1 = 64
 x1min = -1.0
 x1max = 1.0
-ix1_bc = outflow
-ox1_bc = outflow
+ix1_bc = "outflow"
+ox1_bc = "outflow"
 
 nx2 = 64
 x2min = -1.0
 x2max = 1.0
-ix2_bc = outflow
-ox2_bc = outflow
+ix2_bc = "outflow"
+ox2_bc = "outflow"
 
 nx3 = 1
 x3min = 0.0
 x3max = 1.0
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 32
@@ -52,9 +52,9 @@ nx3 = 1
 #ncycle_out_mesh = -10000
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = poisson.res_err, poisson.u, poisson.x, poisson.r, poisson.rhs, poisson.p, poisson.s, poisson.t, poisson.v, poisson.exact
+variables = "poisson.res_err", "poisson.u", "poisson.x", "poisson.r", "poisson.rhs", "poisson.p", "poisson.s", "poisson.t", "poisson.v", "poisson.exact"
 ghost_zones = true 
 
 <parthenon/static_refinement0> 
@@ -65,7 +65,7 @@ x2max = -0.75
 level = 3
 
 <poisson>
-solver = BiCGSTAB # or MG
+solver = "BiCGSTAB" # or MG
 flux_correct = true
 diagonal_alpha = 0.0
 
@@ -81,5 +81,5 @@ precondition = true
 max_iterations = 15
 residual_tolerance = 1.e-8
 print_per_step = true
-smoother = SRJ2
+smoother = "SRJ2"
 do_FAS = true

--- a/example/sparse_advection/parthinput.sparse_advection
+++ b/example/sparse_advection/parthinput.sparse_advection
@@ -16,7 +16,7 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = sparse
+problem_id = "sparse"
 
 <parthenon/sparse>
 enable_sparse = true
@@ -25,26 +25,26 @@ dealloc_threshold = 1e-6
 dealloc_count = 5
 
 <parthenon/mesh>
-refinement = adaptive
+refinement = "adaptive"
 numlevel = 3
 
 nx1 = 64
 x1min = -1.0
 x1max = 1.0
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 64
 x2min = -1.0
 x2max = 1.0
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 1
 x3min = -1.0
 x3max = 1.0
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 8
@@ -54,7 +54,7 @@ nx3 = 1
 <parthenon/time>
 nlim = -1
 tlim = 2.0
-integrator = rk2
+integrator = "rk2"
 ncycle_out_mesh = -10000
 
 <sparse_advection>
@@ -67,14 +67,14 @@ refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
 
 <parthenon/output1>
-file_type = rst
+file_type = "rst"
 dt = 0.5
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.1
-variables = sparse, dense_A, dense_B, shape_shift
+variables = "sparse", "dense_A", "dense_B", "shape_shift"
 
 <parthenon/output3>
-file_type = hst
+file_type = "hst"
 dt = 0.00001

--- a/example/stochastic_subgrid/parthinput.stochastic_subgrid
+++ b/example/stochastic_subgrid/parthinput.stochastic_subgrid
@@ -16,29 +16,29 @@
 # ========================================================================================
 
 <parthenon/job>
-problem_id = advection
+problem_id = "advection"
 
 <parthenon/mesh>
-refinement = adaptive
+refinement = "adaptive"
 numlevel = 3
 
 nx1 = 64
 x1min = -0.5
 x1max = 0.5
-ix1_bc = periodic
-ox1_bc = periodic
+ix1_bc = "periodic"
+ox1_bc = "periodic"
 
 nx2 = 64
 x2min = -0.5
 x2max = 0.5
-ix2_bc = periodic
-ox2_bc = periodic
+ix2_bc = "periodic"
+ox2_bc = "periodic"
 
 nx3 = 1
 x3min = -0.5
 x3max = 0.5
-ix3_bc = periodic
-ox3_bc = periodic
+ix3_bc = "periodic"
+ox3_bc = "periodic"
 
 <parthenon/meshblock>
 nx1 = 16
@@ -48,14 +48,14 @@ nx3 = 1
 <parthenon/time>
 nlim = -1
 tlim = 1.0
-integrator = rk2
+integrator = "rk2"
 
 <Advection>
 cfl = 0.45
 vx = 1.0
 vy = 1.0
 vz = 1.0
-profile = hard_sphere
+profile = "hard_sphere"
 
 refine_tol = 0.3    # control the package specific refinement tagging function
 derefine_tol = 0.03
@@ -80,12 +80,12 @@ num_iter_max = 100
 power_law_coeff = -3.0
 
 <parthenon/output1>
-file_type = rst
+file_type = "rst"
 dt = 0.05
 
 <parthenon/output0>
-file_type = hdf5
+file_type = "hdf5"
 dt = 0.05
-variables = advected, one_minus_advected, & # comments are ok
-            one_minus_advected_sq, & # on every (& characters are ok in comments)
-            one_minus_sqrt_one_minus_advected_sq # line
+variables = "advected", "one_minus_advected", & # comments are ok
+            "one_minus_advected_sq", & # on every (& characters are ok in comments)
+            "one_minus_sqrt_one_minus_advected_sq" # line

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -373,6 +373,8 @@ endif()
 
 target_link_libraries(parthenon PUBLIC Kokkos::kokkos Threads::Threads)
 
+target_link_libraries(parthenon PUBLIC Rummy::rummy)
+
 if (PARTHENON_ENABLE_ASCENT)
   if (ENABLE_MPI)
     target_link_libraries(parthenon PUBLIC ascent::ascent_mpi)
@@ -397,6 +399,18 @@ target_include_directories(parthenon PUBLIC
   )
 
 install(TARGETS parthenon EXPORT parthenonTargets)
+
+if(NOT Rummy_FOUND)
+  install(TARGETS rummylib pipslib EXPORT parthenonTargets
+      RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+      LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  )
+  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../external/rummy/rummy 
+      DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+      FILES_MATCHING PATTERN "*.hpp" PATTERN "*.h"
+  )
+endif()
 
 # Maintain directory structure in installed include files
 install(DIRECTORY ./ TYPE INCLUDE FILES_MATCHING PATTERN "*.hpp")

--- a/src/argument_parser.hpp
+++ b/src/argument_parser.hpp
@@ -51,11 +51,17 @@ class ArgParse {
         switch (opt_letter) {
         case 'i': // -i <input_filename>
           invalid = invalid_arg();
-          input_filename = argv[++i];
+          input_filename.push_back(argv[++i]);
           break;
         case 'r': // -r <restart_file>
           invalid = invalid_arg();
           is_restart = true;
+          restart_filename = argv[++i];
+          break;
+        case 'R': // -R <restart_file>
+          invalid = invalid_arg();
+          is_restart = true;
+          is_old_restart = true;
           restart_filename = argv[++i];
           break;
         case 'a': // -a <restart_file>
@@ -92,10 +98,11 @@ class ArgParse {
           complete = true;
         default:
           if (Globals::my_rank == 0) {
-            std::cout << "Usage: " << argv[0] << " [options] [block/par=value ...]\n";
+            std::cout << "Usage: " << argv[0] << " [options] [block.par=value ...]\n";
             std::cout << "Options:" << std::endl;
             std::cout << "  -i <file>       specify input file [athinput]\n";
             std::cout << "  -r <file>       restart with this file\n";
+            std::cout << "  -R <file>       restart with this file but with the old syntax\n";
             std::cout << "  -a <file>       analyze/postprocess this file\n";
             std::cout << "  -d <directory>  specify run dir [current dir]\n";
             std::cout << "  -p [regex]      parse input file, report parameters\n"
@@ -122,10 +129,12 @@ class ArgParse {
           }
           return ArgStatus::error;
         }
-      } // else if argv[i] not of form "-?" ignore it here (tested in ModifyFromCmdline)
+      } else {
+        mods.push_back(argv[i]);
+      }
     }
 
-    if (restart_filename == nullptr && input_filename == nullptr) {
+    if (restart_filename == nullptr && input_filename.empty()) {
       // no input file is given
       std::cout << "### FATAL ERROR in main" << std::endl
                 << "No input file or restart file is specified." << std::endl;
@@ -134,12 +143,14 @@ class ArgParse {
     return ArgStatus::ok;
   }
 
-  char *input_filename = nullptr;
+  std::vector<std::string> input_filename;
+  std::vector<std::string> mods;
   char *restart_filename = nullptr;
   char *prundir = nullptr;
   char *params_regex = nullptr;
   bool analysis_flag = false;
   bool is_restart = false;
+  bool is_old_restart = false;
   int param_flag = 0;
   int mesh_flag = 0;
   int wtlim = 0;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -208,7 +208,6 @@ void ParameterInput::LoadFromOldRestart(std::istringstream &is) {
     }
   }
   deck.Build(ss);
-
 }
 
 
@@ -221,7 +220,8 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
   std::stringstream par, msg;
   constexpr int kBufSize = 4096;
   char buf[kBufSize];
-  IOWrapperSizeT header = 0, ret, loc;
+  IOWrapperSizeT header = 0, ret;
+  std::size_t loc;
 
   // search <par_end> or EOF.
   do {
@@ -233,7 +233,7 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
         MPI_Bcast(&ret, sizeof(IOWrapperSizeT), MPI_BYTE, 0, MPI_COMM_WORLD));
     PARTHENON_MPI_CHECK(MPI_Bcast(buf, ret, MPI_BYTE, 0, MPI_COMM_WORLD));
 #endif
-    par.write(buf, ret); // add the buffer into the stjuream
+    par.write(buf, ret); // add the buffer into the stream
     header += ret;
     std::string sbuf = par.str();    // create string for search
     loc = sbuf.find("<par_end>", 0); // search from the top of the stream
@@ -247,11 +247,12 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
           << "Probably the file is broken or a wrong file is specified" << std::endl;
       PARTHENON_FAIL(msg);
     }
-    // remove <par_end>
-    par = std::stringstream(sbuf.substr(0, loc)); 
   } while (ret == kBufSize); // till EOF (or par_end is found)
 
-  // Now par contains the parameter inputs + some additional including <par_end>
+  if (loc != std::string::npos) {
+    par = std::stringstream(par.str().substr(0, std::size_t(loc)));
+  }
+  // Now par contains the parameter inputs but without <par_end>
   // Read the stream and load the parameters
   LoadFromStream(par);
   // Seek the file to the end of the header

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -73,12 +73,53 @@ namespace parthenon {
 
 ParameterInput::ParameterInput() : pfirst_block{}, last_filename_{} {}
 
-ParameterInput::ParameterInput(std::string input_filename)
+ParameterInput::ParameterInput(std::istringstream &is, const bool old, std::vector<std::string> input_filename, std::vector<std::string> mods)
     : pfirst_block{}, last_filename_{} {
-  IOWrapper infile;
-  infile.Open(input_filename.c_str(), IOWrapper::FileMode::read);
-  LoadFromFile(infile);
-  infile.Close();
+  
+  // restart file first
+  if (old) {
+    LoadFromOldRestart(is);
+  } else {
+    LoadFromRestart(is);
+  }
+
+  // then input files
+  for ( auto &fname : input_filename) {
+    IOWrapper infile;
+    infile.Open(fname.c_str(), IOWrapper::FileMode::read);
+    LoadFromFile(infile);
+    infile.Close();
+  }
+  // now additional command line modifications
+  if (!mods.empty()) {
+    std::stringstream ss;
+    for (auto &mod : mods) {
+      ss << mod << "\n";
+    }
+    LoadFromStream(ss);
+  }
+  GenerateLinkedList();
+
+}
+
+ParameterInput::ParameterInput(std::vector<std::string> input_filename, std::vector<std::string> mods)
+    : pfirst_block{}, last_filename_{} {
+  // Do the input files first
+  for ( auto &fname : input_filename) {
+    IOWrapper infile;
+    infile.Open(fname.c_str(), IOWrapper::FileMode::read);
+    LoadFromFile(infile);
+    infile.Close();
+  }
+  // now additional command line modifications
+  if (!mods.empty()) {
+    std::stringstream ss;
+    for (auto &mod : mods) {
+      ss << mod << "\n";
+    }
+    LoadFromStream(ss);
+  }
+  GenerateLinkedList();
 }
 
 // ParameterInput destructor- iterates through nested singly linked lists of blocks/lines
@@ -115,102 +156,61 @@ InputBlock::~InputBlock() {
 //  and stored in a singly linked list of InputLines.
 
 void ParameterInput::LoadFromStream(std::istream &is) {
-  std::string line, block_name, param_name, param_value, param_comment;
-  std::size_t first_char, last_char;
-  std::stringstream msg;
-  InputBlock *pib{};
-  int line_num{-1}, blocks_found{0};
+ deck.Build(is);
+}
 
-  // Buffer multiple lines if a continuation character is present
-  std::string multiline_name, multiline_value, multiline_comment;
-  // Status in/out of continuation
-  bool continuing = false;
+void ParameterInput::LoadFromRestart(std::istringstream &is) {
+  // When reading from a restart file, the string buffer has the <par_end> tag at the end.
+  // This is not a real parameter block, so we need to remove it before passing it off.
+  std::string sbuf = is.str();
+  std::size_t loc = sbuf.find("<par_end>", 0);
+  if (loc != std::string::npos) {
+    sbuf = sbuf.substr(0, loc);
+    std::istringstream ss = std::istringstream(sbuf);
+    deck.Build(ss);
+  } else {
+    deck.Build(is);
+  }
+}
 
-  while (is.good()) {
-    std::getline(is, line);
-    line_num++;
-
-    // remove all \t\f\n\r\v but leave pure spaces
+void ParameterInput::LoadFromOldRestart(std::istringstream &is) {
+  // The old format did not enclose string parameters in quotes, so we need to
+  // preprocess the input to add quotes around string values.
+  std::stringstream ss;
+  std::string line;
+  while(std::getline(is, line)) {
     line.erase(std::remove_if(line.begin(), line.end(),
                               [](char c) { return std::isspace(c) && c != ' '; }),
                line.end());
-
-    if (line.empty()) continue;                               // skip blank line
-    first_char = line.find_first_not_of(" ");                 // skip white space
-    if (first_char == std::string::npos) continue;            // line is all white space
+    if (line.empty()) continue;                          // skip blank line
+    std::size_t first_char = line.find_first_not_of(" ");
     if (line.compare(first_char, 1, "#") == 0) continue;      // skip comments
     if (line.compare(first_char, 9, "<par_end>") == 0) break; // stop on <par_end>
 
-    if (line.compare(first_char, 1, "<") == 0) { // a new block
-      if (continuing) {
-        msg << "### FATAL ERROR in function [ParameterInput::LoadFromStream]" << std::endl
-            << "Multiline field ended unexpectedly with new block "
-            << "character <.  Look above this line for the error:" << std::endl
-            << line << std::endl
-            << std::endl;
-        PARTHENON_FAIL(msg);
+    std::size_t equal_pos = line.find('=');
+    if (equal_pos != std::string::npos) {
+      std::string name = line.substr(0, equal_pos);
+      std::string value = line.substr(equal_pos + 1);
+      name.erase(name.find_last_not_of(" \t\r\n") + 1);
+      name.erase(0, name.find_first_not_of(" \t\r\n"));
+      value.erase(value.find_last_not_of(" \t\r\n") + 1);
+      value.erase(0, value.find_first_not_of(" \t\r\n"));
+      bool is_numeric = !value.empty() && (std::all_of(value.begin(), value.end(),
+                          [](char c){ return std::isdigit(c) || c == '.' || c == '-' || c == '+'; }));
+      bool is_boolean = (value == "true" || value == "false" || value == "1" || value == "0");
+      if (!is_numeric && !is_boolean) {
+        // Add quotes around string values
+        value = "\"" + value + "\"";
       }
-      first_char++;
-      last_char = (line.find_first_of(">", first_char));
-      block_name.assign(line, first_char, last_char - 1); // extract block name
-
-      if (last_char == std::string::npos) {
-        msg << "### FATAL ERROR in function [ParameterInput::LoadFromStream]" << std::endl
-            << "Block name '" << block_name << "' in the input stream'"
-            << "' not properly ended";
-        PARTHENON_FAIL(msg);
-      }
-
-      pib = FindOrAddBlock(block_name); // find or add block to singly linked list
-
-      if (pib == nullptr) {
-        msg << "### FATAL ERROR in function [ParameterInput::LoadFromStream]" << std::endl
-            << "Block name '" << block_name << "' could not be found/added";
-        PARTHENON_FAIL(msg);
-      }
-      blocks_found++;
-      continue; // skip to next line if block name was found
-    }           // end "a new block was found"
-
-    // if line does not contain a block name or skippable information (comments,
-    // whitespace), it must contain a parameter value
-    if (blocks_found == 0) {
-      msg << "### FATAL ERROR in function [ParameterInput::LoadFromStream]" << std::endl
-          << "Input file must specify a block name before the first"
-          << " parameter = value line";
-      PARTHENON_FAIL(msg);
-    }
-    // parse line and add name/value/comment strings (if found) to current block name
-    bool has_cont_char = ParseLine(pib, line, param_name, param_value, param_comment);
-    if (continuing || has_cont_char) {
-      // Append line data
-      multiline_name += param_name;
-      multiline_value += param_value;
-      multiline_comment += param_comment;
-      // Set new state
-      continuing = true;
-    }
-
-    if (continuing && !has_cont_char) {
-      // Flush line data
-      param_name = multiline_name;
-      param_value = multiline_value;
-      param_comment = multiline_comment;
-      multiline_name = "";
-      multiline_value = "";
-      multiline_comment = "";
-      // Set new state
-      continuing = false;
-    }
-
-    if (!continuing) {
-      if (param_name != "") {
-        AddParameter(pib, param_name, param_value, param_comment);
-      }
+      ss << name << " = " << value << "\n";
+    } else {
+      ss << line << "\n";
     }
   }
-  return;
+  deck.Build(ss);
+
 }
+
 
 //----------------------------------------------------------------------------------------
 //! \fn  void ParameterInput::LoadFromFile(IOWrapper &input)
@@ -233,7 +233,7 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
         MPI_Bcast(&ret, sizeof(IOWrapperSizeT), MPI_BYTE, 0, MPI_COMM_WORLD));
     PARTHENON_MPI_CHECK(MPI_Bcast(buf, ret, MPI_BYTE, 0, MPI_COMM_WORLD));
 #endif
-    par.write(buf, ret); // add the buffer into the stream
+    par.write(buf, ret); // add the buffer into the stjuream
     header += ret;
     std::string sbuf = par.str();    // create string for search
     loc = sbuf.find("<par_end>", 0); // search from the top of the stream
@@ -247,6 +247,8 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
           << "Probably the file is broken or a wrong file is specified" << std::endl;
       PARTHENON_FAIL(msg);
     }
+    // remove <par_end>
+    par = std::stringstream(sbuf.substr(0, loc)); 
   } while (ret == kBufSize); // till EOF (or par_end is found)
 
   // Now par contains the parameter inputs + some additional including <par_end>
@@ -258,218 +260,34 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
   return;
 }
 
-//----------------------------------------------------------------------------------------
-//! \fn InputBlock* ParameterInput::FindOrAddBlock(const std::string & name)
-//  \brief find or add specified InputBlock.  Returns pointer to block.
 
-InputBlock *ParameterInput::FindOrAddBlock(const std::string &name) {
+
+void ParameterInput::GenerateLinkedList() {
   InputBlock *pib, *plast;
   plast = pfirst_block;
   pib = pfirst_block;
 
-  // Search singly linked list of InputBlocks to see if name exists, return if found.
-  while (pib != nullptr) {
-    if (name.compare(pib->block_name) == 0) return pib;
-    plast = pib;
-    pib = pib->pnext;
-  }
-
+  for (auto &name : deck.GetSuitsInOrder()) {
   // Create new block in list if not found above
-  pib = new InputBlock;
-  pib->block_name.assign(name); // store the new block name
-  pib->pline = nullptr;         // Terminate the InputLine list
-  pib->pnext = nullptr;         // Terminate the InputBlock list
+    pib = new InputBlock;
+    pib->block_name.assign(name); // store the new block name
+    pib->pline = nullptr;         // Terminate the InputLine list
+    pib->pnext = nullptr;         // Terminate the InputBlock list
 
-  // Default max lengths to zero (in case of no parameters in this block)
-  pib->max_len_parname = 0;
-  pib->max_len_parvalue = 0;
+    // Default max lengths to zero (in case of no parameters in this block)
+    pib->max_len_parname = 0;
+    pib->max_len_parvalue = 0;
 
-  // if this is the first block in list, save pointer to it in class
-  if (pfirst_block == nullptr) {
-    pfirst_block = pib;
-  } else {
-    plast->pnext = pib; // link new node into list
-  }
-
-  return pib;
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn void ParameterInput::ParseLine(InputBlock *pib, std::string line,
-//           std::string& name, std::string& value, std::string& comment)
-//  \brief parse "name = value # comment" format, return name/value/comment strings.
-
-bool ParameterInput::ParseLine(InputBlock *pib, std::string line, std::string &name,
-                               std::string &value, std::string &comment) {
-  std::size_t first_char, last_char, equal_char, hash_char, cont_char, len;
-  bool continuation = false;
-
-  hash_char = line.find_first_of("#"); // find "#" (optional)
-  comment = "";
-  if (hash_char != std::string::npos) {
-    comment = line.substr(hash_char);
-    line.erase(hash_char, std::string::npos);
-  }
-
-  first_char = line.find_first_not_of(" "); // find first non-white space
-  equal_char = line.find_first_of("=");     // find "=" char
-
-  // copy substring into name, remove white space at end of name
-  if (equal_char == std::string::npos) {
-    name = "";
-    line.erase(0, first_char);
-  } else {
-    len = equal_char - first_char;
-    name.assign(line, first_char, len);
-    last_char = name.find_last_not_of(" ");
-    name.erase(last_char + 1, std::string::npos);
-    line.erase(0, equal_char + 1);
-  }
-
-  cont_char = line.find_first_of("&"); // find "&" continuation character
-  // copy substring into value, remove white space at start and end
-  len = cont_char;
-  if (cont_char != std::string::npos) {
-    std::string right_of_cont;
-    right_of_cont.assign(line, cont_char + 1, std::string::npos);
-    first_char = right_of_cont.find_first_not_of(" ");
-    if (first_char != std::string::npos) {
-      throw std::runtime_error("ERROR: Non-comment characters are not permitted to the "
-                               "right of line continuations");
-    }
-    continuation = true;
-  }
-  value.assign(line, 0, len);
-
-  first_char = value.find_first_not_of(" ");
-  value.erase(0, first_char);
-
-  last_char = value.find_last_not_of(" ");
-  value.erase(last_char + 1, std::string::npos);
-
-  return continuation;
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn void ParameterInput::AddParameter(InputBlock *pb, const std::string & name,
-//   std::string value, const std::string & comment)
-//  \brief add name/value/comment tuple to the InputLine singly linked list in block *pb.
-//  If a parameter with the same name already exists, the value and comment strings
-//  are replaced (overwritten).
-
-void ParameterInput::AddParameter(InputBlock *pb, const std::string &name,
-                                  const std::string &value, const std::string &comment) {
-  InputLine *pl, *plast;
-  // Search singly linked list of InputLines to see if name exists.  This also sets *plast
-  // to point to the tail node (but not storing a pointer to the tail node in InputBlock)
-  pl = pb->pline;
-  plast = pb->pline;
-  while (pl != nullptr) {
-    if (name.compare(pl->param_name) == 0) { // param name already exists
-      pl->param_value.assign(value);         // replace existing param value
-      pl->param_comment.assign(comment);     // replace exisiting param comment
-      if (value.length() > pb->max_len_parvalue) pb->max_len_parvalue = value.length();
-      return;
-    }
-    plast = pl;
-    pl = pl->pnext;
-  }
-
-  // Create new node in singly linked list if name does not already exist
-  pl = new InputLine;
-  pl->param_name.assign(name);
-  pl->param_value.assign(value);
-  pl->param_comment.assign(comment);
-  pl->pnext = nullptr;
-
-  // if this is the first parameter in list, save pointer to it in block.
-  if (pb->pline == nullptr) {
-    pb->pline = pl;
-    pb->max_len_parname = name.length();
-    pb->max_len_parvalue = value.length();
-  } else {
-    plast->pnext = pl; // link new node into list
-    if (name.length() > pb->max_len_parname) pb->max_len_parname = name.length();
-    if (value.length() > pb->max_len_parvalue) pb->max_len_parvalue = value.length();
-  }
-
-  return;
-}
-
-//----------------------------------------------------------------------------------------
-//! void ParameterInput::ModifyFromCmdline(int argc, char *argv[])
-//  \brief parse commandline for changes to input parameters
-// Note this function is very forgiving (no warnings!) if there is an error in format
-
-void ParameterInput::ModifyFromCmdline(int argc, char *argv[]) {
-  std::string input_text, block, name, value;
-  std::stringstream msg;
-  InputBlock *pb;
-  InputLine *pl;
-
-  for (int i = 1; i < argc; i++) {
-    input_text = argv[i];
-    std::size_t equal_posn = input_text.find_first_of("=");     // first "=" character
-    std::size_t slash_posn = input_text.rfind("/", equal_posn); // last "/" before "="
-
-    if (slash_posn > equal_posn) {
-      msg << "'/' used as value (rhs of =) when modifying " << input_text << "."
-          << " Please update value of change "
-          << "logic in ModifyFromCmdline function.";
-      PARTHENON_FAIL(msg.str().c_str());
-    }
-
-    // skip if either "/" or "=" do not exist in input
-    if ((slash_posn == std::string::npos) || (equal_posn == std::string::npos)) continue;
-
-    // extract block/name/value strings
-    block = input_text.substr(0, slash_posn);
-    name = input_text.substr(slash_posn + 1, (equal_posn - slash_posn - 1));
-    value = input_text.substr(equal_posn + 1, std::string::npos);
-
-    // get pointer to node with same block name in singly linked list of InputBlocks
-    pb = GetPtrToBlock(block);
-    if (pb == nullptr) {
-      if (Globals::my_rank == 0) {
-        msg << "In function [ParameterInput::ModifyFromCmdline]:" << std::endl
-            << "               Block name '" << block
-            << "' on command line not found in input/restart file. Block will be added.";
-        PARTHENON_WARN(msg);
-      }
-      pb = FindOrAddBlock(block);
-    }
-
-    // get pointer to node with same parameter name in singly linked list of InputLines
-    pl = pb->GetPtrToLine(name);
-    if (pl == nullptr) {
-      if (Globals::my_rank == 0) {
-        msg << "In function [ParameterInput::ModifyFromCmdline]:" << std::endl
-            << "               Parameter '" << name << "' in block '" << block
-            << "' on command line not found in input/restart file. Parameter will be "
-               "added.";
-        PARTHENON_WARN(msg);
-      }
-      AddParameter(pb, name, value, " # Added from command line");
-
+    // if this is the first block in list, save pointer to it in class
+    if (pfirst_block == nullptr) {
+      pfirst_block = pib;
     } else {
-      pl->param_value.assign(value); // replace existing value
+      plast->pnext = pib; // link new node into list
     }
-
-    if (value.length() > pb->max_len_parvalue) pb->max_len_parvalue = value.length();
+    plast = pib;
   }
 }
 
-//----------------------------------------------------------------------------------------
-//! \fn InputBlock* ParameterInput::GetPtrToBlock(const std::string & name)
-//  \brief return pointer to specified InputBlock if it exists
-
-InputBlock *ParameterInput::GetPtrToBlock(const std::string &name) {
-  InputBlock *pb;
-  for (pb = pfirst_block; pb != nullptr; pb = pb->pnext) {
-    if (name.compare(pb->block_name) == 0) return pb;
-  }
-  return nullptr;
-}
 
 //----------------------------------------------------------------------------------------
 //! \fn int ParameterInput::DoesParameterExist(const std::string & block, const
@@ -478,12 +296,7 @@ InputBlock *ParameterInput::GetPtrToBlock(const std::string &name) {
 
 int ParameterInput::DoesParameterExist(const std::string &block,
                                        const std::string &name) {
-  InputLine *pl;
-  InputBlock *pb;
-  pb = GetPtrToBlock(block);
-  if (pb == nullptr) return 0;
-  pl = pb->GetPtrToLine(name);
-  return (pl == nullptr ? 0 : 1);
+  return deck.DoesCardExist(block,name);
 }
 
 //----------------------------------------------------------------------------------------
@@ -491,36 +304,12 @@ int ParameterInput::DoesParameterExist(const std::string &block,
 //  \brief check whether block exists
 
 int ParameterInput::DoesBlockExist(const std::string &block) {
-  InputBlock *pb = GetPtrToBlock(block);
-  if (pb == nullptr) return 0;
-  return 1;
+  return deck.DoesSuitExist(block);
 }
 
 std::string ParameterInput::GetComment(const std::string &block,
                                        const std::string &name) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream msg;
-
-  // get pointer to node with same block name in singly linked list of InputBlocks
-  pb = GetPtrToBlock(block);
-  if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetComment]" << std::endl
-        << "Block name '" << block << "' not found when trying to set value "
-        << "for parameter '" << name << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  // get pointer to node with same parameter name in singly linked list of InputLines
-  pl = pb->GetPtrToLine(name);
-  if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetComment]" << std::endl
-        << "Parameter name '" << name << "' not found in block '" << block << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  std::string val = pl->param_comment;
-  return val;
+  return deck.GetCard(block,name).GetComment();
 }
 
 //----------------------------------------------------------------------------------------
@@ -530,33 +319,11 @@ std::string ParameterInput::GetComment(const std::string &block,
 
 int ParameterInput::GetInteger(const std::string &block, const std::string &name,
                                const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream msg;
 
-  // get pointer to node with same block name in singly linked list of InputBlocks
-  pb = GetPtrToBlock(block);
-  if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetInteger]" << std::endl
-        << "Block name '" << block << "' not found when trying to set value "
-        << "for parameter '" << name << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  // get pointer to node with same parameter name in singly linked list of InputLines
-  pl = pb->GetPtrToLine(name);
-  if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetInteger]" << std::endl
-        << "Parameter name '" << name << "' not found in block '" << block << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  std::string val = pl->param_value;
-
+  auto val = deck.GetCardValue<int>(block,name);
   CheckAndUpdateQueries_<int>(block, name, docstring);
 
-  // Convert string to integer and return value
-  return stoi(val);
+  return val;
 }
 
 //----------------------------------------------------------------------------------------
@@ -565,33 +332,13 @@ int ParameterInput::GetInteger(const std::string &block, const std::string &name
 
 Real ParameterInput::GetReal(const std::string &block, const std::string &name,
                              const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
+            
   std::stringstream msg;
 
-  // get pointer to node with same block name in singly linked list of InputBlocks
-  pb = GetPtrToBlock(block);
-  if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetReal]" << std::endl
-        << "Block name '" << block << "' not found when trying to set value "
-        << "for parameter '" << name << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  // get pointer to node with same parameter name in singly linked list of InputLines
-  pl = pb->GetPtrToLine(name);
-  if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetReal]" << std::endl
-        << "Parameter name '" << name << "' not found in block '" << block << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  std::string val = pl->param_value;
-
+  auto val = deck.GetCardValue<Real>(block,name);
   CheckAndUpdateQueries_<Real>(block, name, docstring);
 
-  // Convert string to real and return value
-  return static_cast<Real>(atof(val.c_str()));
+  return val;
 }
 
 //----------------------------------------------------------------------------------------
@@ -601,30 +348,10 @@ Real ParameterInput::GetReal(const std::string &block, const std::string &name,
 
 bool ParameterInput::GetBoolean(const std::string &block, const std::string &name,
                                 const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream msg;
-
-  // get pointer to node with same block name in singly linked list of InputBlocks
-  pb = GetPtrToBlock(block);
-  if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetBoolean]" << std::endl
-        << "Block name '" << block << "' not found when trying to set value "
-        << "for parameter '" << name << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  // get pointer to node with same parameter name in singly linked list of InputLines
-  pl = pb->GetPtrToLine(name);
-  if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetBoolean]" << std::endl
-        << "Parameter name '" << name << "' not found in block '" << block << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  std::string val = pl->param_value;
+  auto val = deck.GetCardValue<bool>(block,name);
   CheckAndUpdateQueries_<bool>(block, name, docstring);
-  return stob(val);
+
+  return val;
 }
 
 //----------------------------------------------------------------------------------------
@@ -634,32 +361,9 @@ bool ParameterInput::GetBoolean(const std::string &block, const std::string &nam
 
 std::string ParameterInput::GetString(const std::string &block, const std::string &name,
                                       const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream msg;
-
-  // get pointer to node with same block name in singly linked list of InputBlocks
-  pb = GetPtrToBlock(block);
-  if (pb == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetString]" << std::endl
-        << "Block name '" << block << "' not found when trying to set value "
-        << "for parameter '" << name << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  // get pointer to node with same parameter name in singly linked list of InputLines
-  pl = pb->GetPtrToLine(name);
-  if (pl == nullptr) {
-    msg << "### FATAL ERROR in function [ParameterInput::GetString]" << std::endl
-        << "Parameter name '" << name << "' not found in block '" << block << "'";
-    PARTHENON_FAIL(msg);
-  }
-
-  std::string val = pl->param_value;
-
+  auto val = deck.GetCardValue<std::string>(block,name);
   CheckAndUpdateQueries_<std::string>(block, name, docstring);
 
-  // return value
   return val;
 }
 
@@ -683,27 +387,8 @@ std::string ParameterInput::GetString(const std::string &block, const std::strin
 int ParameterInput::GetOrAddInteger(const std::string &block, const std::string &name,
                                     int def_value,
                                     const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream ss_value;
-  int ret;
-
   CheckAndUpdateQueries_<int>(block, name, def_value, std::vector<int>{}, docstring);
-
-  if (DoesParameterExist(block, name)) {
-    pb = GetPtrToBlock(block);
-    pl = pb->GetPtrToLine(name);
-    std::string val = pl->param_value;
-    ret = stoi(val);
-  } else {
-    pb = FindOrAddBlock(block);
-    ss_value << def_value;
-    AddParameter(pb, name, ss_value.str(), "# Default value added at run time");
-    ret = def_value;
-    UpdateQueryProvenance_(block, name, QueryRecord::OriginType::Default);
-  }
-
-  return ret;
+  return deck.GetOrAddCardValue<int>(block,name,def_value);
 }
 int ParameterInput::GetOrAddInteger(const std::string &block, const std::string &name,
                                     const ParameterRef &value,
@@ -724,28 +409,9 @@ int ParameterInput::GetOrAddInteger(const std::string &block, const std::string 
 Real ParameterInput::GetOrAddReal(const std::string &block, const std::string &name,
                                   Real def_value,
                                   const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream ss_value;
-  Real ret;
 
   CheckAndUpdateQueries_<Real>(block, name, def_value, std::vector<Real>{}, docstring);
-
-  if (DoesParameterExist(block, name)) {
-    pb = GetPtrToBlock(block);
-    pl = pb->GetPtrToLine(name);
-    std::string val = pl->param_value;
-    ret = static_cast<Real>(atof(val.c_str()));
-  } else {
-    pb = FindOrAddBlock(block);
-    static_assert(sizeof(Real) <= sizeof(double), "Real is greater than double!");
-    ss_value.precision(std::numeric_limits<double>::max_digits10);
-    ss_value << def_value;
-    AddParameter(pb, name, ss_value.str(), "# Default value added at run time");
-    ret = def_value;
-    UpdateQueryProvenance_(block, name, QueryRecord::OriginType::Default);
-  }
-  return ret;
+  return deck.GetOrAddCardValue<Real>(block,name,def_value);
 }
 Real ParameterInput::GetOrAddReal(const std::string &block, const std::string &name,
                                   const ParameterRef &value,
@@ -766,32 +432,9 @@ Real ParameterInput::GetOrAddReal(const std::string &block, const std::string &n
 bool ParameterInput::GetOrAddBoolean(const std::string &block, const std::string &name,
                                      bool def_value,
                                      const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream ss_value;
-  bool ret;
 
   CheckAndUpdateQueries_<bool>(block, name, def_value, std::vector<bool>{}, docstring);
-
-  if (DoesParameterExist(block, name)) {
-    pb = GetPtrToBlock(block);
-    pl = pb->GetPtrToLine(name);
-    std::string val = pl->param_value;
-    if (val.compare(0, 1, "0") == 0 || val.compare(0, 1, "1") == 0) {
-      ret = static_cast<bool>(stoi(val));
-    } else {
-      std::transform(val.begin(), val.end(), val.begin(), ::tolower);
-      std::istringstream is(val);
-      is >> std::boolalpha >> ret;
-    }
-  } else {
-    pb = FindOrAddBlock(block);
-    ss_value << def_value;
-    AddParameter(pb, name, ss_value.str(), "# Default value added at run time");
-    ret = def_value;
-    UpdateQueryProvenance_(block, name, QueryRecord::OriginType::Default);
-  }
-  return ret;
+  return deck.GetOrAddCardValue<bool>(block,name,def_value);
 }
 bool ParameterInput::GetOrAddBoolean(const std::string &block, const std::string &name,
                                      const ParameterRef &value,
@@ -813,25 +456,10 @@ std::string ParameterInput::GetOrAddString(const std::string &block,
                                            const std::string &name,
                                            const std::string &def_value,
                                            const std::optional<std::string> &docstring) {
-  InputBlock *pb;
-  InputLine *pl;
-  std::stringstream ss_value;
-  std::string ret;
 
   CheckAndUpdateQueries_<std::string>(block, name, def_value, std::vector<std::string>{},
                                       docstring);
-
-  if (DoesParameterExist(block, name)) {
-    pb = GetPtrToBlock(block);
-    pl = pb->GetPtrToLine(name);
-    ret = pl->param_value;
-  } else {
-    pb = FindOrAddBlock(block);
-    AddParameter(pb, name, def_value, "# Default value added at run time");
-    ret = def_value;
-    UpdateQueryProvenance_(block, name, QueryRecord::OriginType::Default);
-  }
-  return ret;
+  return deck.GetOrAddCardValue<std::string>(block,name,def_value);
 }
 
 std::string ParameterInput::GetOrAddString(const std::string &block,
@@ -839,7 +467,7 @@ std::string ParameterInput::GetOrAddString(const std::string &block,
                                            const std::string &def_value,
                                            const std::vector<std::string> &allowed_values,
                                            const std::optional<std::string> &docstring) {
-  auto val = GetOrAddString(block, name, def_value);
+  auto val = deck.GetOrAddCardValue<std::string>(block,name,def_value);
   CheckAllowedValues_(block, name, val, allowed_values);
   CheckAndUpdateQueries_<std::string>(block, name, def_value, allowed_values, docstring);
   return val;
@@ -856,11 +484,8 @@ int ParameterInput::SetInteger(const std::string &block, const std::string &name
     CheckAndUpdateQueries_<int>(block, name, docstring);
   }
 
-  InputBlock *pb;
-  std::stringstream ss_value;
-  pb = FindOrAddBlock(block);
-  ss_value << value;
-  AddParameter(pb, name, ss_value.str(), "# Updated during run time");
+  deck.AddCard(block,name,value);
+
   UpdateQueryProvenance_(block, name, QueryRecord::OriginType::SetInCode);
 
   return value;
@@ -876,15 +501,7 @@ Real ParameterInput::SetReal(const std::string &block, const std::string &name,
   if (queries_.count(std::make_pair(block, name)) == 0) {
     CheckAndUpdateQueries_<Real>(block, name, docstring);
   }
-
-  InputBlock *pb;
-  std::stringstream ss_value;
-
-  pb = FindOrAddBlock(block);
-  static_assert(sizeof(Real) <= sizeof(double), "Real is greater than double!");
-  ss_value.precision(std::numeric_limits<double>::max_digits10);
-  ss_value << value;
-  AddParameter(pb, name, ss_value.str(), "# Updated during run time");
+  deck.AddCard(block,name,value);
   UpdateQueryProvenance_(block, name, QueryRecord::OriginType::SetInCode);
 
   return value;
@@ -901,12 +518,8 @@ bool ParameterInput::SetBoolean(const std::string &block, const std::string &nam
     CheckAndUpdateQueries_<bool>(block, name, docstring);
   }
 
-  InputBlock *pb;
-  std::stringstream ss_value;
+  deck.AddCard(block,name,value);
 
-  pb = FindOrAddBlock(block);
-  ss_value << value;
-  AddParameter(pb, name, ss_value.str(), "# Updated during run time");
   UpdateQueryProvenance_(block, name, QueryRecord::OriginType::SetInCode);
 
   return value;
@@ -925,46 +538,26 @@ std::string ParameterInput::SetString(const std::string &block, const std::strin
     CheckAndUpdateQueries_<std::string>(block, name, docstring);
   }
 
-  InputBlock *pb;
+  deck.AddCard(block,name,value);
 
-  pb = FindOrAddBlock(block);
-  AddParameter(pb, name, value, "# Updated during run time");
   UpdateQueryProvenance_(block, name, QueryRecord::OriginType::SetInCode);
 
   return value;
 }
 
 void ParameterInput::RemoveParameter(const std::string &block, const std::string &name) {
-  InputBlock *pb = GetPtrToBlock(block);
-  InputLine *plast = pb->pline;
-  bool deleted = false;
-  for (InputLine *pl = pb->pline; pl != nullptr; pl = pl->pnext) {
-    if (name.compare(pl->param_name) == 0) {
-      // if head of list
-      if (plast == pb->pline) {
-        pb->pline = pl->pnext;
-      } else {
-        plast->pnext = pl->pnext;
-      }
-      delete pl;
-      deleted = true;
-      break;
-    }
-    plast = pl;
-  }
-  if (deleted) {
-    auto key = std::make_pair(block, name);
-    auto it = queries_.find(key);
-    if (it != queries_.end()) {
-      queries_.erase(it);
-    }
+  deck.RemoveCard(block,name);
+  auto key = std::make_pair(block, name);
+  auto it = queries_.find(key);
+  if (it != queries_.end()) {
+    queries_.erase(it);
   }
 }
 
 void ParameterInput::CheckRequired(const std::string &block, const std::string &name) {
   bool missing = true;
   if (DoesParameterExist(block, name)) {
-    missing = (GetComment(block, name) == "# Default value added at run time");
+    missing = (GetComment(block, name) == "Default value added at run time");
   }
   if (missing) {
     std::stringstream ss;
@@ -981,7 +574,7 @@ void ParameterInput::CheckDesired(const std::string &block, const std::string &n
   bool defaulted = false;
   if (DoesParameterExist(block, name)) {
     missing = false;
-    defaulted = (GetComment(block, name) == "# Default value added at run time");
+    defaulted = (GetComment(block, name) == "Default value added at run time");
   }
   if (missing) {
     std::cout << std::endl
@@ -1027,20 +620,7 @@ void ParameterInput::ParameterDump(std::ostream &os) {
 
   os << "#------------------------- PAR_DUMP -------------------------" << std::endl;
 
-  for (pb = pfirst_block; pb != nullptr; pb = pb->pnext) { // loop over InputBlocks
-    os << "<" << pb->block_name << ">" << std::endl;       // write block name
-    for (pl = pb->pline; pl != nullptr; pl = pl->pnext) {  // loop over InputLines
-      param_name.assign(pl->param_name);
-      param_value.assign(pl->param_value);
-
-      len = pb->max_len_parname - param_name.length() + 1;
-      param_name.append(len, ' '); // pad name to align vertically
-      len = pb->max_len_parvalue - param_value.length() + 1;
-      param_value.append(len, ' '); // pad value to align vertically
-
-      os << param_name << "= " << param_value << pl->param_comment << std::endl;
-    }
-  }
+  deck.WriteDeck(os);
 
   os << "#------------------------- PAR_DUMP -------------------------" << std::endl;
   os << "<par_end>" << std::endl; // finish with par-end (useful in restart files)
@@ -1108,17 +688,6 @@ void ParameterInput::OutputParameterTable(std::ostream &os,
       i++;
     }
   }
-}
-
-//----------------------------------------------------------------------------------------
-//! \fn InputLine* InputBlock::GetPtrToLine(std::string name)
-//  \brief return pointer to InputLine containing specified parameter if it exists
-
-InputLine *InputBlock::GetPtrToLine(std::string name) {
-  for (InputLine *pl = pline; pl != nullptr; pl = pl->pnext) {
-    if (name.compare(pl->param_name) == 0) return pl;
-  }
-  return nullptr;
 }
 
 } // namespace parthenon

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -592,12 +592,12 @@ void ParameterInput::CheckDesired(const std::string &block, const std::string &n
 
 void ParameterInput::CheckOrphans() const {
   std::set<std::pair<std::string, std::string>> orphans;
-  for (InputBlock *pib = pfirst_block; pib != nullptr; pib = pib->pnext) {
-    for (InputLine *pline = pib->pline; pline != nullptr; pline = pline->pnext) {
-      auto key = std::make_pair(pib->block_name, pline->param_name);
-      if (queries_.count(key) == 0) {
+  for (auto &block_name : deck.GetSuitsInOrder()) {
+    for( auto &param : deck.FindSuitInOrder(block_name)) {
+       auto key = std::make_pair(block_name, param.name);
+       if (queries_.count(key) == 0) {
         orphans.insert(key);
-      }
+        }
     }
   }
   std::stringstream msg;
@@ -631,12 +631,12 @@ void ParameterInput::OutputParameterTable(std::ostream &os,
                                           const std::regex &block_regex) const {
   // Loop through once and store in a map for lexicographic ordering
   std::map<std::string, std::map<std::string, std::string>> csvblocks;
-  for (InputBlock *pb = pfirst_block; pb != nullptr; pb = pb->pnext) {
-    const std::string &block_name = pb->block_name;
+
+  for (auto &block_name : deck.GetSuitsInOrder()) {
     if (std::regex_match(block_name, block_regex)) {
       auto &csvlines = csvblocks[block_name];
-      for (InputLine *pl = pb->pline; pl != nullptr; pl = pl->pnext) {
-        const std::string &param_name = pl->param_name;
+      for( auto &param : deck.FindSuitInOrder(block_name)) {
+        const std::string &param_name = param.name;
         auto record_key = std::make_pair(block_name, param_name);
         /* clang-format off */
         // This ensures the code doesn't crash for orphan parameters

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -518,24 +518,11 @@ class ParameterInput {
 // JMM: Believe it or not, this is the recommended way to overload hash functions
 // See: https://en.cppreference.com/w/cpp/utility/hash
 namespace std {
-template <>
-struct hash<parthenon::InputLine> {
-  std::size_t operator()(const parthenon::InputLine &il) {
-    return parthenon::impl::hash_combine(0, il.param_name, il.param_value,
-                                         il.param_comment);
-  }
-};
 
 template <>
-struct hash<parthenon::InputBlock> {
-  std::size_t operator()(const parthenon::InputBlock &ib) {
-    using parthenon::impl::hash_combine;
-    std::size_t out =
-        hash_combine(0, ib.block_name, ib.max_len_parname, ib.max_len_parvalue);
-    for (parthenon::InputLine *pline = ib.pline; pline != nullptr; pline = pline->pnext) {
-      out = hash_combine(out, *pline);
-    }
-    return out;
+struct hash<Rummy::Card> {
+  std::size_t operator()(const Rummy::Card &card) const {
+    return parthenon::impl::hash_combine(0, card.name, card.GetString(), card.GetComment());
   }
 };
 
@@ -546,9 +533,9 @@ struct hash<parthenon::ParameterInput> {
     using parthenon::impl::hash_combine;
     std::size_t out = 0;
     out = hash_combine(out, in.last_filename_);
-    for (InputBlock *pblock = in.pfirst_block; pblock != nullptr;
-         pblock = pblock->pnext) {
-      out = hash_combine(out, *pblock);
+    for (auto &block_name : in.deck.GetSuitsInOrder()) {
+      auto &block = in.deck.GetSuit(block_name);
+      out = hash_combine(out, std::make_pair(block_name, block));
     }
     return out;
   }

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -36,6 +36,9 @@
 #include <utility> // for std::forward, std::pair
 #include <vector>
 
+#include <rummy/deck.hpp>
+
+
 #include "config.hpp"
 #include "defs.hpp"
 #include "globals.hpp"
@@ -194,7 +197,8 @@ class ParameterInput {
  public:
   // constructor/destructor
   ParameterInput();
-  explicit ParameterInput(std::string input_filename);
+  explicit ParameterInput(std::istringstream &is, const bool old, std::vector<std::string> input_filename={}, std::vector<std::string> mods={});
+  explicit ParameterInput(std::vector<std::string> input_filename, std::vector<std::string> mods={});
   ~ParameterInput();
 
   // data
@@ -204,8 +208,11 @@ class ParameterInput {
   // functions
   void LoadFromStream(std::istream &is);
   void LoadFromFile(IOWrapper &input);
+  void LoadFromRestart(std::istringstream &is);
+  void LoadFromOldRestart(std::istringstream &is);
   void ModifyFromCmdline(int argc, char *argv[]);
   void ParameterDump(std::ostream &os);
+  void GenerateLinkedList();
   // TODO(JMM): Make this more general?
   void OutputParameterTable(std::ostream &os,
                             const std::regex &block_regex = std::regex("(.*)")) const;
@@ -326,19 +333,7 @@ class ParameterInput {
   std::vector<T>
   GetVector(const std::string &block, const std::string &name,
             const std::optional<std::string> &docstring = std::optional<std::string>{}) {
-    std::vector<std::string> fields = GetVector_(block, name);
-    if constexpr (std::is_same<T, std::string>::value) return fields;
-
-    std::vector<T> ret;
-    for (auto &f : fields) {
-      if constexpr (std::is_same<T, int>::value) {
-        ret.push_back(stoi(f));
-      } else if constexpr (std::is_same<T, Real>::value) {
-        ret.push_back(atof(f.c_str()));
-      } else if constexpr (std::is_same<T, bool>::value) {
-        ret.push_back(stob(f));
-      }
-    }
+    auto ret = deck.GetVector<T>(block, name);
     CheckAndUpdateQueries_<std::vector<T>>(block, name, docstring);
     return ret;
   }
@@ -350,9 +345,7 @@ class ParameterInput {
                                            std::vector<std::vector<T>>{}, docstring);
     if (DoesParameterExist(block, name)) return GetVector<T>(block, name);
 
-    std::string cname = ConcatVector_(def);
-    auto *pb = FindOrAddBlock(block);
-    AddParameter(pb, name, cname, "# Default value added at run time");
+    deck.AddVector(block, name, def, "# Default value added at run time");
     return def;
   }
   template <typename T>
@@ -366,17 +359,13 @@ class ParameterInput {
   }
 
  private:
+  Rummy::Deck deck;
   std::string last_filename_; // last input file opened, to prevent duplicate reads
   // We will want to iterate through the record in lexicographic
   // order, so this needs to be an ordered map
   std::map<std::pair<std::string, std::string>, QueryRecord> queries_;
 
   InputBlock *FindOrAddBlock(const std::string &name);
-  InputBlock *GetPtrToBlock(const std::string &name);
-  bool ParseLine(InputBlock *pib, std::string line, std::string &name, std::string &value,
-                 std::string &comment);
-  void AddParameter(InputBlock *pib, const std::string &name, const std::string &value,
-                    const std::string &comment);
   bool stob(std::string val) {
     // check is string contains integers 0 or 1 (instead of true or false) and return
     if (val.compare(0, 1, "0") == 0 || val.compare(0, 1, "1") == 0) {
@@ -408,35 +397,9 @@ class ParameterInput {
       PARTHENON_THROW(msg);
     }
   }
-  std::vector<std::string> GetVector_(const std::string &block, const std::string &name) {
-    std::string s = GetString(block, name);
-    std::string delimiter = ",";
-    size_t pos = 0;
-    std::string token;
-    std::vector<std::string> variables;
-    while ((pos = s.find(delimiter)) != std::string::npos) {
-      token = s.substr(0, pos);
-      variables.push_back(string_utils::trim(token));
-      s.erase(0, pos + delimiter.length());
-    }
-    variables.push_back(string_utils::trim(s));
-    return variables;
-  }
-  template <typename T>
-  std::string ConcatVector_(std::vector<T> &vec) {
-    std::stringstream ss;
-    const int n = vec.size();
-    if (n == 0) return "";
-
-    ss << vec[0];
-    for (int i = 1; i < n; i++) {
-      ss << "," << vec[i];
-    }
-    return ss.str();
-  }
 
   // JMM: Using std::optional here aggressively to simplify overload
-  // and default parameter logic logic
+  // and default parameter logic
   template <typename T, template <class...> class Container_t, class... extra>
   void CheckAndUpdateQueries_(const std::string &block, const std::string &name,
                               const std::optional<T> &defval,

--- a/src/parthenon_manager.cpp
+++ b/src/parthenon_manager.cpp
@@ -108,28 +108,12 @@ ParthenonStatus ParthenonManager::ParthenonInitEnv(int argc, char *argv[]) {
     }
 
     // Load input stream
-    pinput = std::make_unique<ParameterInput>();
     auto inputString = restartReader->GetInputString();
     std::istringstream is(inputString);
-    pinput->LoadFromStream(is);
+    pinput = std::make_unique<ParameterInput>(is, arg.is_old_restart, arg.input_filename, arg.mods);
+  } else {
+    pinput = std::make_unique<ParameterInput>(arg.input_filename, arg.mods);
   }
-  // If an input file was provided
-  if (arg.input_filename != nullptr) {
-    // Modify info read from restart file
-    if (arg.is_restart) {
-      IOWrapper infile;
-      infile.Open(arg.input_filename, IOWrapper::FileMode::read);
-      pinput->LoadFromFile(infile);
-      infile.Close();
-
-      // Populate new object for fresh simulation
-    } else {
-      pinput = std::make_unique<ParameterInput>(arg.input_filename);
-    }
-  }
-
-  // Modify based on command line inputs
-  pinput->ModifyFromCmdline(argc, argv);
 
   PARTHENON_REQUIRE_THROWS(
       !pinput->DoesParameterExist("parthenon/job", "run_only_analysis") ||

--- a/src/utils/hash.hpp
+++ b/src/utils/hash.hpp
@@ -83,6 +83,24 @@ struct std::hash<std::tuple<Ts...>> {
   }
 };
 
+template <class T1, class T2>
+struct std::hash<std::pair<T1, T2>> {
+  std::size_t operator()(const std::pair<T1, T2> &p) const {
+    return parthenon::impl::hash_combine(std::hash<typename std::remove_const<T1>::type>()(p.first),
+                                         std::hash<typename std::remove_const<T2>::type>()(p.second));
+  }
+};
+
+template <class Key, class T, class Compare, class Allocator>
+struct std::hash<std::map<Key, T, Compare, Allocator>> {
+  std::size_t operator()(const std::map<Key, T, Compare, Allocator> &m) const {
+    std::size_t h{0};
+    for (auto &&kv : m)
+      parthenon::impl::boost_hash_combine(h, hash<std::pair<const Key, T>>()(kv));
+    return h;
+  }
+};
+
 namespace parthenon {
 template <class T>
 struct WeakPtrHash {
@@ -100,6 +118,7 @@ struct WeakPtrEqual {
     return !lhs.owner_before(rhs) && !rhs.owner_before(lhs);
   }
 };
+
 
 // This is just here for backward compatibility
 template <class T>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This overhauls the entire parameter input machinery to rely on my input deck library [Rummy](https://github.com/lanl/rummy). For examples of the new syntax, see the various input files in `examples/` and the Rummy repository.

Rummy breaks an input deck down into suits (the `<parthenon/...>` nodes) and cards (the parameters themselves). The values of the cards are passed into a byte-code compiler that I wrote. The compiler supports strings, bools, and number variables and various operations on those variables. The syntax for the card values is similar to python. The three big things this adds is support for global variables, referencing other parameters defined in the input deck and full infix expressions. For example,

```
nb = 16,16, 1  # can also do [16,16,1]
Lx = 1.0
<parthenon/meshblock>
nx1 = nb[0]
nx2 = nb[1]
nx3 = nb[2]

<parthenon/mesh>
nx1 = parthenon.meshblock.nx1 * 10
x1min = -Lx/2.
x1max =  Lx/2.
ix1_bc = "periodic"
ox1_bc = ix1_bc

nx2 = parthenon.meshblock.nx2 * 10
x2min = -pi
x2max = pi
ix2_bc = ix1_bc
ox2_bc = ix1_bc

nx3 = nb[2]

print("Inner X1 BC is " + parthenon.mesh.ix1_bc)
print("X2 Extent:")
print(x2max - x2min)
```

Operators that are defined are `+, - ,*, /, ** (power), // (integer division), %, >, <, >=, <=, !, !=`. You can add strings with `+`.  Almost all of the `<cmath>` functions are supported. Vector params are supported and there is some limited support for slice operations. The compiled parts will spit out errors telling you what you did wrong.

The syntax for variable reference is like classes. The `/` in a node is replaced with a `.` . At this time, there is no inheritance.

To support the new syntax I've changed a bit how the input arguments are handled. Now you can do things like this,

```
./app -i input1.par -i input2.par 'parthenon.mesh.ix1_bc = "outflow"'
```
We accept multiple `-i` input files now. These are stuffed into a vector and compiled in order. The modifications are compiled after the input files and should now be wrapped in single quotes (if there are strings, otherwise double quotes is fine). 

Restarts are mostly the same, but I have added a `-R` option to read old restart files that use the old syntax. 

Another nice feature this adds is the ability for the host code to pre-populate parameters that can be used in the input files. For example, you could add all of the physical constants before the input decks are compiled. 

Lastly, there is a simple `print` function that can print the value of any parameter or expression from the input file. 

I anticipate the utility of this to grow with time as I work more on my compiler. Right now, branches and loops are supported in the compiler but not Rummy, and functions and classes are supported in neither, but I plan to work on those as time permits. The idea is to work towards a fully compiled and interpreted input file. 

This is still WIP but appears to work for all the parthenon examples and various artemis tests, so I'm putting it up now for feedback. Things left to do include:

- [ ] Fix the unit tests
- [ ] Verify various downstream code usage
- [ ] Decide on support for legacy format. Compile time or runtime?


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
