### PR TITLE
Bump formatters to clang-format-20 and black 25.12

### DIFF
--- a/.github/workflows/apply-formatting.yml
+++ b/.github/workflows/apply-formatting.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.comment.body, '@par-hermes format')
     steps:
-    - uses: pgrete/cpp-py-formatter/command@v0.3.0
+    - uses: pgrete/cpp-py-formatter/command@v0.4.0
       with:
         botName: par-hermes
-        clangFormatVersion: 11
+        clangFormatVersion: 18
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/apply-formatting.yml
+++ b/.github/workflows/apply-formatting.yml
@@ -11,5 +11,5 @@ jobs:
     - uses: pgrete/cpp-py-formatter/command@v0.4.0
       with:
         botName: par-hermes
-        clangFormatVersion: 18
+        clangFormatVersion: 20
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -5,7 +5,7 @@ jobs:
     name: Check Python and C++ Formatting
     runs-on: ubuntu-latest
     steps:
-    - uses: pgrete/cpp-py-formatter/check@v0.3.0
+    - uses: pgrete/cpp-py-formatter/check@v0.4.0
       with:
-        clangFormatVersion: 11
+        clangFormatVersion: 18
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -7,5 +7,5 @@ jobs:
     steps:
     - uses: pgrete/cpp-py-formatter/check@v0.4.0
       with:
-        clangFormatVersion: 18
+        clangFormatVersion: 20
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 
 ### Infrastructure (changes irrelevant to downstream codes)
-- [[PR 1361]] Bump formatters to clang-format-18 and black 25.12
+- [[PR 1361]] Bump formatters to clang-format-20 and black 25.12
 
 ### Removed (removing behavior/API/variables/...)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 
 ### Infrastructure (changes irrelevant to downstream codes)
-
+- [[PR 1361]] Bump formatters to clang-format-18 and black 25.12
 
 ### Removed (removing behavior/API/variables/...)
 

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -14,8 +14,8 @@
 find_program(
     CLANG_FORMAT
     NAMES
-        clang-format-18 # Debian package manager, among others, provide this name
-        clang-format-mp-18.0 # MacPorts
+        clang-format-20 # Debian package manager, among others, provide this name
+        clang-format-mp-20.0 # MacPorts
         clang-format-13 # Debian package manager, among others, provide this name
         clang-format-mp-13.0 # MacPorts
         clang-format-12 # Debian package manager, among others, provide this name

--- a/cmake/Format.cmake
+++ b/cmake/Format.cmake
@@ -14,6 +14,8 @@
 find_program(
     CLANG_FORMAT
     NAMES
+        clang-format-18 # Debian package manager, among others, provide this name
+        clang-format-mp-18.0 # MacPorts
         clang-format-13 # Debian package manager, among others, provide this name
         clang-format-mp-13.0 # MacPorts
         clang-format-12 # Debian package manager, among others, provide this name

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -22,7 +22,7 @@ RUN pip3 install blosc2
 RUN pip3 install esbonio
 
 # current formatting standard
-RUN pip3 install clang-format==18.1.1
+RUN pip3 install clang-format==20.1.8
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list

--- a/scripts/docker/Dockerfile.nvcc
+++ b/scripts/docker/Dockerfile.nvcc
@@ -22,7 +22,7 @@ RUN pip3 install blosc2
 RUN pip3 install esbonio
 
 # current formatting standard
-RUN pip3 install clang-format==11.0.1
+RUN pip3 install clang-format==18.1.1
 
 RUN wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key| apt-key add - && \
     echo "deb http://apt.llvm.org/noble/ llvm-toolchain-noble-20 main" > /etc/apt/sources.list.d/llvm.list

--- a/src/bvals/bvals.hpp
+++ b/src/bvals/bvals.hpp
@@ -106,8 +106,8 @@ class BoundarySwarm : public BoundaryCommunication {
 
   // BoundaryCommunication
   void SetupPersistentMPI() final;
-  void StartReceiving(BoundaryCommSubset phase) final{};
-  void ClearBoundary(BoundaryCommSubset phase) final{};
+  void StartReceiving(BoundaryCommSubset phase) final {};
+  void ClearBoundary(BoundaryCommSubset phase) final {};
   void Receive(BoundaryCommSubset phase);
   void Send(BoundaryCommSubset phase);
 

--- a/src/defs.hpp
+++ b/src/defs.hpp
@@ -79,8 +79,8 @@ struct RegionSize {
   RegionSize() = default;
   RegionSize(std::array<Real, 3> xmin, std::array<Real, 3> xmax, std::array<Real, 3> xrat,
              std::array<int, 3> nx)
-      : xmin_(xmin), xmax_(xmax), xrat_(xrat),
-        nx_(nx), symmetry_{nx[0] == 1, nx[1] == 1, nx[2] == 1} {}
+      : xmin_(xmin), xmax_(xmax), xrat_(xrat), nx_(nx),
+        symmetry_{nx[0] == 1, nx[1] == 1, nx[2] == 1} {}
   RegionSize(std::array<Real, 3> xmin, std::array<Real, 3> xmax, std::array<Real, 3> xrat,
              std::array<int, 3> nx, std::array<bool, 3> symmetry)
       : xmin_(xmin), xmax_(xmax), xrat_(xrat), nx_(nx), symmetry_(symmetry) {}

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -208,7 +208,7 @@ DriverStatus EvolutionDriver::Execute() {
       }
     } // END OF MAIN INTEGRATION LOOP
       // ======================================================
-  }   // Main t < tmax loop region
+  } // Main t < tmax loop region
 
   if (pmesh->UserWorkAfterLoop != nullptr) {
     pmesh->UserWorkAfterLoop(pmesh, pinput, tm);

--- a/src/mesh/mesh-amr_loadbalance.cpp
+++ b/src/mesh/mesh-amr_loadbalance.cpp
@@ -773,7 +773,7 @@ void Mesh::RedistributeAndRefineMeshBlocks(ParameterInput *pin, ApplicationInput
                                                   oloc, var.get(), this));
       }
     }
-  }    // AMR Send region
+  } // AMR Send region
 #endif // MPI_PARALLEL
 
   // Construct a new MeshBlock list (moving the data within the MPI rank)

--- a/src/outputs/parthenon_hdf5.cpp
+++ b/src/outputs/parthenon_hdf5.cpp
@@ -150,7 +150,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
 
     HDF5WriteAttribute("File", oss.str().c_str(), input_group);
     Kokkos::Profiling::popRegion(); // write input
-  }                                 // Input section
+  } // Input section
 
   // we'll need this again at the end
   const H5G info_group = MakeGroup(file, "/Info");
@@ -224,7 +224,7 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
     HDF5WriteAttribute("BoundaryConditions", pm->mesh_bc_names, info_group);
     HDF5WriteAttribute("SwarmBoundaryConditions", pm->mesh_swarm_bc_names, info_group);
     Kokkos::Profiling::popRegion(); // write Info
-  }                                 // Info section
+  } // Info section
 
   // write Params
   {
@@ -237,8 +237,8 @@ void PHDF5Output::WriteOutputFileImpl(Mesh *pm, ParameterInput *pin, SimTime *tm
       state->AllParams().WriteAllToHDF5(state->label(), params_group);
     }
     Kokkos::Profiling::popRegion(); // behold: write Params
-  }                                 // Params section
-  Kokkos::Profiling::popRegion();   // write Attributes
+  } // Params section
+  Kokkos::Profiling::popRegion(); // write Attributes
 
   // -------------------------------------------------------------------------------- //
   //   WRITING MESHBLOCK METADATA                                                     //

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -170,7 +170,7 @@ void ParameterInput::LoadFromStream(std::istream &is) {
       }
       blocks_found++;
       continue; // skip to next line if block name was found
-    }           // end "a new block was found"
+    } // end "a new block was found"
 
     // if line does not contain a block name or skippable information (comments,
     // whitespace), it must contain a parameter value

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -99,8 +99,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
            const std::string &container_rhs, MGParams params_in,
            equations_t eq_in = equations_t(), prolongator_t prol_in = prolongator_t())
       : SolverBase(container_base, container_u, container_rhs), params_(params_in),
-        iter_counter(0), eqs_(eq_in),
-        prolongator_(prol_in), constant_prolongation{false} {
+        iter_counter(0), eqs_(eq_in), prolongator_(prol_in),
+        constant_prolongation{false} {
     FieldTL::IterateTypes(
         [this](auto t) { this->sol_fields.push_back(decltype(t)::name()); });
     std::string solver_id = "mg" + std::to_string(id++);

--- a/tst/performance/test_meshblock_data_iterator.cpp
+++ b/tst/performance/test_meshblock_data_iterator.cpp
@@ -191,7 +191,7 @@ TEST_CASE("Catch2 Container Iterator Performance",
             });
       });
     } // GIVEN
-  }   // SECTION
+  } // SECTION
 
   SECTION("Iterate Variables") {
     GIVEN("A container.") {
@@ -233,7 +233,7 @@ TEST_CASE("Catch2 Container Iterator Performance",
         }
       });
     } // GIVEN
-  }   // SECTION
+  } // SECTION
 
   SECTION("View of Views") {
     GIVEN("A container.") {
@@ -308,5 +308,5 @@ TEST_CASE("Catch2 Container Iterator Performance",
         });
       }
     } // GIVEN
-  }   // SECTION
+  } // SECTION
 } // TEST_CASE

--- a/tst/unit/test_swarm.cpp
+++ b/tst/unit/test_swarm.cpp
@@ -108,8 +108,7 @@ TEST_CASE("Swarm memory management", "[Swarm][MPI]") {
   auto mask = swarm->GetMask();
   REQUIRE(mask.size() == NUMINIT);
   ParArrayND<int> failures_d("Number of failures", 1);
-  meshblock->par_for(
-      "Reset", 0, 0, KOKKOS_LAMBDA(const int n) { failures_d(n) = 0; });
+  meshblock->par_for("Reset", 0, 0, KOKKOS_LAMBDA(const int n) { failures_d(n) = 0; });
   meshblock->par_for(
       "Check mask", 0, NUMINIT - 1, KOKKOS_LAMBDA(const int n) {
         if (swarm_d.IsActive(n) == true) {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In addition to an outdated `clang-format` (original version 11) we now also faced issue with black and python files in AthenaPK.
That sparked an update of the default versions to sth more recent (clang-format 18 is now 2+ years old).
~IIRC the formatting changes are now robust across many clang-format version~ so that installing a local "old" version should not be required any more for development.
[edit]
Changes seem to be less robust.
clang-format 16/17 are different from 18/19 and 20/21 again agree with 16/17.
[/edit]
However, there might be an impact for downstream codes and their tooling/formatting.

Therefore, I'm specifically asking for approval/feedback from many downstream codes.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
