### PR TITLE
Fix comm buffer init for mesh data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [[PR 1355]](https://github.com/parthenon-hpc-lab/parthenon/pull/1355) Allow disabling format and lint targets
 
 ### Fixed (not changing behavior/API/variables/...)
-
+- [[PR 1360]](https://github.com/parthenon-hpc-lab/parthenon/pull/1360) Fix boundary cache clearing in different MeshData partitions
 
 ### Infrastructure (changes irrelevant to downstream codes)
 - [[PR 1361]] Bump formatters to clang-format-20 and black 25.12

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -40,6 +40,10 @@
 
 namespace parthenon {
 
+bool BvarsSubCache_t::RequiresReinitialize(Mesh *pmesh) const {
+  return buf_vec.size() == 0 || epoch != pmesh->boundary_comm_map.epoch;
+}
+
 void ProResCache_t::Initialize(int n_regions, StateDescriptor *pkg) {
   prores_info = ProResInfoArr_t(ViewOfViewAlloc("prores_info"), n_regions);
   prores_info_h = create_view_of_view_mirror(prores_info);

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -41,7 +41,7 @@
 namespace parthenon {
 
 bool BvarsSubCache_t::RequiresReinitialize(Mesh *pmesh) const {
-  return buf_vec.size() == 0 || epoch != pmesh->boundary_comm_map.epoch;
+  return buf_vec.size() == 0 || epoch != pmesh->boundary_comm_map.GetCurrentEpoch();
 }
 
 void ProResCache_t::Initialize(int n_regions, StateDescriptor *pkg) {

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -186,6 +186,11 @@ struct BvarsSubCache_t {
     bnd_info_h = BndInfoArr_t::host_mirror_type{};
     prores_cache.clear();
   }
+
+  bool RequiresReinitialize(std::size_t current_epoch) {
+    return buf_vec.size() == 0 || epoch != current_epoch;
+  }
+
   // Stores prolongation and restriction information for boundary regions
   ProResCache_t prores_cache;
 
@@ -198,6 +203,7 @@ struct BvarsSubCache_t {
 
   BndInfoArr_t bnd_info{};
   BndInfoArr_t::host_mirror_type bnd_info_h{};
+  std::size_t epoch{0};
 };
 
 struct BvarsCache_t {

--- a/src/bvals/comms/bnd_info.hpp
+++ b/src/bvals/comms/bnd_info.hpp
@@ -187,9 +187,7 @@ struct BvarsSubCache_t {
     prores_cache.clear();
   }
 
-  bool RequiresReinitialize(std::size_t current_epoch) {
-    return buf_vec.size() == 0 || epoch != current_epoch;
-  }
+  bool RequiresReinitialize(Mesh *pmesh) const;
 
   // Stores prolongation and restriction information for boundary regions
   ProResCache_t prores_cache;
@@ -211,8 +209,6 @@ struct BvarsCache_t {
   auto &GetSubCache(BoundaryType boundType, bool send) {
     return caches[2 * static_cast<int>(boundType) + send];
   }
-  // auto &operator[](BoundaryType boundType) { return
-  // caches[static_cast<int>(boundType)]; }
   void clear() {
     for (int i = 0; i < caches.size(); ++i)
       caches[i].clear();

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -54,7 +54,7 @@ TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
   Mesh *pmesh = md->GetMeshPointer();
   auto &cache = md->GetBvarsCache().GetSubCache(bound_type, true);
 
-  if (cache.buf_vec.size() == 0)
+  if (cache.RequiresReinitialize(pmesh->boundary_comm_map.epoch))
     InitializeBufferCache<bound_type>(md, &(pmesh->boundary_comm_map), &cache, SendKey,
                                       true);
 
@@ -186,7 +186,7 @@ TaskStatus StartReceiveBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
   PARTHENON_INSTRUMENT
   Mesh *pmesh = md->GetMeshPointer();
   auto &cache = md->GetBvarsCache().GetSubCache(bound_type, false);
-  if (cache.buf_vec.size() == 0)
+  if (cache.RequiresReinitialize(pmesh->boundary_comm_map.epoch))
     InitializeBufferCache<bound_type>(md, &(pmesh->boundary_comm_map), &cache, ReceiveKey,
                                       false);
   if (!pmesh->do_coalesced_comms) {
@@ -218,7 +218,7 @@ TaskStatus ReceiveBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
 
   Mesh *pmesh = md->GetMeshPointer();
   auto &cache = md->GetBvarsCache().GetSubCache(bound_type, false);
-  if (cache.buf_vec.size() == 0)
+  if (cache.RequiresReinitialize(pmesh->boundary_comm_map.epoch))
     InitializeBufferCache<bound_type>(md, &(pmesh->boundary_comm_map), &cache, ReceiveKey,
                                       false);
 

--- a/src/bvals/comms/boundary_communication.cpp
+++ b/src/bvals/comms/boundary_communication.cpp
@@ -54,7 +54,7 @@ TaskStatus SendBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
   Mesh *pmesh = md->GetMeshPointer();
   auto &cache = md->GetBvarsCache().GetSubCache(bound_type, true);
 
-  if (cache.RequiresReinitialize(pmesh->boundary_comm_map.epoch))
+  if (cache.RequiresReinitialize(pmesh))
     InitializeBufferCache<bound_type>(md, &(pmesh->boundary_comm_map), &cache, SendKey,
                                       true);
 
@@ -186,7 +186,7 @@ TaskStatus StartReceiveBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
   PARTHENON_INSTRUMENT
   Mesh *pmesh = md->GetMeshPointer();
   auto &cache = md->GetBvarsCache().GetSubCache(bound_type, false);
-  if (cache.RequiresReinitialize(pmesh->boundary_comm_map.epoch))
+  if (cache.RequiresReinitialize(pmesh))
     InitializeBufferCache<bound_type>(md, &(pmesh->boundary_comm_map), &cache, ReceiveKey,
                                       false);
   if (!pmesh->do_coalesced_comms) {
@@ -218,7 +218,7 @@ TaskStatus ReceiveBoundBufs(std::shared_ptr<MeshData<Real>> &md) {
 
   Mesh *pmesh = md->GetMeshPointer();
   auto &cache = md->GetBvarsCache().GetSubCache(bound_type, false);
-  if (cache.RequiresReinitialize(pmesh->boundary_comm_map.epoch))
+  if (cache.RequiresReinitialize(pmesh))
     InitializeBufferCache<bound_type>(md, &(pmesh->boundary_comm_map), &cache, ReceiveKey,
                                       false);
 

--- a/src/bvals/comms/build_boundary_buffers.cpp
+++ b/src/bvals/comms/build_boundary_buffers.cpp
@@ -174,11 +174,6 @@ void RegisterCoalescedCommsSubset(std::shared_ptr<MeshData<Real>> &md) {
 TaskStatus BuildBoundaryBuffers(std::shared_ptr<MeshData<Real>> &md) {
   PARTHENON_INSTRUMENT
   Mesh *pmesh = md->GetMeshPointer();
-  auto &all_caches = md->GetBvarsCache();
-
-  // Clear the fast access vectors for this block since they are no longer valid
-  // after all MeshData call BuildBoundaryBuffers
-  all_caches.clear();
 
   BuildBoundaryBufferSubset<BoundaryType::any>(md, pmesh->boundary_comm_map);
   BuildBoundaryBufferSubset<BoundaryType::flxcor_send>(md, pmesh->boundary_comm_map);
@@ -190,11 +185,7 @@ TaskStatus BuildBoundaryBuffers(std::shared_ptr<MeshData<Real>> &md) {
 TaskStatus BuildGMGBoundaryBuffers(std::shared_ptr<MeshData<Real>> &md) {
   PARTHENON_INSTRUMENT
   Mesh *pmesh = md->GetMeshPointer();
-  auto &all_caches = md->GetBvarsCache();
 
-  // Clear the fast access vectors for this block since they are no longer valid
-  // after all MeshData call BuildBoundaryBuffers
-  all_caches.clear();
   BuildBoundaryBufferSubset<BoundaryType::gmg_same>(md, pmesh->boundary_comm_map);
   BuildBoundaryBufferSubset<BoundaryType::gmg_prolongate_send>(md,
                                                                pmesh->boundary_comm_map);

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -94,6 +94,8 @@ void InitializeBufferCache(std::shared_ptr<MeshData<Real>> &md, COMM_MAP *comm_m
   using namespace loops::shorthands;
   Mesh *pmesh = md->GetMeshPointer();
 
+  pcache->clear();
+
   std::vector<std::tuple<int, int, Mesh::channel_key_t>> key_order;
 
   int boundary_idx = 0;
@@ -141,6 +143,7 @@ void InitializeBufferCache(std::shared_ptr<MeshData<Real>> &md, COMM_MAP *comm_m
           Kokkos::create_mirror_view(pcache->sending_non_zero_flags);
     }
   }
+  pcache->epoch = comm_map->epoch;
 }
 
 template <BoundaryType BOUND_TYPE, bool SENDER>

--- a/src/bvals/comms/bvals_utils.hpp
+++ b/src/bvals/comms/bvals_utils.hpp
@@ -143,7 +143,7 @@ void InitializeBufferCache(std::shared_ptr<MeshData<Real>> &md, COMM_MAP *comm_m
           Kokkos::create_mirror_view(pcache->sending_non_zero_flags);
     }
   }
-  pcache->epoch = comm_map->epoch;
+  pcache->epoch = comm_map->GetCurrentEpoch();
 }
 
 template <BoundaryType BOUND_TYPE, bool SENDER>

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1185,10 +1185,6 @@ void Mesh::BuildAndRegisterCommBuffers_() {
   // partition here. We shouldn't have to, but I don't know how to fix
   // it without a refactor.
   BuildBoundaryBuffers(mesh_data.Add("base", GetBasePartition()));
-  for (auto &partition : GetDefaultBlockPartitions()) {
-    auto &md = mesh_data.Add("base", partition);
-    md->GetBvarsCache().clear();
-  }
 
   if (do_coalesced_comms) RegisterCoalescedComms(this);
 

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1184,9 +1184,10 @@ void Mesh::BuildAndRegisterCommBuffers_() {
   // TODO(JMM): I don't like that we need to add base with the base
   // partition here. We shouldn't have to, but I don't know how to fix
   // it without a refactor.
+  BuildBoundaryBuffers(mesh_data.Add("base", GetBasePartition()));
   for (auto &partition : GetDefaultBlockPartitions()) {
     auto &md = mesh_data.Add("base", partition);
-    BuildBoundaryBuffers(md);
+    md->GetBvarsCache().clear();
   }
 
   if (do_coalesced_comms) RegisterCoalescedComms(this);

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1185,7 +1185,6 @@ void Mesh::BuildAndRegisterCommBuffers_() {
   // partition here. We shouldn't have to, but I don't know how to fix
   // it without a refactor.
   BuildBoundaryBuffers(mesh_data.Add("base", GetBasePartition()));
-
   if (do_coalesced_comms) RegisterCoalescedComms(this);
 
   if (multigrid) { // But... multigrid is sufficiently hairy that I'm

--- a/src/mesh/mesh.cpp
+++ b/src/mesh/mesh.cpp
@@ -1184,7 +1184,11 @@ void Mesh::BuildAndRegisterCommBuffers_() {
   // TODO(JMM): I don't like that we need to add base with the base
   // partition here. We shouldn't have to, but I don't know how to fix
   // it without a refactor.
-  BuildBoundaryBuffers(mesh_data.Add("base", GetBasePartition()));
+  for (auto &partition : GetDefaultBlockPartitions()) {
+    auto &md = mesh_data.Add("base", partition);
+    BuildBoundaryBuffers(md);
+  }
+
   if (do_coalesced_comms) RegisterCoalescedComms(this);
 
   if (multigrid) { // But... multigrid is sufficiently hairy that I'm

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -265,22 +265,35 @@ class Mesh {
   using comm_buf_t = CommBuffer<buf_pool_t<Real>::owner_t>;
   std::unordered_map<int, buf_pool_t<Real>> pool_map;
 
-  struct comm_buf_map_t {
-    std::size_t epoch{0};
-    using map_t = std::unordered_map<channel_key_t, comm_buf_t>;
-    map_t m;
-    auto &operator[](const channel_key_t &k) { return m[k]; }
-    auto &at(const channel_key_t &k) { return m.at(k); }
-    auto count(const channel_key_t &k) const { return m.count(k); }
+  class comm_buf_map_t {
+   public: 
+    using map_t = std::unordered_map<channel_key_t, comm_buf_t>; 
+    using key_type = map_t::key_type;
+    using mapped_type = map_t::mapped_type;
+  
+   private:
+    // On initial meshing and after remeshing, the comm buffer map is cleared and
+    // rebuilt. The member epoch_ stores the number of times the comm buffers have
+    // been built so that various boundary cache objects that point to the comm 
+    // buffers can easily check if they point to buffers from an old mesh
+    // configuration that have been cleared.
+    std::size_t epoch_{1};
+    map_t m_;
 
-    auto begin() noexcept { return m.begin(); }
-    auto end() noexcept { return m.end(); }
-    auto begin() const noexcept { return m.begin(); }
-    auto end() const noexcept { return m.end(); }
+   public:
+    auto &operator[](const key_type &k) { return m_[k]; }
+    auto &at(const key_type &k) { return m_.at(k); }
+    auto count(const key_type &k) const { return m_.count(k); }
 
+    auto begin() noexcept { return m_.begin(); }
+    auto end() noexcept { return m_.end(); }
+    auto begin() const noexcept { return m_.begin(); }
+    auto end() const noexcept { return m_.end(); }
+    
+    auto GetCurrentEpoch() const {return epoch_; } 
     void clear() {
-      m.clear();
-      epoch++;
+      m_.clear();
+      epoch_++;
     }
   };
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -264,7 +264,26 @@ class Mesh {
   using channel_key_t = std::tuple<int, int, std::string, int, int>;
   using comm_buf_t = CommBuffer<buf_pool_t<Real>::owner_t>;
   std::unordered_map<int, buf_pool_t<Real>> pool_map;
-  using comm_buf_map_t = std::unordered_map<channel_key_t, comm_buf_t>;
+
+  struct comm_buf_map_t {
+    std::size_t epoch{0};
+    using map_t = std::unordered_map<channel_key_t, comm_buf_t>;
+    map_t m;
+    auto &operator[](const channel_key_t &k) { return m[k]; }
+    auto &at(const channel_key_t &k) { return m.at(k); }
+    auto count(const channel_key_t &k) const { return m.count(k); }
+
+    auto begin() noexcept { return m.begin(); }
+    auto end() noexcept { return m.end(); }
+    auto begin() const noexcept { return m.begin(); }
+    auto end() const noexcept { return m.end(); }
+
+    void clear() {
+      m.clear();
+      epoch++;
+    }
+  };
+
   comm_buf_map_t boundary_comm_map;
   TagMap tag_map;
 

--- a/src/mesh/mesh.hpp
+++ b/src/mesh/mesh.hpp
@@ -266,15 +266,15 @@ class Mesh {
   std::unordered_map<int, buf_pool_t<Real>> pool_map;
 
   class comm_buf_map_t {
-   public: 
-    using map_t = std::unordered_map<channel_key_t, comm_buf_t>; 
+   public:
+    using map_t = std::unordered_map<channel_key_t, comm_buf_t>;
     using key_type = map_t::key_type;
     using mapped_type = map_t::mapped_type;
-  
+
    private:
     // On initial meshing and after remeshing, the comm buffer map is cleared and
     // rebuilt. The member epoch_ stores the number of times the comm buffers have
-    // been built so that various boundary cache objects that point to the comm 
+    // been built so that various boundary cache objects that point to the comm
     // buffers can easily check if they point to buffers from an old mesh
     // configuration that have been cleared.
     std::size_t epoch_{1};
@@ -289,8 +289,8 @@ class Mesh {
     auto end() noexcept { return m_.end(); }
     auto begin() const noexcept { return m_.begin(); }
     auto end() const noexcept { return m_.end(); }
-    
-    auto GetCurrentEpoch() const {return epoch_; } 
+
+    auto GetCurrentEpoch() const { return epoch_; }
     void clear() {
       m_.clear();
       epoch_++;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This fixes the issue seen in #1359 *but I'm not sure if there isn't sth wrong more fundamentally*.
Thus, additional comments/eyes on the code around the caching of comm buffer and `MeshData` would be great, particularly looking at @lroberts36 and @Yurlungur 

As far as I was able to follow the issue, it stems from calling `BuildBoundaryBuffers(mesh_data.Add("base", GetBasePartition()));` with the "base partition",  which contains *all* block, i.e, a single `MeshData` object.
In subsequent places (e.g., in the following `RegisterCoalescedComms`) or in the `BuildTagMapAndBoundaryBuffers`, the comm related routine are called via the default partitions, so there was a misalignment between those.

Does this mean our comm patterns are tied to `MeshData` itself and not to blocks (and then collected/summarized in `MeshData`)?
Is this what we want?
Are there other place that might be affected by different default use between "all blocks" and "partitioned blocks"?

For example, I noticed in the swarms
```c++
// Eliminate any cached SwarmPacks, as they will need to be rebuilt following SetPoolMax
pmb->meshblock_data.Get()->ClearSwarmCaches();
pm->mesh_data.Add("base", pm->GetBasePartition())->ClearSwarmCaches();
for (auto &partition : pm->GetDefaultBlockPartitions()) {
  pm->mesh_data.Add("base", partition)->ClearSwarmCaches();
```
that the caches are cleaned separately.


Fixes #1359

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
