### PR TITLE
Parser for ASCII tables and string broadcasting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,4 +24,5 @@ detail.  Why is this change required?  What problem does it solve?-->
   - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
 - [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
 - [ ] Docs build
+- [ ] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was made in part with generative AI.`
 - [ ] (@lanl.gov employees) Update copyright on changed files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1369]](https://github.com/parthenon-hpc-lab/parthenon/pull/1369) Add an ascii table parser and a string broadcast operator
 - [[PR 1368]](https://github.com/parthenon-hpc-lab/parthenon/pull/1368) Add close, __enter__, and __exit__ for phdf / Add EvolutionDriver::OutputDownstreamCycleDiagnostics()
 - [[PR 1346]](https://github.com/parthenon-hpc-lab/parthenon/pull/1346) Allow for user defined inter-level restrictions in multigrid 
 - [[PR 1308]](https://github.com/parthenon-hpc-lab/parthenon/pull/1308) Add additional indexing options for (b, type, ...indices) meshdata fields. Helpful for lower dimensional Metadata::None fields.

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -22,6 +22,7 @@
 #include "config.hpp"
 #include "error_checking.hpp"
 #include "globals.hpp"
+#include "kokkos_types.hpp"
 #include "parthenon_mpi.hpp"
 
 namespace parthenon {
@@ -105,14 +106,14 @@ std::string BroadcastFileString(const std::string &filename) {
 }
 
 template <typename T>
-Table2D<T> ParseAsciiTable(std::istream &in) {
-  Table2D<T> out;
+HostArray2D<T> ParseAsciiTable(std::istream &in) {
+  std::vector<T> data;
 
   std::string line;
-  std::size_t line_no = 0;
+  std::size_t rows = 0;
+  std::size_t cols = 0;
 
   while (std::getline(in, line)) {
-    ++line_no;
 
     // Strip comments...
     if (auto pos = line.find('#'); pos != std::string::npos) {
@@ -128,44 +129,57 @@ Table2D<T> ParseAsciiTable(std::istream &in) {
     std::size_t row_count = 0;
 
     while (iss >> value) {
-      out.data.push_back(value);
+      data.push_back(value);
       ++row_count;
     }
 
     if (!iss.eof()) {
-      PARTHENON_THROW("ASCII parser error on line: " + std::to_string(line_no) +
+      PARTHENON_THROW("ASCII parser error on line: " + std::to_string(rows) +
                       "! Incorrect type.");
     }
     if (row_count == 0) continue; // should not happen after trim, but safe
 
-    if (out.rows == 0) {
-      out.cols = row_count;
-      if (out.cols == 0) { // table is empty. We can just return.
-        return out;
+    if (rows == 0) {
+      cols = row_count;
+      if (cols == 0) { // table is empty. We can just return.
+        break;
       }
-    } else if (row_count != out.cols) {
+    } else if (row_count != cols) {
       PARTHENON_THROW("Parsed ASCII table is ragged.");
     }
-    ++out.rows;
+    ++rows;
+  }
+
+  // JMM: Thought about doing this by just copying the data, but doing
+  // it this way safeguards against HostArray2D having a different
+  // layout than row-major ordering.
+  HostArray2D<T> out("Parsed ascii table", rows, cols);
+  {
+    std::size_t idx = 0;
+    for (std::size_t row = 0; row < rows; ++row) {
+      for (std::size_t col = 0; col < cols; ++col) {
+        out(row, col) = data[idx++];
+      }
+    }
   }
 
   return out;
 }
-template Table2D<double> ParseAsciiTable(std::istream &);
-template Table2D<float> ParseAsciiTable(std::istream &);
-template Table2D<int> ParseAsciiTable(std::istream &);
-template Table2D<std::size_t> ParseAsciiTable(std::istream &);
+template HostArray2D<double> ParseAsciiTable<double>(std::istream &);
+template HostArray2D<float> ParseAsciiTable<float>(std::istream &);
+template HostArray2D<int> ParseAsciiTable<int>(std::istream &);
+template HostArray2D<std::size_t> ParseAsciiTable<std::size_t>(std::istream &);
 
 template <typename T>
-Table2D<T> ParseAsciiTable(const std::string &filename) {
+HostArray2D<T> ParseAsciiTable(const std::string &filename) {
   std::string str = BroadcastFileString(filename);
   std::istringstream stream(str);
   return ParseAsciiTable<T>(stream);
 }
-template Table2D<double> ParseAsciiTable(const std::string &);
-template Table2D<float> ParseAsciiTable(const std::string &);
-template Table2D<int> ParseAsciiTable(const std::string &);
-template Table2D<std::size_t> ParseAsciiTable(const std::string &);
+template HostArray2D<double> ParseAsciiTable<double>(const std::string &);
+template HostArray2D<float> ParseAsciiTable<float>(const std::string &);
+template HostArray2D<int> ParseAsciiTable<int>(const std::string &);
+template HostArray2D<std::size_t> ParseAsciiTable<std::size_t>(const std::string &);
 
 } // namespace string_utils
 } // namespace parthenon

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -152,7 +152,7 @@ template Table2D<float> ParseAsciiTable(std::istream &);
 template Table2D<int> ParseAsciiTable(std::istream &);
 template Table2D<std::size_t> ParseAsciiTable(std::istream &);
 
-template <typename T = Real>
+template <typename T>
 Table2D<T> ParseAsciiTable(const std::string &filename) {
   std::string str = BroadcastFileString(filename);
   std::istringstream stream(str);

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -81,9 +81,13 @@ std::string BroadcastFileString(const std::string &filename) {
       PARTHENON_THROW("Failed to open file " + filename);
     }
 
-    // allocates memory for string upfront
+    // Figure out length of file. Careful with tellg error code.
     in.seekg(0, std::ios::end);
-    strlen = static_cast<std::uint64_t>(in.tellg());
+    auto maybe_strlen = static_cast<std::int64_t>(in.tellg());
+    PARTHENON_REQUIRE(maybe_strlen > 0, "File has menaingful length");
+    strlen = static_cast<std::uint64_t>(maybe_strlen);
+
+    // allocate memory for string upfront
     str.reserve(strlen);
     in.seekg(0, std::ios::beg);
 
@@ -91,7 +95,7 @@ std::string BroadcastFileString(const std::string &filename) {
   }
 
 #ifdef MPI_PARALLEL
-  MPI_Bcast(&strlen, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&strlen, 1, MPI_UINT64_T, 0, MPI_COMM_WORLD);
   if (Globals::my_rank != 0) {
     str.resize(strlen);
   }

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -10,6 +10,8 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
+
+// This file was made in part with generative AI
 
 #include "string_utils.hpp"
 
@@ -65,6 +67,58 @@ std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter) 
 
   return unpack;
 }
+
+template <typename T>
+Table2D<T> ParseAsciiTable(std::istream &in) {
+  Table2D<T> out;
+
+  std::string line;
+  std::size_t line_no = 0;
+
+  while (std::getline(in, line)) {
+    ++line_no;
+
+    // Strip comments...
+    if (auto pos = line.find('#'); pos != std::string::npos) {
+      line.erase(pos);
+    }
+
+    // ...and whitespace
+    line = trim(line);
+    if (line.empty()) continue;
+
+    std::istringstream iss(line);
+    T value;
+    std::size_t row_count = 0;
+
+    while (iss >> value) {
+      out.data.push_back(value);
+      ++row_count;
+    }
+
+    if (!iss.eof()) {
+      PARTHENON_THROW("ASCII parser error on line: " + std::to_string(line_no) +
+                      "! Incorrect type.");
+    }
+    if (row_count == 0) continue; // should not happen after trim, but safe
+
+    if (out.rows == 0) {
+      out.cols = row_count;
+      if (out.cols == 0) { // table is empty. We can just return.
+        return out;
+      }
+    } else if (row_count != out.cols) {
+      PARTHENON_THROW("Parsed ASCII table is ragged.");
+    }
+    ++out.rows;
+  }
+
+  return out;
+}
+template Table2D<double> ParseAsciiTable(std::istream &);
+template Table2D<float> ParseAsciiTable(std::istream &);
+template Table2D<int> ParseAsciiTable(std::istream &);
+template Table2D<std::size_t> ParseAsciiTable(std::istream &);
 
 } // namespace string_utils
 } // namespace parthenon

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -114,7 +114,6 @@ HostArray2D<T> ParseAsciiTable(std::istream &in) {
   std::size_t cols = 0;
 
   while (std::getline(in, line)) {
-
     // Strip comments...
     if (auto pos = line.find('#'); pos != std::string::npos) {
       line.erase(pos);

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -19,7 +19,10 @@
 #include <string>
 #include <vector>
 
+#include "config.hpp"
 #include "error_checking.hpp"
+#include "globals.hpp"
+#include "parthenon_mpi.hpp"
 
 namespace parthenon {
 namespace string_utils {
@@ -66,6 +69,35 @@ std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter) 
   }
 
   return unpack;
+}
+
+std::string BroadcastFileString(const std::string &filename) {
+  std::uint64_t strlen;
+  std::string str;
+
+  if (Globals::my_rank == 0) {
+    std::ifstream in(filename);
+    if (!in) {
+      PARTHENON_THROW("Failed to open file " + filename);
+    }
+
+    // allocates memory for string upfront
+    in.seekg(0, std::ios::end);
+    strlen = static_cast<std::uint64_t>(in.tellg());
+    str.reserve(strlen);
+    in.seekg(0, std::ios::beg);
+
+    str.assign((std::istreambuf_iterator<char>(in)), std::istreambuf_iterator<char>());
+  }
+
+#ifdef MPI_PARALLEL
+  MPI_Bcast(&strlen, 1, MPI_UNSIGNED_LONG, 0, MPI_COMM_WORLD);
+  if (Globals::my_rank != 0) {
+    str.resize(strlen);
+  }
+  MPI_Bcast(str.data(), strlen, MPI_BYTE, 0, MPI_COMM_WORLD);
+#endif // MPI_PARALLEL
+  return str;
 }
 
 template <typename T>
@@ -119,6 +151,17 @@ template Table2D<double> ParseAsciiTable(std::istream &);
 template Table2D<float> ParseAsciiTable(std::istream &);
 template Table2D<int> ParseAsciiTable(std::istream &);
 template Table2D<std::size_t> ParseAsciiTable(std::istream &);
+
+template <typename T = Real>
+Table2D<T> ParseAsciiTable(const std::string &filename) {
+  std::string str = BroadcastFileString(filename);
+  std::istringstream stream(str);
+  return ParseAsciiTable<T>(stream);
+}
+template Table2D<double> ParseAsciiTable(const std::string &);
+template Table2D<float> ParseAsciiTable(const std::string &);
+template Table2D<int> ParseAsciiTable(const std::string &);
+template Table2D<std::size_t> ParseAsciiTable(const std::string &);
 
 } // namespace string_utils
 } // namespace parthenon

--- a/src/utils/string_utils.cpp
+++ b/src/utils/string_utils.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -21,23 +21,10 @@
 #include <vector>
 
 #include "basic_types.hpp"
+#include "kokkos_types.hpp"
 
 namespace parthenon {
 namespace string_utils {
-
-// Return type for ParseAsciiTable
-// could alternatively be a HostArray2D
-template <typename T>
-struct Table2D {
-  std::vector<T> data;
-  std::size_t rows = 0;
-  std::size_t cols = 0;
-
-  T &operator()(std::size_t r, std::size_t c) { return data.at(r * cols + c); }
-  const T &operator()(std::size_t r, std::size_t c) const {
-    return data.at(r * cols + c);
-  }
-};
 
 // trim whitespace
 std::string ltrim(const std::string &s);
@@ -55,18 +42,19 @@ std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter);
 std::string BroadcastFileString(const std::string &filename);
 
 template <typename T = Real>
-Table2D<T> ParseAsciiTable(std::istream &in);
-extern template Table2D<double> ParseAsciiTable(std::istream &);
-extern template Table2D<float> ParseAsciiTable(std::istream &);
-extern template Table2D<int> ParseAsciiTable(std::istream &);
-extern template Table2D<std::size_t> ParseAsciiTable(std::istream &);
+HostArray2D<T> ParseAsciiTable(std::istream &in);
+extern template HostArray2D<double> ParseAsciiTable<double>(std::istream &);
+extern template HostArray2D<float> ParseAsciiTable<float>(std::istream &);
+extern template HostArray2D<int> ParseAsciiTable<int>(std::istream &);
+extern template HostArray2D<std::size_t> ParseAsciiTable<std::size_t>(std::istream &);
 
 template <typename T = Real>
-Table2D<T> ParseAsciiTable(const std::string &filename);
-extern template Table2D<double> ParseAsciiTable(const std::string &);
-extern template Table2D<float> ParseAsciiTable(const std::string &);
-extern template Table2D<int> ParseAsciiTable(const std::string &);
-extern template Table2D<std::size_t> ParseAsciiTable(const std::string &);
+HostArray2D<T> ParseAsciiTable(const std::string &filename);
+extern template HostArray2D<double> ParseAsciiTable<double>(const std::string &);
+extern template HostArray2D<float> ParseAsciiTable<float>(const std::string &);
+extern template HostArray2D<int> ParseAsciiTable<int>(const std::string &);
+extern template HostArray2D<std::size_t>
+ParseAsciiTable<std::size_t>(const std::string &);
 
 } // namespace string_utils
 } // namespace parthenon

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -11,14 +11,33 @@
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
 
+// This file was made in part with generative AI
+
 #ifndef UTILS_STRING_UTILS_HPP_
 #define UTILS_STRING_UTILS_HPP_
 
+#include <fstream>
 #include <string>
 #include <vector>
 
+#include "basic_types.hpp"
+
 namespace parthenon {
 namespace string_utils {
+
+// Return type for ParseAsciiTable
+// could alternatively be a HostArray2D
+template <typename T>
+struct Table2D {
+  std::vector<T> data;
+  std::size_t rows = 0;
+  std::size_t cols = 0;
+
+  T &operator()(std::size_t r, std::size_t c) { return data.at(r * cols + c); }
+  const T &operator()(std::size_t r, std::size_t c) const {
+    return data.at(r * cols + c);
+  }
+};
 
 // trim whitespace
 std::string ltrim(const std::string &s);
@@ -27,8 +46,24 @@ std::string trim(const std::string &s);
 
 // pack/unpack strings (basically join and split with a given delimiter)
 std::string PackStrings(const std::vector<std::string> &strs, char delimiter);
-std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter);
+std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter
+);
 
+template <typename T=Real>
+Table2D<T> ParseAsciiTable(std::istream &in);
+extern template Table2D<double> ParseAsciiTable(std::istream &);
+extern template Table2D<float> ParseAsciiTable(std::istream &);
+extern template Table2D<int> ParseAsciiTable(std::istream &);
+extern template Table2D<std::size_t> ParseAsciiTable(std::istream &);
+
+template<typename T = Real>
+inline Table2D<T> ParseAsciiTable(const std::string &filename) {
+  std::ifstream in(filename);
+  if (!in) {
+    PARTHENON_THROW("Failed to open file " + filename);
+  }
+  return ParseAsciiTable(filename);
+}
 } // namespace string_utils
 } // namespace parthenon
 

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -46,24 +46,28 @@ std::string trim(const std::string &s);
 
 // pack/unpack strings (basically join and split with a given delimiter)
 std::string PackStrings(const std::vector<std::string> &strs, char delimiter);
-std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter
-);
+std::vector<std::string> UnpackStrings(const std::string &pack, char delimiter);
 
-template <typename T=Real>
+// A mechanism to read an ascii file on a single rank and MPI
+// broadcast it to all ranks. May be used for parsing in a massively
+// parallel context where all ranks accessing a file might kill the
+// filesystem. Note this idea could be generalized.
+std::string BroadcastFileString(const std::string &filename);
+
+template <typename T = Real>
 Table2D<T> ParseAsciiTable(std::istream &in);
 extern template Table2D<double> ParseAsciiTable(std::istream &);
 extern template Table2D<float> ParseAsciiTable(std::istream &);
 extern template Table2D<int> ParseAsciiTable(std::istream &);
 extern template Table2D<std::size_t> ParseAsciiTable(std::istream &);
 
-template<typename T = Real>
-inline Table2D<T> ParseAsciiTable(const std::string &filename) {
-  std::ifstream in(filename);
-  if (!in) {
-    PARTHENON_THROW("Failed to open file " + filename);
-  }
-  return ParseAsciiTable(filename);
-}
+template <typename T = Real>
+Table2D<T> ParseAsciiTable(const std::string &filename);
+extern template Table2D<double> ParseAsciiTable(const std::string &);
+extern template Table2D<float> ParseAsciiTable(const std::string &);
+extern template Table2D<int> ParseAsciiTable(const std::string &);
+extern template Table2D<std::size_t> ParseAsciiTable(const std::string &);
+
 } // namespace string_utils
 } // namespace parthenon
 

--- a/src/utils/string_utils.hpp
+++ b/src/utils/string_utils.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/tst/CMakeLists.txt
+++ b/tst/CMakeLists.txt
@@ -1,6 +1,6 @@
 
 add_library(catch2_define catch2_define.cpp)
-target_link_libraries(catch2_define PUBLIC Catch2::Catch2 Kokkos::kokkos)
+target_link_libraries(catch2_define PUBLIC Catch2::Catch2 Kokkos::kokkos parthenon)
 if (ENABLE_MPI)
   target_link_libraries(catch2_define PUBLIC MPI::MPI_CXX)
   target_compile_definitions(catch2_define PUBLIC CATCH2_MPI_PARALLEL)

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -29,6 +29,8 @@
 
 #include <Kokkos_Core.hpp>
 
+#include "globals.hpp"
+
 #ifdef CATCH2_MPI_PARALLEL
 template <class T>
 bool HasMPITests(const T &config) {
@@ -49,6 +51,9 @@ bool HasMPITests(const T &config) {
 #endif // CATCH2_MPI_PARALLEL
 
 int main(int argc, char *argv[]) {
+  parthenon::Globals::my_rank = 0; // overwritten below as needed
+  parthenon::Globals::nranks = 1;
+
   // With Catch2 >2.13.4 catch_discover_tests() is used to discover tests by calling the
   // test executable with `--list-test-names-only` and parsing the results.
   // However, we have to init Kokkos first, which potentially shows warnings that are
@@ -77,6 +82,8 @@ int main(int argc, char *argv[]) {
                 << "MPI Initialization failed." << std::endl;
       return -1;
     }
+    MPI_Comm_rank(MPI_COMM_WORLD, &parthenon::Globals::my_rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &parthenon::Globals::nranks);
   }
 #endif // CATCH2_MPI_PARALLEL
 

--- a/tst/unit/CMakeLists.txt
+++ b/tst/unit/CMakeLists.txt
@@ -17,6 +17,7 @@
 ##========================================================================================
 
 list(APPEND unit_tests_SOURCES
+    test_ascii_table_parsing.cpp
     test_concepts_lite.cpp
     test_coordinates.cpp
     test_data_collection.cpp

--- a/tst/unit/test_ascii_table_parsing.cpp
+++ b/tst/unit/test_ascii_table_parsing.cpp
@@ -21,6 +21,8 @@
 #include <catch2/catch.hpp>
 
 #include "basic_types.hpp"
+#include "globals.hpp"
+#include "parthenon_mpi.hpp"
 #include "utils/string_utils.hpp"
 
 using parthenon::Real;
@@ -83,9 +85,7 @@ SCENARIO("We can parse a simple ASCII table", "[AsciiTableParser][StringUtils]")
     WHEN("When we attempt to parse it") {
       std::istringstream s(ss.str());
       auto table = parthenon::string_utils::ParseAsciiTable<Real>(s);
-      THEN("We get an empty table object") {
-        REQUIRE(table.data.size() == 0);
-      }
+      THEN("We get an empty table object") { REQUIRE(table.data.size() == 0); }
     }
   }
 
@@ -93,12 +93,55 @@ SCENARIO("We can parse a simple ASCII table", "[AsciiTableParser][StringUtils]")
     std::stringstream ss;
     ss << "1 2 3 4\n"
        << "5 6\n"
-       << "7 8 9 10"
-       << std::endl;
+       << "7 8 9 10" << std::endl;
     WHEN("We attempt to parse it") {
       std::istringstream s(ss.str());
       THEN("Parthenon throws an error") {
-        REQUIRE_THROWS_AS(parthenon::string_utils::ParseAsciiTable<int>(s), std::runtime_error);
+        REQUIRE_THROWS_AS(parthenon::string_utils::ParseAsciiTable<int>(s),
+                          std::runtime_error);
+      }
+    }
+  }
+}
+
+SCENARIO("We can MPI broadcast a string from a file",
+         "[MPI][BroadcastFileString][StringUtils]") {
+  GIVEN("A file that contains a simple string") {
+    std::stringstream ss;
+    ss << "# header comment line\n"
+       << "0 0.0 123.0e4\n"
+       << "1 2.0 -4567.89e-1\n"
+       << "3 4.0 5.0\n"
+       << std::endl;
+    std::string teststring = ss.str();
+
+    const std::string filename = "testfile.txt";
+    if (parthenon::Globals::my_rank == 0) {
+      std::ofstream out(filename);
+      out << teststring;
+    }
+
+    WHEN("We try to read the file via broadcast") {
+      auto newstring = parthenon::string_utils::BroadcastFileString(filename);
+      THEN("The strings match") { REQUIRE(newstring == teststring); }
+    }
+
+    WHEN("We parse it via broadcast") {
+      auto table = parthenon::string_utils::ParseAsciiTable<Real>(filename);
+      THEN("The resultant table has the right number of rows and columns") {
+        REQUIRE(table.rows == 3);
+        REQUIRE(table.cols == 3);
+        AND_THEN("The resultant table as the correct contents") {
+          REQUIRE(table(0, 0) == 0.0);
+          REQUIRE(table(0, 1) == 0.0);
+          REQUIRE(std::abs(table(0, 2) - 123e4) < EPS);
+          REQUIRE(table(1, 0) == 1);
+          REQUIRE(table(1, 1) == 2);
+          REQUIRE(std::abs(table(1, 2) - -4567.89e-1) < EPS);
+          REQUIRE(table(2, 0) == 3);
+          REQUIRE(table(2, 1) == 4);
+          REQUIRE(table(2, 2) == 5);
+        }
       }
     }
   }

--- a/tst/unit/test_ascii_table_parsing.cpp
+++ b/tst/unit/test_ascii_table_parsing.cpp
@@ -42,8 +42,8 @@ SCENARIO("We can parse a simple ASCII table", "[AsciiTableParser][StringUtils]")
       std::istringstream s(ss.str());
       auto table = parthenon::string_utils::ParseAsciiTable<Real>(s);
       THEN("The resultant table has the right number of rows and columns") {
-        REQUIRE(table.rows == 3);
-        REQUIRE(table.cols == 3);
+        REQUIRE(table.extent_int(0) == 3);
+        REQUIRE(table.extent_int(1) == 3);
         AND_THEN("The resultant table as the correct contents") {
           REQUIRE(table(0, 0) == 0.0);
           REQUIRE(table(0, 1) == 0.0);
@@ -66,8 +66,8 @@ SCENARIO("We can parse a simple ASCII table", "[AsciiTableParser][StringUtils]")
       std::istringstream s(ss.str());
       auto table = parthenon::string_utils::ParseAsciiTable<int>(s);
       THEN("The resultant table has the right number of rows and columns") {
-        REQUIRE(table.rows == 1);
-        REQUIRE(table.cols == 5);
+        REQUIRE(table.extent_int(0) == 1);
+        REQUIRE(table.extent_int(1) == 5);
         AND_THEN("The contents are correct") {
           for (int i = 1; i < 5; ++i) {
             REQUIRE(table(0, i - 1) == i);
@@ -85,7 +85,7 @@ SCENARIO("We can parse a simple ASCII table", "[AsciiTableParser][StringUtils]")
     WHEN("When we attempt to parse it") {
       std::istringstream s(ss.str());
       auto table = parthenon::string_utils::ParseAsciiTable<Real>(s);
-      THEN("We get an empty table object") { REQUIRE(table.data.size() == 0); }
+      THEN("We get an empty table object") { REQUIRE(table.size() == 0); }
     }
   }
 
@@ -129,8 +129,8 @@ SCENARIO("We can MPI broadcast a string from a file",
     WHEN("We parse it via broadcast") {
       auto table = parthenon::string_utils::ParseAsciiTable<Real>(filename);
       THEN("The resultant table has the right number of rows and columns") {
-        REQUIRE(table.rows == 3);
-        REQUIRE(table.cols == 3);
+        REQUIRE(table.extent_int(0) == 3);
+        REQUIRE(table.extent_int(1) == 3);
         AND_THEN("The resultant table as the correct contents") {
           REQUIRE(table(0, 0) == 0.0);
           REQUIRE(table(0, 1) == 0.0);

--- a/tst/unit/test_ascii_table_parsing.cpp
+++ b/tst/unit/test_ascii_table_parsing.cpp
@@ -1,0 +1,105 @@
+//========================================================================================
+// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+//
+// This program was produced under U.S. Government contract 89233218CNA000001 for Los
+// Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
+// for the U.S. Department of Energy/National Nuclear Security Administration. All rights
+// in the program are reserved by Triad National Security, LLC, and the U.S. Department
+// of Energy/National Nuclear Security Administration. The Government is granted for
+// itself and others acting on its behalf a nonexclusive, paid-up, irrevocable worldwide
+// license in this material to reproduce, prepare derivative works, distribute copies to
+// the public, perform publicly and display publicly, and to permit others to do so.
+//========================================================================================
+
+#include <iostream>
+#include <istream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <catch2/catch.hpp>
+
+#include "basic_types.hpp"
+#include "utils/string_utils.hpp"
+
+using parthenon::Real;
+constexpr Real EPS = 1e-12;
+
+SCENARIO("We can parse a simple ASCII table", "[AsciiTableParser][StringUtils]") {
+  GIVEN("A gross but valid ascii table") {
+    std::stringstream ss;
+    ss << "# header comment line\n"
+       << "                # weird header comment line\n"
+       << "\n" // empty line
+       << "0\t0.0\t123.0e4\n"
+       << "1 2.0 \t -4567.89e-1     " << std::endl // trailing whitespace
+       << "\t     3 4.0 5   \t  # inine comment" << std::endl
+       << std::endl;
+    WHEN("We parse it") {
+      std::istringstream s(ss.str());
+      auto table = parthenon::string_utils::ParseAsciiTable<Real>(s);
+      THEN("The resultant table has the right number of rows and columns") {
+        REQUIRE(table.rows == 3);
+        REQUIRE(table.cols == 3);
+        AND_THEN("The resultant table as the correct contents") {
+          REQUIRE(table(0, 0) == 0.0);
+          REQUIRE(table(0, 1) == 0.0);
+          REQUIRE(std::abs(table(0, 2) - 123e4) < EPS);
+          REQUIRE(table(1, 0) == 1);
+          REQUIRE(table(1, 1) == 2);
+          REQUIRE(std::abs(table(1, 2) - -4567.89e-1) < EPS);
+          REQUIRE(table(2, 0) == 3);
+          REQUIRE(table(2, 1) == 4);
+          REQUIRE(table(2, 2) == 5);
+        }
+      }
+    }
+  }
+
+  GIVEN("A table containing ints with only 1 row") {
+    std::stringstream ss;
+    ss << "1 2 3 4 5" << std::endl;
+    WHEN("We parse it") {
+      std::istringstream s(ss.str());
+      auto table = parthenon::string_utils::ParseAsciiTable<int>(s);
+      THEN("The resultant table has the right number of rows and columns") {
+        REQUIRE(table.rows == 1);
+        REQUIRE(table.cols == 5);
+        AND_THEN("The contents are correct") {
+          for (int i = 1; i < 5; ++i) {
+            REQUIRE(table(0, i - 1) == i);
+          }
+        }
+      }
+    }
+  }
+
+  GIVEN("An empty ascii table") {
+    std::stringstream ss;
+    ss << "# some header" << std::endl
+       << "# but no actual contents" << std::endl
+       << std::endl;
+    WHEN("When we attempt to parse it") {
+      std::istringstream s(ss.str());
+      auto table = parthenon::string_utils::ParseAsciiTable<Real>(s);
+      THEN("We get an empty table object") {
+        REQUIRE(table.data.size() == 0);
+      }
+    }
+  }
+
+  GIVEN("A ragged table") {
+    std::stringstream ss;
+    ss << "1 2 3 4\n"
+       << "5 6\n"
+       << "7 8 9 10"
+       << std::endl;
+    WHEN("We attempt to parse it") {
+      std::istringstream s(ss.str());
+      THEN("Parthenon throws an error") {
+        REQUIRE_THROWS_AS(parthenon::string_utils::ParseAsciiTable<int>(s), std::runtime_error);
+      }
+    }
+  }
+}

--- a/tst/unit/test_ascii_table_parsing.cpp
+++ b/tst/unit/test_ascii_table_parsing.cpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

In riot we have a need to be able to read ascii tables. I decided to put in something relatively generic, which basically reads a 2D table of primitive types in numpy txt format. I also add functionality to read a string from a file on one rank and then broadcast it to all ranks before parsing. I'm using this with the intent to avoid thrashing the filesystem when reading a table. But it could also be used for, e.g., the input decks if we run into filesystem problems at scale.

The catch2 unit testing machinery *does* support tests with MPI (though I can't tell if the tests are actually run on multiple ranks through ctest), but it wasn't threaded all the way through. So minor changes were needed to expose things like MPI ranks to the test code.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] (@lanl.gov employees) Update copyright on changed files
