### PR TITLE
Allow for user defined restriction between multigrid levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1346]](https://github.com/parthenon-hpc-lab/parthenon/pull/1346) Allow for user defined inter-level restrictions in multigrid 
 - [[PR 1344]](https://github.com/parthenon-hpc-lab/parthenon/pull/1344) Add option to communicate single layer of ghosts, only communicate required two-level composite boundaries
 
 

--- a/example/poisson_gmg/poisson_package.cpp
+++ b/example/poisson_gmg/poisson_package.cpp
@@ -96,7 +96,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
   std::shared_ptr<parthenon::solvers::SolverBase> psolver;
   using prolongator_t = parthenon::solvers::ProlongationBlockInteriorZeroDirichlet;
   using restrictor_t = parthenon::solvers::RestrictionCombined;
-  using preconditioner_t = parthenon::solvers::MGSolver<PoissEq, prolongator_t, restrictor_t>;
+  using preconditioner_t =
+      parthenon::solvers::MGSolver<PoissEq, prolongator_t, restrictor_t>;
   if (solver == "MG") {
     psolver = std::make_shared<parthenon::solvers::MGSolver<PoissEq, prolongator_t>>(
         "base", "u", "rhs", pin, "poisson/solver_params", PoissEq(pin, "poisson"));

--- a/example/poisson_gmg/poisson_package.cpp
+++ b/example/poisson_gmg/poisson_package.cpp
@@ -95,7 +95,8 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
 
   std::shared_ptr<parthenon::solvers::SolverBase> psolver;
   using prolongator_t = parthenon::solvers::ProlongationBlockInteriorZeroDirichlet;
-  using preconditioner_t = parthenon::solvers::MGSolver<PoissEq, prolongator_t>;
+  using restrictor_t = parthenon::solvers::RestrictionCombined;
+  using preconditioner_t = parthenon::solvers::MGSolver<PoissEq, prolongator_t, restrictor_t>;
   if (solver == "MG") {
     psolver = std::make_shared<parthenon::solvers::MGSolver<PoissEq, prolongator_t>>(
         "base", "u", "rhs", pin, "poisson/solver_params", PoissEq(pin, "poisson"));

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -48,7 +48,8 @@ using namespace loops;
 using namespace loops::shorthands;
 
 template <BoundaryType bound_type>
-TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
+TaskStatus SendBoundBufsWithRestrictOption(std::shared_ptr<MeshData<Real>> &md,
+                                           bool restrict) {
   PARTHENON_INSTRUMENT
 
   Mesh *pmesh = md->GetMeshPointer();
@@ -87,7 +88,7 @@ TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
     }
   }
   // Restrict
-  if (md->NumBlocks() > 0) {
+  if (md->NumBlocks() > 0 && restrict) {
     auto pmb = md->GetBlockData(0)->GetBlockPointer();
     StateDescriptor *resolved_packages = pmb->resolved_packages.get();
     refinement::Restrict(resolved_packages, cache.prores_cache, pmb->cellbounds,

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -49,7 +49,7 @@ using namespace loops::shorthands;
 
 template <BoundaryType bound_type>
 TaskStatus SendBoundBufsWithRestrictOption(std::shared_ptr<MeshData<Real>> &md,
-                                           bool restrict) {
+                                           bool do_restriction) {
   PARTHENON_INSTRUMENT
 
   Mesh *pmesh = md->GetMeshPointer();
@@ -88,7 +88,7 @@ TaskStatus SendBoundBufsWithRestrictOption(std::shared_ptr<MeshData<Real>> &md,
     }
   }
   // Restrict
-  if (md->NumBlocks() > 0 && restrict) {
+  if (md->NumBlocks() > 0 && do_restriction) {
     auto pmb = md->GetBlockData(0)->GetBlockPointer();
     StateDescriptor *resolved_packages = pmb->resolved_packages.get();
     refinement::Restrict(resolved_packages, cache.prores_cache, pmb->cellbounds,

--- a/src/bvals/comms/bvals_in_one.hpp
+++ b/src/bvals/comms/bvals_in_one.hpp
@@ -41,7 +41,7 @@ class Variable;
 
 template <BoundaryType bound_type>
 TaskStatus SendBoundBufsWithRestrictOption(std::shared_ptr<MeshData<Real>> &md,
-                                           bool restrict);
+                                           bool do_restriction);
 
 template <BoundaryType bound_type>
 inline TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {

--- a/src/bvals/comms/bvals_in_one.hpp
+++ b/src/bvals/comms/bvals_in_one.hpp
@@ -40,7 +40,19 @@ template <typename T>
 class Variable;
 
 template <BoundaryType bound_type>
-TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md);
+TaskStatus SendBoundBufsWithRestrictOption(std::shared_ptr<MeshData<Real>> &md,
+                                           bool restrict);
+
+template <BoundaryType bound_type>
+inline TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
+  return SendBoundBufsWithRestrictOption<bound_type>(md, true);
+}
+
+template <BoundaryType bound_type>
+inline TaskStatus SendBoundBufsNoRestrict(std::shared_ptr<MeshData<Real>> &md) {
+  return SendBoundBufsWithRestrictOption<bound_type>(md, false);
+}
+
 template <BoundaryType bound_type>
 TaskStatus StartReceiveBoundBufs(std::shared_ptr<MeshData<Real>> &md);
 template <BoundaryType bound_type>

--- a/src/solvers/internal_prolongation.hpp
+++ b/src/solvers/internal_prolongation.hpp
@@ -212,6 +212,7 @@ class RestrictionDefault {
 };
 
 class RestrictionCombined {
+// This Restriction class is an example that is only correct for uniform cartesian coordinates
  public:
   RestrictionCombined() = default;
   RestrictionCombined(parthenon::ParameterInput *pin, const std::string &label) {}

--- a/src/solvers/internal_prolongation.hpp
+++ b/src/solvers/internal_prolongation.hpp
@@ -212,8 +212,8 @@ class RestrictionDefault {
 };
 
 class RestrictionCombined {
-// This Restriction class is an example that is only correct for uniform
-// cartesian coordinates
+  // This Restriction class is an example that is only correct for uniform
+  // cartesian coordinates
  public:
   RestrictionCombined() = default;
   RestrictionCombined(parthenon::ParameterInput *pin, const std::string &label) {}

--- a/src/solvers/internal_prolongation.hpp
+++ b/src/solvers/internal_prolongation.hpp
@@ -203,22 +203,19 @@ class ProlongationBlockInteriorZeroDirichlet {
   }
 };
 
-// This is just an empty class without a Restrict method, which will trigger 
+// This is just an empty class without a Restrict method, which will trigger
 // calling the default restriction machinery in multigrid
 class RestrictionDefault {
  public:
   RestrictionDefault() = default;
-  RestrictionDefault(parthenon::ParameterInput *pin,
-                     const std::string &label){}
+  RestrictionDefault(parthenon::ParameterInput *pin, const std::string &label) {}
 };
 
 class RestrictionCombined {
  public:
-
   RestrictionCombined() = default;
-  RestrictionCombined(parthenon::ParameterInput *pin,
-                      const std::string &label){}
-  
+  RestrictionCombined(parthenon::ParameterInput *pin, const std::string &label) {}
+
   template <class VarTL>
   parthenon::TaskID Restrict(parthenon::TaskList &tl, parthenon::TaskID depends_on,
                              std::shared_ptr<parthenon::MeshData<Real>> &md) {

--- a/src/solvers/internal_prolongation.hpp
+++ b/src/solvers/internal_prolongation.hpp
@@ -212,7 +212,8 @@ class RestrictionDefault {
 };
 
 class RestrictionCombined {
-// This Restriction class is an example that is only correct for uniform cartesian coordinates
+// This Restriction class is an example that is only correct for uniform
+// cartesian coordinates
  public:
   RestrictionCombined() = default;
   RestrictionCombined(parthenon::ParameterInput *pin, const std::string &label) {}

--- a/src/solvers/internal_prolongation.hpp
+++ b/src/solvers/internal_prolongation.hpp
@@ -196,6 +196,58 @@ class ProlongationBlockInteriorZeroDirichlet {
         });
     return TaskStatus::complete;
   }
+
+  template <class VarTL>
+  parthenon::TaskID Restrict(parthenon::TaskList &tl, parthenon::TaskID depends_on,
+                             std::shared_ptr<parthenon::MeshData<Real>> &md) {
+    return tl.AddTask(depends_on, TF(RestrictImpl<VarTL>), md);
+  }
+
+  template <class VarTL>
+  static parthenon::TaskStatus
+  RestrictImpl(std::shared_ptr<parthenon::MeshData<Real>> &md) {
+    using namespace parthenon;
+    const int ndim = md->GetMeshPointer()->ndim;
+    IndexRange ib = md->GetBoundsI(IndexDomain::interior);
+    IndexRange jb = md->GetBoundsJ(IndexDomain::interior);
+    IndexRange kb = md->GetBoundsK(IndexDomain::interior);
+    IndexRange cib = md->GetBoundsI(CellLevel::coarse, IndexDomain::interior);
+    IndexRange cjb = md->GetBoundsJ(CellLevel::coarse, IndexDomain::interior);
+    IndexRange ckb = md->GetBoundsK(CellLevel::coarse, IndexDomain::interior);
+
+    using TE = parthenon::TopologicalElement;
+    int nblocks = md->NumBlocks();
+    std::vector<bool> include_block(nblocks, true);
+    for (int b = 0; b < nblocks; ++b) {
+      include_block[b] =
+          md->grid.logical_level == md->GetBlockData(b)->GetBlockPointer()->loc.level();
+    }
+    const auto desc = parthenon::MakePackDescriptorFromTypeList<VarTL>(md.get());
+    const auto desc_coarse = parthenon::MakePackDescriptorFromTypeList<VarTL>(
+        md.get(), std::vector<MetadataFlag>{}, std::set<PDOpt>{PDOpt::Coarse});
+    auto pack = desc.GetPack(md.get(), include_block);
+    auto pack_coarse = desc_coarse.GetPack(md.get(), include_block);
+    if (pack.GetNBlocks() == 0) return TaskStatus::complete;
+    const int joff = ndim > 1;
+    const int koff = ndim > 2;
+    parthenon::par_for(
+        "Restrict", 0, pack.GetNBlocks() - 1, pack.GetLowerBoundHost(0),
+        pack.GetUpperBoundHost(0), ckb.s, ckb.e, cjb.s, cjb.e, cib.s, cib.e,
+        KOKKOS_LAMBDA(const int b, const int n, const int ck, const int cj,
+                      const int ci) {
+          const int fk = koff * 2 * (ck - ckb.s) + kb.s;
+          const int fj = joff * 2 * (cj - cjb.s) + jb.s;
+          const int fi = 2 * (ci - cib.s) + ib.s;
+          pack_coarse(b, n, ck, cj, ci) =
+              pack(b, n, fk, fj, fi) + pack(b, n, fk, fj, fi + 1) +
+              pack(b, n, fk, fj + joff, fi) + pack(b, n, fk, fj + joff, fi + 1) +
+              pack(b, n, fk + koff, fj, fi) + pack(b, n, fk + koff, fj, fi + 1) +
+              pack(b, n, fk + koff, fj + joff, fi) +
+              pack(b, n, fk + koff, fj + joff, fi + 1);
+          pack_coarse(b, n, ck, cj, ci) /= 8.0;
+        });
+    return TaskStatus::complete;
+  }
 };
 } // namespace solvers
 

--- a/src/solvers/internal_prolongation.hpp
+++ b/src/solvers/internal_prolongation.hpp
@@ -124,17 +124,11 @@ class ProlongationBlockInteriorZeroDirichlet {
 
     using TE = parthenon::TopologicalElement;
 
-    int nblocks = md->NumBlocks();
-    std::vector<bool> include_block(nblocks, true);
-    for (int b = 0; b < nblocks; ++b) {
-      include_block[b] =
-          md->grid.logical_level == md->GetBlockData(b)->GetBlockPointer()->loc.level();
-    }
     const auto desc = parthenon::MakePackDescriptorFromTypeList<VarTL>(md.get());
     const auto desc_coarse = parthenon::MakePackDescriptorFromTypeList<VarTL>(
         md.get(), std::vector<MetadataFlag>{}, std::set<PDOpt>{PDOpt::Coarse});
-    auto pack = desc.GetPack(md.get(), include_block);
-    auto pack_coarse = desc_coarse.GetPack(md.get(), include_block);
+    auto pack = desc.GetPack(md.get());
+    auto pack_coarse = desc_coarse.GetPack(md.get());
     if (pack.GetNBlocks() == 0) return TaskStatus::complete;
 
     parthenon::par_for(
@@ -207,7 +201,24 @@ class ProlongationBlockInteriorZeroDirichlet {
         });
     return TaskStatus::complete;
   }
+};
 
+// This is just an empty class without a Restrict method, which will trigger 
+// calling the default restriction machinery in multigrid
+class RestrictionDefault {
+ public:
+  RestrictionDefault() = default;
+  RestrictionDefault(parthenon::ParameterInput *pin,
+                     const std::string &label){}
+};
+
+class RestrictionCombined {
+ public:
+
+  RestrictionCombined() = default;
+  RestrictionCombined(parthenon::ParameterInput *pin,
+                      const std::string &label){}
+  
   template <class VarTL>
   parthenon::TaskID Restrict(parthenon::TaskList &tl, parthenon::TaskID depends_on,
                              std::shared_ptr<parthenon::MeshData<Real>> &md) {
@@ -226,18 +237,11 @@ class ProlongationBlockInteriorZeroDirichlet {
     IndexRange cjb = md->GetBoundsJ(CellLevel::coarse, IndexDomain::interior);
     IndexRange ckb = md->GetBoundsK(CellLevel::coarse, IndexDomain::interior);
 
-    using TE = parthenon::TopologicalElement;
-    int nblocks = md->NumBlocks();
-    std::vector<bool> include_block(nblocks, true);
-    for (int b = 0; b < nblocks; ++b) {
-      include_block[b] =
-          md->grid.logical_level == md->GetBlockData(b)->GetBlockPointer()->loc.level();
-    }
     const auto desc = parthenon::MakePackDescriptorFromTypeList<VarTL>(md.get());
     const auto desc_coarse = parthenon::MakePackDescriptorFromTypeList<VarTL>(
         md.get(), std::vector<MetadataFlag>{}, std::set<PDOpt>{PDOpt::Coarse});
-    auto pack = desc.GetPack(md.get(), include_block);
-    auto pack_coarse = desc_coarse.GetPack(md.get(), include_block);
+    auto pack = desc.GetPack(md.get());
+    auto pack_coarse = desc_coarse.GetPack(md.get());
     if (pack.GetNBlocks() == 0) return TaskStatus::complete;
     const int joff = ndim > 1;
     const int koff = ndim > 2;

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -94,7 +94,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
            const std::string &container_rhs, ParameterInput *pin,
            const std::string &input_block, equations_t eq_in = equations_t())
       : MGSolver(container_base, container_u, container_rhs, MGParams(pin, input_block),
-                 eq_in, prolongator_t(pin, input_block), restrictor_t(pin, input_block)) {}
+                 eq_in, prolongator_t(pin, input_block), restrictor_t(pin, input_block)) {
+  }
 
   MGSolver(const std::string &container_base, const std::string &container_u,
            const std::string &container_rhs, MGParams params_in,
@@ -555,8 +556,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
         communicate_to_coarse = tl.AddTask(
             residual, BTF(SendBoundBufsNoRestrict<BoundaryType::gmg_restrict_send>),
             md_u);
-        communicate_to_coarse = restrictor_.template Restrict<FieldTL>(
-            tl, communicate_to_coarse, md_res_err);
+        communicate_to_coarse =
+            restrictor_.template Restrict<FieldTL>(tl, communicate_to_coarse, md_res_err);
         communicate_to_coarse = tl.AddTask(
             communicate_to_coarse,
             BTF(SendBoundBufsNoRestrict<BoundaryType::gmg_restrict_send>), md_res_err);

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -79,7 +79,8 @@ struct MGSolverCounter {
 //
 // That stores the (possibly approximate) diagonal of matrix A in the field
 // associated with the type diag_t. This is used for Jacobi iteration.
-template <class equations_t, class prolongator_t = ProlongationBlockInteriorDefault>
+template <class equations_t, class prolongator_t = ProlongationBlockInteriorDefault,
+          class restrictor_t = RestrictionDefault>
 class MGSolver : public SolverBase, MGSolverCounter {
  public:
   using FieldTL = typename equations_t::IndependentVars;
@@ -93,13 +94,14 @@ class MGSolver : public SolverBase, MGSolverCounter {
            const std::string &container_rhs, ParameterInput *pin,
            const std::string &input_block, equations_t eq_in = equations_t())
       : MGSolver(container_base, container_u, container_rhs, MGParams(pin, input_block),
-                 eq_in, prolongator_t(pin, input_block)) {}
+                 eq_in, prolongator_t(pin, input_block), restrictor_t(pin, input_block)) {}
 
   MGSolver(const std::string &container_base, const std::string &container_u,
            const std::string &container_rhs, MGParams params_in,
-           equations_t eq_in = equations_t(), prolongator_t prol_in = prolongator_t())
+           equations_t eq_in = equations_t(), prolongator_t prol_in = prolongator_t(),
+           restrictor_t rest_in = restrictor_t())
       : SolverBase(container_base, container_u, container_rhs), params_(params_in),
-        iter_counter(0), eqs_(eq_in), prolongator_(prol_in),
+        iter_counter(0), eqs_(eq_in), prolongator_(prol_in), restrictor_(rest_in),
         constant_prolongation{false} {
     FieldTL::IterateTypes(
         [this](auto t) { this->sol_fields.push_back(decltype(t)::name()); });
@@ -225,6 +227,7 @@ class MGSolver : public SolverBase, MGSolverCounter {
   AllReduce<Real> residual;
   equations_t eqs_;
   prolongator_t prolongator_;
+  restrictor_t restrictor_;
   std::string container_;
 
   // These functions apparently have to be public to compile with cuda since
@@ -546,13 +549,13 @@ class MGSolver : public SolverBase, MGSolverCounter {
           solver_timings.GetOrAddAndRegister(GetTimeLabel("Restrict send", level), tl);
       timer_res->StartCollectingTasks();
       auto communicate_to_coarse = residual;
-      if constexpr (has_Restrict<decltype(prolongator_), FieldTL>::value) {
+      if constexpr (has_Restrict<decltype(restrictor_), FieldTL>::value) {
         communicate_to_coarse =
-            prolongator_.template Restrict<FieldTL>(tl, communicate_to_coarse, md_u);
+            restrictor_.template Restrict<FieldTL>(tl, communicate_to_coarse, md_u);
         communicate_to_coarse = tl.AddTask(
             residual, BTF(SendBoundBufsNoRestrict<BoundaryType::gmg_restrict_send>),
             md_u);
-        communicate_to_coarse = prolongator_.template Restrict<FieldTL>(
+        communicate_to_coarse = restrictor_.template Restrict<FieldTL>(
             tl, communicate_to_coarse, md_res_err);
         communicate_to_coarse = tl.AddTask(
             communicate_to_coarse,

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -528,11 +528,25 @@ class MGSolver : public SolverBase, MGSolverCounter {
       auto timer_res =
           solver_timings.GetOrAddAndRegister(GetTimeLabel("Restrict send", level), tl);
       timer_res->StartCollectingTasks();
-      auto communicate_to_coarse =
-          tl.AddTask(residual, BTF(SendBoundBufs<BoundaryType::gmg_restrict_send>), md_u);
-      communicate_to_coarse =
-          tl.AddTask(communicate_to_coarse,
-                     BTF(SendBoundBufs<BoundaryType::gmg_restrict_send>), md_res_err);
+      auto communicate_to_coarse = residual;
+      if constexpr (has_Restrict<decltype(prolongator_), FieldTL>::value) {
+        communicate_to_coarse =
+            prolongator_.template Restrict<FieldTL>(tl, communicate_to_coarse, md_u);
+        communicate_to_coarse = tl.AddTask(
+            residual, BTF(SendBoundBufsNoRestrict<BoundaryType::gmg_restrict_send>),
+            md_u);
+        communicate_to_coarse = prolongator_.template Restrict<FieldTL>(
+            tl, communicate_to_coarse, md_res_err);
+        communicate_to_coarse = tl.AddTask(
+            communicate_to_coarse,
+            BTF(SendBoundBufsNoRestrict<BoundaryType::gmg_restrict_send>), md_res_err);
+      } else {
+        communicate_to_coarse = tl.AddTask(
+            residual, BTF(SendBoundBufs<BoundaryType::gmg_restrict_send>), md_u);
+        communicate_to_coarse =
+            tl.AddTask(communicate_to_coarse,
+                       BTF(SendBoundBufs<BoundaryType::gmg_restrict_send>), md_res_err);
+      }
       timer_res->StopCollectingTasks();
 
       // 6. Receive error field into communication field and prolongate

--- a/src/solvers/solver_base.hpp
+++ b/src/solvers/solver_base.hpp
@@ -43,7 +43,7 @@ struct has_Restrict : std::false_type {};
 template <typename T, typename FieldTL>
 struct has_Restrict<T, FieldTL,
                     std::void_t<decltype(std::declval<T>().template Restrict<FieldTL>(
-                        std::declval<TaskList&>(), std::declval<TaskID>(),
+                        std::declval<TaskList &>(), std::declval<TaskID>(),
                         std::declval<std::shared_ptr<MeshData<Real>> &>()))>>
     : std::true_type {};
 

--- a/src/solvers/solver_base.hpp
+++ b/src/solvers/solver_base.hpp
@@ -36,6 +36,17 @@ struct has_SetBoundary<
            std::declval<std::shared_ptr<MeshData<Real>> &>(), std::declval<bool>()))>>
     : std::true_type {};
 
+// Used for checking if a given equations class has a SetBoundary function
+template <typename T, typename FieldTL, typename = void>
+struct has_Restrict : std::false_type {};
+
+template <typename T, typename FieldTL>
+struct has_Restrict<T, FieldTL,
+                    std::void_t<decltype(std::declval<T>().template Restrict<FieldTL>(
+                        std::declval<TaskList&>(), std::declval<TaskID>(),
+                        std::declval<std::shared_ptr<MeshData<Real>> &>()))>>
+    : std::true_type {};
+
 // Solver base class
 class SolverBase {
  public:


### PR DESCRIPTION
## PR Summary

This PR just adds the option to override the default restriction machinery when communicating. In partitular, this is useful for communicating between multigrid levels. Doing the restriction in a unified kernel, as shown in `RestrictionCombined`, seems to be significantly more performant than the default machinery when restricting over the entire block.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
