### PR TITLE
[Small][Bugfix] Clear all GMG levels on AMR remesh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1338]](https://github.com/parthenon-hpc-lab/parthenon/pull/1338) Fix bug where gmg block list wasn't completely cleared after remesh
 - [[PR 1330]](https://github.com/parthenon-hpc-lab/parthenon/pull/1330) Add missing device-side destructor to BndId. Make comm buffer pools safe to clear.
 - [[PR 1327]](https://github.com/parthenon-hpc-lab/parthenon/pull/1327) Eliminate warnings from ViewOfViewAlloc
 - [[PR 1328]](https://github.com/parthenon-hpc-lab/parthenon/pull/1328) Add more useful error message for task list timeout

--- a/src/mesh/mesh-gmg.cpp
+++ b/src/mesh/mesh-gmg.cpp
@@ -115,6 +115,7 @@ void Mesh::BuildGMGBlockLists(ParameterInput *pin, ApplicationInput *app_in) {
 
   const int gmg_min_level = -gmg_level_offset;
   gmg_min_logical_level_ = gmg_min_level;
+  gmg_block_lists_.clear();
   for (int level = gmg_min_level; level <= current_level; ++level) {
     gmg_block_lists_[level] = BlockList_t();
   }


### PR DESCRIPTION
## PR Summary

Previously, we were not clearing logical locations from all levels of `Mesh::gmg_block_lists_`. Rather, we were only clearing levels that existed in the new mesh. There are some edge cases in the forest where this can mean that internal locations from the the previous mesh setup are spuriously left over in a newly refined mesh on levels finer than the finest level of the current mesh. This is fixed by explicitly clearing `Mesh::gmg_block_lists_` before building the new lists level by level. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
