### PR TITLE
Pin homebrew hdf5-mpi

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -30,7 +30,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        brew install openmpi hdf5-mpi adios2 || true
+        brew install openmpi adios2 || true
+        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0c3d786402ad7d9dd5eb6907e3ed3f2525a0472d/Formula/h/hdf5-mpi.rb || true
 
     - name: Install parthenon_tools
       run: |

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -37,8 +37,8 @@ jobs:
     # this *should* be fixed in cmake 4.3
     - name: Install hdf5 from old formula
       run: |
-        mkdir -p $(brew --repository)/Library/Taps/user/repo
-        curl -o $(brew --repository)/Library/Taps/user/repo/hdf5-mpi.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/d03791212a4670e68f21c66939c5d348bc1d4bef/Formula/h/hdf5-mpi.rb
+        mkdir -p $(brew --repository)/Library/Taps/user/homebrew-repo
+        curl -o $(brew --repository)/Library/Taps/user/homebrew-repo/hdf5-mpi.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/d03791212a4670e68f21c66939c5d348bc1d4bef/Formula/h/hdf5-mpi.rb
         brew install user/repo/hdf5-mpi
 
     - name: Install parthenon_tools

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -31,7 +31,15 @@ jobs:
     - name: Install dependencies
       run: |
         brew install openmpi adios2 || true
-        brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/0c3d786402ad7d9dd5eb6907e3ed3f2525a0472d/Formula/h/hdf5-mpi.rb || true
+
+    # this is a workaround because homebrew's stable is hdf5 2.0.0 and cmake's
+    # find_package(HDF5) doesn't properly determine HDF5_IS_PARALLEL
+    # this *should* be fixed in cmake 4.3
+    - name: Install hdf5 from old formula
+      run: |
+        mkdir -p $(brew --repository)/Library/Taps/user/repo
+        curl -o $(brew --repository)/Library/Taps/user/repo/hdf5-mpi.rb https://raw.githubusercontent.com/Homebrew/homebrew-core/d03791212a4670e68f21c66939c5d348bc1d4bef/Formula/h/hdf5-mpi.rb
+        brew install user/repo/hdf5-mpi
 
     - name: Install parthenon_tools
       run: |


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Workaround for [issue](https://discourse.cmake.org/t/hdf5-2-0-has-breaking-changes-cmake-doesnt-set-the-hdf5-is-parallel-variable-anymore/15444) with cmake's FindHDF5 and hdf5 2.0.0 in the mac os CI. This should get all fixed in cmake 4.3 and then this can get reverted.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->



<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
