### PR TITLE
Tiny: Add destructor for phdf and add cycle output hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1368]](https://github.com/parthenon-hpc-lab/parthenon/pull/1368) Add close, __enter__, and __exit__ for phdf / Add EvolutionDriver::OutputDownstreamCycleDiagnostics()
 - [[PR 1346]](https://github.com/parthenon-hpc-lab/parthenon/pull/1346) Allow for user defined inter-level restrictions in multigrid 
 - [[PR 1308]](https://github.com/parthenon-hpc-lab/parthenon/pull/1308) Add additional indexing options for (b, type, ...indices) meshdata fields. Helpful for lower dimensional Metadata::None fields.
 - [[PR 1344]](https://github.com/parthenon-hpc-lab/parthenon/pull/1344) Add option to communicate single layer of ghosts, only communicate required two-level composite boundaries

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -350,6 +350,7 @@ class phdf:
             )
 
             idx_i += num_components
+
     def close(self):
         try:
             self.fid.close()
@@ -362,7 +363,7 @@ class phdf:
     def __exit__(self, exc_type, exc, tb):
         self.close()
         return False
-     
+
     def GenAuxData(self):
         """
         Additional attributes filled in by function GenAuxData():

--- a/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
+++ b/scripts/python/packages/parthenon_tools/parthenon_tools/phdf.py
@@ -350,7 +350,19 @@ class phdf:
             )
 
             idx_i += num_components
+    def close(self):
+        try:
+            self.fid.close()
+        except Exception:
+            pass
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        self.close()
+        return False
+     
     def GenAuxData(self):
         """
         Additional attributes filled in by function GenAuxData():

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -349,6 +349,8 @@ void EvolutionDriver::OutputCycleDiagnostics() {
                   << static_cast<double>(zonecycles) / (time_cycle_step + time_LBandAMR)
                   << " wsec_AMR=" << time_LBandAMR;
       }
+      
+      OutputDownstreamCycleDiagnostics();
 
       // insert more diagnostics here
       std::cout << std::endl;

--- a/src/driver/driver.cpp
+++ b/src/driver/driver.cpp
@@ -349,7 +349,7 @@ void EvolutionDriver::OutputCycleDiagnostics() {
                   << static_cast<double>(zonecycles) / (time_cycle_step + time_LBandAMR)
                   << " wsec_AMR=" << time_LBandAMR;
       }
-      
+
       OutputDownstreamCycleDiagnostics();
 
       // insert more diagnostics here

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -139,6 +139,7 @@ class EvolutionDriver : public Driver {
   DriverStatus Execute() override;
   virtual void SetGlobalTimeStep();
   virtual void OutputCycleDiagnostics();
+  virtual void OutputDownstreamCycleDiagnostics() {return;}
 
   virtual TaskListStatus Step() = 0;
   SimTime tm;

--- a/src/driver/driver.hpp
+++ b/src/driver/driver.hpp
@@ -139,7 +139,7 @@ class EvolutionDriver : public Driver {
   DriverStatus Execute() override;
   virtual void SetGlobalTimeStep();
   virtual void OutputCycleDiagnostics();
-  virtual void OutputDownstreamCycleDiagnostics() {return;}
+  virtual void OutputDownstreamCycleDiagnostics() { return; }
 
   virtual TaskListStatus Step() = 0;
   SimTime tm;


### PR DESCRIPTION
## PR Summary
This PR does two completely separate things:

1. **Adds a `close()` method to phdf as well as `__enter__` and `__exit__` functions**. `close()` explicitly closes the `h5py` object that is opened by phdf. I was having some problems were I would run a simulation, visualize it in a jupyter notebook where the hdf5 file should have been released, and then the next time I ran the parthenon based code it would hang on output. You can now do something like
```python
with d as phdf(my_file):
   do some stuff
```
and `d` will automatically be closed and the hdf5 file released.

2. **Adds `virtual EvolutionDriver::OutputDownstreamCycleDiagnostics(){return;}` which can be overridden downstream to add per step output easily to the output line.**

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] (@lanl.gov employees) Update copyright on changed files
