### PR TITLE
[Tiny] Allow for disabling formatting and linting targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 
 ### Changed (changing behavior/API/variables/...)
-
+- [[PR 1355]](https://github.com/parthenon-hpc-lab/parthenon/pull/1355) Allow disabling format and lint targets
 
 ### Fixed (not changing behavior/API/variables/...)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,14 @@ endif()
 if(PARTHENON_ENABLE_DEVELOPER_TARGETS)
   include(cmake/Format.cmake)
   include(cmake/Lint.cmake)
+else()
+    # Disabled path: define no-op stubs so scattered lint_target/format_target calls
+    # don't break when Parthenon is used as a subproject.
+    if (NOT COMMAND lint_target)
+        function(lint_target target)
+            # intentionally empty
+        endfunction()
+    endif()
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,15 +73,28 @@ else()
     OFF)
 endif()
 
-# Developer-only targets: format, lint, etc.
-option(PARTHENON_ENABLE_DEVELOPER_TARGETS "Enable Parthenon developer targets (format, lint, etc.)" ON)
-# Only add formatting and linting targets if they are asked for and if we are working in the base
-# directory of parthenon
-if(PARTHENON_ENABLE_DEVELOPER_TARGETS
-   AND CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+# Check if we are using Parthenon as a subproject
+set(_parthenon_is_toplevel OFF)
+if (CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+    set(_parthenon_is_toplevel ON)
+endif()
+
+# Optionally disable formatting and linting, disabled by default
+# if Parthenon is a subdirectory to prevent collision with downstream 
+# code targets
+if (NOT DEFINED PARTHENON_ENABLE_DEVELOPER_TARGETS)
+    set(PARTHENON_ENABLE_DEVELOPER_TARGETS
+        ${_parthenon_is_toplevel}
+        CACHE BOOL "Enable Parthenon developer targets (format, lint, etc.)"
+    )
+endif()
+
+if(PARTHENON_ENABLE_DEVELOPER_TARGETS)
   include(cmake/Format.cmake)
   include(cmake/Lint.cmake)
 endif()
+
+
 
 
 # regression test reference data

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,8 +73,15 @@ else()
     OFF)
 endif()
 
-include(cmake/Format.cmake)
-include(cmake/Lint.cmake)
+# Developer-only targets: format, lint, etc.
+option(PARTHENON_ENABLE_DEVELOPER_TARGETS "Enable Parthenon developer targets (format, lint, etc.)" ON)
+# Only add formatting and linting targets if they are asked for and if we are working in the base
+# directory of parthenon
+if(PARTHENON_ENABLE_DEVELOPER_TARGETS
+   AND CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR)
+  include(cmake/Format.cmake)
+  include(cmake/Lint.cmake)
+endif()
 
 
 # regression test reference data


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
When Parthenon is included in a downstream code, it still adds the cmake targets `format` and `lint` currently. This can collide with those targets in a downstream code. This PR adds a flag `PARTHENON_ENABLE_DEVELOPER_TARGETS` (that is default `On` if Parthenon is standalone) that allows for switching on and off the format and lint targets. 

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
