### PR TITLE
make object pool map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 
 ### Infrastructure (changes irrelevant to downstream codes)
-
+- [[1356]](https://github.com/parthenon-hpc-lab/parthenon/pull/1356) Implement ObjectPoolMap type
 
 ### Removed (removing behavior/API/variables/...)
 

--- a/doc/sphinx/src/boundary_communication.rst
+++ b/doc/sphinx/src/boundary_communication.rst
@@ -302,6 +302,44 @@ On host a lot of this functionality could be replicated with
 be able to exist on device (even though the reference counting doesn’t
 work there).
 
+It is often convenient to hold multiple pools, one for each different
+size of object that we might want to pool. (For example for
+differently shaped comm buffers.) We implement that via the
+``ObjectPoolMap<T>`` type, which owns an arbitrary number of
+pools. The main functionality that it provides is it can construct a
+pool with an allocation strategy that allocates buffers in chunks of
+contiguous blocks of memory, reducing the number of malloc calls
+required. For example, the code
+
+.. code:: cpp
+
+  ObjectPoolMap<ParArray1D<Real>> pool_map;
+  pool_map.AddPool(buf_len, nbufs);
+
+tells the pool map that you would like a pool of objects of size
+``buf_len`` that allocates ``nbufs`` at once when it runs out of
+memory, minimizing allocation costs. Objects can be explicitly added
+to the pool with
+
+.. code:: cpp
+
+  pool_map.AddFreeObjectsToPool(buf_len, nbufs);
+
+A pool for objects of a given size may be requested with
+``pool_map.GetPool(buf_len)``, a ``weak_t`` buffer may be requested
+with ``pool_map.GetBuffer(buf_len)`` and an ``owning_t`` may be
+requested with ``GetOwningBuffer``. The existence of a pool for
+objects may be checked with ``pool_map.Contains(buf_len)`` and all
+pools may be cleared and their buffers deallocated with
+``pool_map.Clear()``. Finally, the underlying map may be accessed for,
+e.g., iteration, with ``pool_map.GetMap()``.
+
+.. note::
+
+   The pool map is bounds checking. It will not add a new pool of
+   objects of a given shape unless they are requested. If you request
+   a buffer from a non-existent pool, the code will throw an error.
+
 Sparse boundary communication implementation
 --------------------------------------------
 

--- a/src/bvals/comms/build_boundary_buffers.cpp
+++ b/src/bvals/comms/build_boundary_buffers.cpp
@@ -75,36 +75,20 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
 
     // Add a buffer pool if one does not exist for this size
     using buf_t = buf_pool_t<Real>::base_t;
-    if (pmesh->pool_map.count(buf_size) == 0) {
+    if (!pmesh->pool_map.Contains(buf_size)) {
       // Minimum number of comm buffers to initialize a pool of a
       // given shape with. As an upper bound, we use the maximum
       // number that might be present.
       const std::size_t nbuf = std::min(pmesh->CommBufferChunkSize(), nbufs.at(buf_size));
-      // This lambda is called whenever a buffer is requested but no
-      // buffers remain in the pool
-      auto allocation_strategy = [buf_size, nbuf](buf_pool_t<Real> *pool) {
-        const auto pool_size = nbuf * buf_size;
-        buf_t chunk("pool buffer", pool_size);
-        for (int i = 1; i < nbuf; ++i) {
-          pool->AddFreeObjectToPool(
-              buf_t(chunk, std::make_pair(i * buf_size, (i + 1) * buf_size)));
-        }
-        return buf_t(chunk, std::make_pair(0, buf_size));
-      };
-      pmesh->pool_map.emplace(buf_size, buf_pool_t<Real>(allocation_strategy));
+      pmesh->pool_map.AddPool(buf_size, nbuf);
     }
     // Now that the pool is guaranteed to exist we can add free objects of the required
     // amount.
-    auto &pool = pmesh->pool_map.at(buf_size);
     const std::int64_t new_buffers_req =
-        nbufs_allocated.at(buf_size) - pool.NumBuffersInPool();
+        nbufs_allocated.at(buf_size) -
+        pmesh->pool_map.GetPool(buf_size).NumBuffersInPool();
     if (new_buffers_req > 0) {
-      const auto pool_size = new_buffers_req * buf_size;
-      buf_t chunk("pool buffer", pool_size);
-      for (int i = 0; i < new_buffers_req; ++i) {
-        pool.AddFreeObjectToPool(
-            buf_t(chunk, std::make_pair(i * buf_size, (i + 1) * buf_size)));
-      }
+      pmesh->pool_map.AddFreeObjectsToPool(buf_size, new_buffers_req);
     }
 
     const int receiver_rank = nb.rank;
@@ -127,7 +111,7 @@ void BuildBoundaryBufferSubset(std::shared_ptr<MeshData<Real>> &md,
     auto get_resource_method = [pmesh, buf_size](int size) {
       PARTHENON_REQUIRE(size <= buf_size,
                         "Asking for a buffer that is larger than size of pool.");
-      return buf_pool_t<Real>::owner_t(pmesh->pool_map.at(buf_size).Get());
+      return buf_pool_t<Real>::owner_t(pmesh->pool_map.GetPool(buf_size).Get());
     };
 
     // Build send buffer (unless this is a receiving flux boundary)

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1209,7 +1209,7 @@ void Mesh::BuildAndRegisterCommBuffers_() {
 
 bool Mesh::TryReallocCommBufferPools() {
   bool realloc = false;
-  for (auto &[k, pool] : pool_map) {
+  for (auto &[k, pool] : pool_map.GetMap()) {
     std::size_t inuse = pool.NumBuffersInUse();
     std::size_t total = pool.NumBuffersInPool();
     std::size_t delta = total - inuse;
@@ -1221,9 +1221,7 @@ bool Mesh::TryReallocCommBufferPools() {
   if (realloc) {
     // The buffer pool must be cleared out, since otherwise, buffers
     // will just be reference-count-freed
-    for (auto &[k, pool] : pool_map) {
-      pool.Clear();
-    }
+    pool_map.Clear();
     // We need to clear the caches because they point to comm buffers that
     // are no longer valid
     for (auto &[label, pdata] : mesh_data.Stages()) {

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -263,7 +263,7 @@ class Mesh {
   // between two blocks for a given variable
   using channel_key_t = std::tuple<int, int, std::string, int, int>;
   using comm_buf_t = CommBuffer<buf_pool_t<Real>::owner_t>;
-  std::unordered_map<int, buf_pool_t<Real>> pool_map;
+  ObjectPoolMap<BufArray1D<Real>> pool_map;
   using comm_buf_map_t = std::unordered_map<channel_key_t, comm_buf_t>;
   comm_buf_map_t boundary_comm_map;
   TagMap tag_map;
@@ -287,7 +287,7 @@ class Mesh {
 
   uint64_t GetBufferPoolSizeInBytes() const {
     std::uint64_t buffer_memory = 0;
-    for (auto &p : pool_map) {
+    for (auto &p : pool_map.GetMap()) {
       buffer_memory += p.second.SizeInBytes();
     }
     return buffer_memory;

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -275,6 +275,11 @@ bool UsingSameResource(const T &lhs, const U &rhs) {
   return lhs.GetKey() == rhs.GetKey();
 }
 
+/*
+  TODO(JMM): Currently the key type here is always size_t. It can
+  easily be extended to vector types such as std::tuple if needed,
+  but I didn't bother since we don't need that right now.
+ */
 template <typename T>
 class ObjectPoolMap {
  public:

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -273,6 +273,51 @@ bool UsingSameResource(const T &lhs, const U &rhs) {
   return lhs.GetKey() == rhs.GetKey();
 }
 
+template <typename T>
+class ObjectPoolMap {
+ public:
+  using map_t = std::unordered_map<std::size_t, ObjectPool<T>>;
+
+  auto &GetPool(const std::size_t shape) { return map_.at(shape); }
+  // TODO(JMM): This assumes the pool is of a Kokkos view-like object
+  void AddPool(const std::size_t shape, const std::size_t chunk_size) {
+    if (map_.count(shape) > 0) return;
+    // This lambda is called whenever a buffer is requested but no
+    // buffers remain in the pool
+    auto allocation_strategy = [shape, chunk_size](ObjectPool<T> *pool) {
+      const auto pool_size = shape * chunk_size;
+      auto label = "pool buffer of size " + std::to_string(shape) + " x " +
+                   std::to_string(chunk_size);
+      T chunk(label, pool_size);
+      for (std::size_t i = 1; i < chunk_size; ++i) {
+        pool->AddFreeObjectToPool(T(chunk, std::make_pair(i * shape, (i + 1) * shape)));
+      }
+      return T(chunk, std::make_pair(static_cast<std::size_t>(0), shape));
+    };
+    map_.emplace(shape, ObjectPool<T>(allocation_strategy));
+  }
+  void AddFreeObjectsToPool(const std::size_t shape, const std::size_t nobjs) const {
+    auto pool = map_.at(shape);
+    const auto pool_size = shape * nobjs;
+    auto label =
+        "pool buffer of size " + std::to_string(shape) + " x " + std::to_string(nobjs);
+    T chunk(label, pool_size);
+    for (int i = 0; i < nobjs; ++i) {
+      pool.AddFreeObjectToPool(T(chunk, std::make_pair(i * shape, (i + 1) * shape)));
+    }
+  }
+  void Clear() {
+    for (auto &[k, p] : map_) {
+      p.Clear();
+    }
+  }
+  auto &GetMap() const { return map_; }
+  bool Contains(const std::size_t shape) const { return map_.count(shape) > 0; }
+
+ private:
+  map_t map_;
+};
+
 } // namespace parthenon
 
 #endif // UTILS_OBJECT_POOL_HPP_

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -1,9 +1,9 @@
 //========================================================================================
-// parthenon performance portable AMR framework
-// Copyright(C) 2022 The Parthenon collaboration
+// Parthenon performance portable AMR framework
+// Copyright(C) 2022-2026 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2022-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -282,6 +282,9 @@ bool UsingSameResource(const T &lhs, const U &rhs) {
 
   This means that right now, T really needs to be a 1D Kokkos view
   under the hood.
+
+  Also note this is not thread safe, so will need to be updated if we
+  ever worry about that.
  */
 template <typename T, class = ENABLEIF(implements<kokkos_view(T)>::value)>
 class ObjectPoolMap {
@@ -318,9 +321,10 @@ class ObjectPoolMap {
     // This lambda is called whenever a buffer is requested but no
     // buffers remain in the pool
     auto allocation_strategy = [shape, chunk_size](ObjectPool<T> *pool) {
+      static std::size_t counter = 0; // per shape/chunk size. NOT thread safe.
       const auto pool_size = shape * chunk_size;
-      auto label = "pool buffer of size " + std::to_string(shape) + " x " +
-                   std::to_string(chunk_size);
+      auto label = "pool buffer " + std::to_string(counter++) + " of size " +
+                   std::to_string(shape) + " x " + std::to_string(chunk_size);
       T chunk(label, pool_size);
       for (std::size_t i = 1; i < chunk_size; ++i) {
         pool->AddFreeObjectToPool(T(chunk, std::make_pair(i * shape, (i + 1) * shape)));
@@ -335,7 +339,7 @@ class ObjectPoolMap {
         std::is_pointer_v<std::remove_reference_t<data_t>> &&
             !std::is_pointer_v<std::remove_pointer_t<std::remove_reference_t<data_t>>>,
         "Underlying view must be 1D");
-    auto &pool = map_.at(shape);
+    auto &pool = GetPool(shape);
     const auto pool_size = shape * nobjs;
     auto label =
         "pool buffer of size " + std::to_string(shape) + " x " + std::to_string(nobjs);

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// Parthenon performance portable AMR framework
+// parthenon performance portable AMR framework
 // Copyright(C) 2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
@@ -279,14 +279,18 @@ bool UsingSameResource(const T &lhs, const U &rhs) {
   TODO(JMM): Currently the key type here is always size_t. It can
   easily be extended to vector types such as std::tuple if needed,
   but I didn't bother since we don't need that right now.
+
+  This means that right now, T really needs to be a 1D Kokkos view
+  under the hood.
  */
-template <typename T>
+template <typename T, class = ENABLEIF(implements<kokkos_view(T)>::value)>
 class ObjectPoolMap {
  public:
   using pool_t = ObjectPool<T>;
   using map_t = std::unordered_map<std::size_t, pool_t>;
   using owner_t = typename pool_t::owner_t;
   using weak_t = typename pool_t::weak_t;
+  using data_t = typename T::data_type;
 
   auto &GetPool(const std::size_t shape) {
     if (!Contains(shape)) {
@@ -304,8 +308,12 @@ class ObjectPoolMap {
   auto GetOwningBuffer(const std::size_t shape) {
     return static_cast<owner_t>(GetBuffer(shape));
   }
-  // TODO(JMM): This assumes the pool is of a Kokkos view-like object
+  // TODO(JMM): This assumes the pool is of a 1D Kokkos view-like object
   void AddPool(const std::size_t shape, const std::size_t chunk_size) {
+    static_assert(
+        std::is_pointer_v<std::remove_reference_t<data_t>> &&
+            !std::is_pointer_v<std::remove_pointer_t<std::remove_reference_t<data_t>>>,
+        "Underlying view must be 1D");
     if (map_.count(shape) > 0) return;
     // This lambda is called whenever a buffer is requested but no
     // buffers remain in the pool
@@ -321,7 +329,12 @@ class ObjectPoolMap {
     };
     map_.emplace(shape, ObjectPool<T>(allocation_strategy));
   }
+  // TODO(JMM): This assumes the pool is of a 1D Kokkos view-like object
   void AddFreeObjectsToPool(const std::size_t shape, const std::size_t nobjs) {
+    static_assert(
+        std::is_pointer_v<std::remove_reference_t<data_t>> &&
+            !std::is_pointer_v<std::remove_pointer_t<std::remove_reference_t<data_t>>>,
+        "Underlying view must be 1D");
     auto &pool = map_.at(shape);
     const auto pool_size = shape * nobjs;
     auto label =

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -28,6 +28,7 @@
 #include <type_traits>
 #include <unordered_map>
 #include <utility>
+#include <utils/error_checking.hpp>
 
 #include <Kokkos_Core.hpp>
 
@@ -277,17 +278,26 @@ bool UsingSameResource(const T &lhs, const U &rhs) {
 template <typename T>
 class ObjectPoolMap {
  public:
-  using map_t = std::unordered_map<std::size_t, ObjectPool<T>>;
+  using pool_t = ObjectPool<T>;
+  using map_t = std::unordered_map<std::size_t, pool_t>;
+  using owner_t = typename pool_t::owner_t;
+  using weak_t = typename pool_t::weak_t;
 
   auto &GetPool(const std::size_t shape) {
     if (!Contains(shape)) {
       std::stringstream msg;
       msg << "ObjectPoolMap must contain an ObjectPool "
-          << "for objects of shape "
-          << shape << "!" << std::endl;
+          << "for objects of shape " << shape << "!" << std::endl;
       PARTHENON_THROW(msg);
     }
     return map_.at(shape);
+  }
+  auto GetBuffer(const std::size_t shape) { return GetPool(shape).Get(); }
+  // Sometimes the compiler complains about requiring a static cast
+  // when going from weak_t to owner_t. This just is syntatic sugar
+  // for that cast.
+  auto GetOwningBuffer(const std::size_t shape) {
+    return static_cast<owner_t>(GetBuffer(shape));
   }
   // TODO(JMM): This assumes the pool is of a Kokkos view-like object
   void AddPool(const std::size_t shape, const std::size_t chunk_size) {
@@ -306,8 +316,8 @@ class ObjectPoolMap {
     };
     map_.emplace(shape, ObjectPool<T>(allocation_strategy));
   }
-  void AddFreeObjectsToPool(const std::size_t shape, const std::size_t nobjs) const {
-    auto pool = map_.at(shape);
+  void AddFreeObjectsToPool(const std::size_t shape, const std::size_t nobjs) {
+    auto &pool = map_.at(shape);
     const auto pool_size = shape * nobjs;
     auto label =
         "pool buffer of size " + std::to_string(shape) + " x " + std::to_string(nobjs);

--- a/src/utils/object_pool.hpp
+++ b/src/utils/object_pool.hpp
@@ -23,6 +23,7 @@
 #include <cstdint>
 #include <iostream>
 #include <memory>
+#include <sstream>
 #include <stack>
 #include <type_traits>
 #include <unordered_map>
@@ -278,7 +279,16 @@ class ObjectPoolMap {
  public:
   using map_t = std::unordered_map<std::size_t, ObjectPool<T>>;
 
-  auto &GetPool(const std::size_t shape) { return map_.at(shape); }
+  auto &GetPool(const std::size_t shape) {
+    if (!Contains(shape)) {
+      std::stringstream msg;
+      msg << "ObjectPoolMap must contain an ObjectPool "
+          << "for objects of shape "
+          << shape << "!" << std::endl;
+      PARTHENON_THROW(msg);
+    }
+    return map_.at(shape);
+  }
   // TODO(JMM): This assumes the pool is of a Kokkos view-like object
   void AddPool(const std::size_t shape, const std::size_t chunk_size) {
     if (map_.count(shape) > 0) return;

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -39,6 +39,7 @@ list(APPEND unit_tests_SOURCES
     test_sparse_pack.cpp
     test_parameter_input.cpp
     test_error_checking.cpp
+    test_object_pool.cpp
     test_partitioning.cpp
     test_scratch_variables.cpp
     test_state_descriptor.cpp

--- a/tst/unit/test_object_pool.cpp
+++ b/tst/unit/test_object_pool.cpp
@@ -1,0 +1,75 @@
+//========================================================================================
+// Parthenon performance portable AMR framework
+// Copyright(C) 2025 The Parthenon collaboration
+// Licensed under the 3-clause BSD License, see LICENSE file for details
+//========================================================================================
+// (C) (or copyright) 2025. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001
+// for Los Alamos National Laboratory (LANL), which is operated by Triad
+// National Security, LLC for the U.S. Department of Energy/National Nuclear
+// Security Administration. All rights in the program are reserved by Triad
+// National Security, LLC, and the U.S. Department of Energy/National Nuclear
+// Security Administration. The Government is granted for itself and others
+// acting on its behalf a nonexclusive, paid-up, irrevocable worldwide license
+// in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do
+// so.
+//========================================================================================
+
+#include <catch2/catch.hpp>
+
+#include "basic_types.hpp"
+#include "defs.hpp"
+#include "kokkos_abstraction.hpp"
+#include "parthenon_arrays.hpp"
+#include "utils/object_pool.hpp"
+
+using parthenon::Real;
+using array_t = parthenon::ParArray1DRaw<Real>;
+using pool_t = parthenon::ObjectPool<array_t>;
+using pool_map_t = parthenon::ObjectPoolMap<array_t>;
+
+SCENARIO("Object pools", "[ObjectPool]") {
+  GIVEN("An object pool map containing several sizes") {
+    const std::size_t NSIZES = 2;
+    const std::size_t sizes[NSIZES] = {3, 5};
+    const std::size_t chunk_sizes[NSIZES] = {2, 3};
+    pool_map_t pool_map;
+    for (std::size_t i = 0; i < NSIZES; ++i) {
+      pool_map.AddPool(sizes[i], chunk_sizes[i]);
+    }
+    THEN("Pools for non-selected shapes are unavailable") {
+      const std::size_t NOTREAL = 987654321;
+      REQUIRE(!pool_map.Contains(NOTREAL));
+      REQUIRE_THROWS(pool_map.GetPool(NOTREAL));
+    }
+    THEN("Each pool contains chunk_size arrays of the appropriate shape") {
+      for (std::size_t i = 0; i < NSIZES; ++i) {
+        REQUIRE(pool_map.Contains(sizes[i]));
+      }
+      AND_WHEN("We request a buffer") {
+        auto &pool = pool_map.GetPool(sizes[0]);
+        { /* Scoping */
+          pool_t::owner_t buf_host = pool_map.GetOwningBuffer(sizes[0]);
+          THEN("The pool contains nchunks buffers, of which one is in use") {
+            REQUIRE(pool.NumBuffersInPool() == chunk_sizes[0]);
+            REQUIRE(pool.NumBuffersInUse() == 1);
+          }
+        }
+        THEN("After the destructor is called, the buffer is no longer in use") {
+          REQUIRE(pool.NumBuffersInPool() == chunk_sizes[0]);
+          REQUIRE(pool.NumBuffersInUse() == 0);
+        }
+      }
+      AND_WHEN("We add buffers to the pool manually") {
+        pool_map.AddFreeObjectsToPool(sizes[1], chunk_sizes[1]);
+        THEN("The pool contains that many free objects") {
+          auto &pool = pool_map.GetPool(sizes[1]);
+          REQUIRE(pool.NumBuffersInPool() == chunk_sizes[1]);
+          REQUIRE(pool.NumBuffersInUse() == 0);
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

@swjones and I are going to use @lroberts36 object pools for more things and I found that the map of pools based on shapes is a useful construct, so I am factoring it out of mesh so I can reuse it. This small MR does that.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
