### PR TITLE
[Bugfix] Set ownership for multigrid neighbors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@
 - [[PR 1253]](https://github.com/parthenon-hpc-lab/parthenon/pull/1253) Add support for uint64 swarm variables and add default id
 - [[PR 1280]](https://github.com/parthenon-hpc-lab/parthenon/pull/1280) Print history file headers on restart
 
-### Fixed (not changing behavior/API/variables/...)
+### Fixed (not changing behavior/API/variables/...)1340
+- [[PR 1340]](https://github.com/parthenon-hpc-lab/parthenon/pull/1340) Set ownership for finer multigrid neighbors 
 - [[PR 1338]](https://github.com/parthenon-hpc-lab/parthenon/pull/1338) Fix bug where gmg block list wasn't completely cleared after remesh
 - [[PR 1330]](https://github.com/parthenon-hpc-lab/parthenon/pull/1330) Add missing device-side destructor to BndId. Make comm buffer pools safe to clear.
 - [[PR 1327]](https://github.com/parthenon-hpc-lab/parthenon/pull/1327) Eliminate warnings from ViewOfViewAlloc

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -246,6 +246,10 @@ CalcIndices(const NeighborBlock &nb, MeshBlock *pmb,
       if (sox3 == 0) sox3 = loc.l(2) % 2 == 1 ? 1 : -1;
     }
     owns = GetIndexRangeMaskFromOwnership(el, nb.ownership, sox1, sox2, sox3);
+  } else if (ir_type == IndexRangeType::InteriorRecv) {
+    // Also need to set ownership when a parent block receives from a daughter
+    // block during multigrid operations
+    owns = GetIndexRangeMaskFromOwnership(el, nb.ownership, 0, 0, 0);
   }
   return SpatiallyMaskedIndexer6D(owns, {0, tensor_shape[0] - 1},
                                   {0, tensor_shape[1] - 1}, {0, tensor_shape[2] - 1},

--- a/src/interface/variable.cpp
+++ b/src/interface/variable.cpp
@@ -69,12 +69,10 @@ std::string Variable<T>::info() {
   return s;
 }
 
-// Makes a shallow copy of the boundary buffer and fluxes of the source variable and
-// assign them to this variable
+// Makes a shallow copy of the coarse buffer from src
 template <typename T>
-void Variable<T>::CopyFluxesAndBdryVar(const Variable<T> *src) {
-  if (IsSet(Metadata::FillGhost) || IsSet(Metadata::Independent) ||
-      IsSet(Metadata::ForceRemeshComm) || IsSet(Metadata::Flux)) {
+void Variable<T>::CopyCoarseBuffer(const Variable<T> *src) {
+  if (RequiresCoarseBuffer()) {
     // no need to check mesh->multilevel, if false, we're just making a shallow copy of
     // an empty ParArrayND
     coarse_s = src->coarse_s;
@@ -93,7 +91,7 @@ std::shared_ptr<Variable<T>> Variable<T>::AllocateCopy(std::weak_ptr<MeshBlock> 
     cv->AllocateData(wpmb);
   }
 
-  cv->CopyFluxesAndBdryVar(this);
+  cv->CopyCoarseBuffer(this);
 
   return cv;
 }
@@ -140,8 +138,7 @@ void Variable<T>::AllocateCoarse(std::weak_ptr<MeshBlock> wpmb) {
   std::string base_name = label();
 
   // Create the boundary object
-  if (IsSet(Metadata::FillGhost) || IsSet(Metadata::Independent) ||
-      IsSet(Metadata::ForceRemeshComm) || IsSet(Metadata::Flux)) {
+  if (RequiresCoarseBuffer()) {
     if (wpmb.expired()) return;
     std::shared_ptr<MeshBlock> pmb = wpmb.lock();
 
@@ -165,8 +162,7 @@ std::int64_t Variable<T>::Deallocate() {
   mem_size += data.size() * sizeof(T);
   data.Reset();
 
-  if (IsSet(Metadata::FillGhost) || IsSet(Metadata::Independent) ||
-      IsSet(Metadata::ForceRemeshComm) || IsSet(Metadata::Flux)) {
+  if (RequiresCoarseBuffer()) {
     mem_size += coarse_s.size() * sizeof(T);
     coarse_s.Reset();
   }

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -66,7 +66,7 @@ class Variable {
   Variable() = default;
   ~Variable() {}
   // copy fluxes and boundary variable from src Variable (shallow copy)
-  void CopyFluxesAndBdryVar(const Variable<T> *src);
+  void CopyCoarseBuffer(const Variable<T> *src);
 
   // make a new Variable based on an existing one
   std::shared_ptr<Variable<T>> AllocateCopy(std::weak_ptr<MeshBlock> wpmb);
@@ -154,6 +154,12 @@ class Variable {
     if (IsSet(Metadata::Edge)) return {TE::E1, TE::E2, TE::E3};
     if (IsSet(Metadata::Node)) return {TE::NN};
     return {TE::CC};
+  }
+  
+  bool RequiresCoarseBuffer() const { 
+    return IsSet(Metadata::FillGhost) || IsSet(Metadata::Independent) ||
+           IsSet(Metadata::ForceRemeshComm) || IsSet(Metadata::Flux) ||
+           IsSet(Metadata::GMGRestrict) || IsSet(Metadata::GMGProlongate);
   }
 
  private:

--- a/src/interface/variable.hpp
+++ b/src/interface/variable.hpp
@@ -155,8 +155,8 @@ class Variable {
     if (IsSet(Metadata::Node)) return {TE::NN};
     return {TE::CC};
   }
-  
-  bool RequiresCoarseBuffer() const { 
+
+  bool RequiresCoarseBuffer() const {
     return IsSet(Metadata::FillGhost) || IsSet(Metadata::Independent) ||
            IsSet(Metadata::ForceRemeshComm) || IsSet(Metadata::Flux) ||
            IsSet(Metadata::GMGRestrict) || IsSet(Metadata::GMGProlongate);

--- a/src/mesh/mesh-gmg.cpp
+++ b/src/mesh/mesh-gmg.cpp
@@ -169,6 +169,9 @@ void Mesh::SetGMGNeighbors() {
           pmb->gmg_coarser_neighbors.emplace_back(
               pmb->pmy_mesh, ploc, ploc, ranklist[leaf_gid], gid,
               Kokkos::Array<int, 3>{0, 0, 0}, 0, 0, 0, 0);
+          // No need to explicitly set ownership (which defaults to
+          // true), since the coarse block owns all elements of all
+          // of its daughter blocks
         }
       }
 
@@ -191,6 +194,17 @@ void Mesh::SetGMGNeighbors() {
           pmb->gmg_leaf_neighbors.emplace_back(
               pmb->pmy_mesh, pmb->loc, pmb->loc, Globals::my_rank, pmb->gid,
               Kokkos::Array<int, 3>{0, 0, 0}, 0, 0, 0, 0);
+        } else if (pmb->gmg_finer_neighbors.size() > 1) {
+          // This block has multiple finer neighbors, so we need to set ownership
+          // on shared elements in the interior of the coarse block. We do not need
+          // to worry about coordinate transformations, since all daughter blocks
+          // are guaranteed to be in the same logical coordinate system.
+          std::vector<forest::NeighborLocation> neighbor_locs;
+          for (const auto &n : pmb->gmg_finer_neighbors)
+            neighbor_locs.emplace_back(n.loc, n.loc,
+                                       forest::LogicalCoordinateTransformation());
+          for (auto &n : pmb->gmg_finer_neighbors)
+            n.ownership = DetermineOwnership(n.loc, neighbor_locs);
         }
       }
 

--- a/src/mesh/meshblock.cpp
+++ b/src/mesh/meshblock.cpp
@@ -304,7 +304,7 @@ void MeshBlock::AllocateSparse(std::string const &label, bool only_control,
         v->AllocateData(this, flag_uninitialized);
 
         // copy fluxes and boundary variable from variable on base stage
-        v->CopyFluxesAndBdryVar(base_var.get());
+        v->CopyCoarseBuffer(base_var.get());
       }
     }
   };


### PR DESCRIPTION
## PR Summary

Previously, we were not setting the ownership array of multigrid `NeighborBlock`s. This meant that there was a race condition when restricting non-cell centered data between multigrid levels. The race condition could show up even in serial because we randomize the order of the buffer caches for communication. The main place this issue showed up was diffusion coefficients, where there was apparently not bitwise agreement between shared elements on both blocks. This resulted in non-reproducible solutions for the diffusion example, for instance, when non-constant diffusion coefficients were employed. 

This PR sets the ownership correctly so that only one block tries to write to any given element in a coarse parent.

Additionally, this fixes an issue where the coarse buffer wasn't allocated for fields that had `Metadata::gmg_restrict` set but also `Metadata::Derived`.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
