### PR TITLE
Add uint64 support to SwarmPacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1375]](https://github.com/parthenon-hpc-lab/parthenon/pull/1375) Add uint64 support to SwarmPacks
 - [[PR 1353]](https://github.com/parthenon-hpc-lab/parthenon/pull/1363) Generalize multigrid hierarchy to include initially include leaf grids
 - [[PR 1369]](https://github.com/parthenon-hpc-lab/parthenon/pull/1369) Add an ascii table parser and a string broadcast operator
 - [[PR 1368]](https://github.com/parthenon-hpc-lab/parthenon/pull/1368) Add close, __enter__, and __exit__ for phdf / Add EvolutionDriver::OutputDownstreamCycleDiagnostics()

--- a/doc/sphinx/src/particles.rst
+++ b/doc/sphinx/src/particles.rst
@@ -169,7 +169,7 @@ This also supports ``FlatIdx`` for indexing; see the
 
 Similar to grid variables, swarms can be packed over ``MeshBlock``\ s via ``SwarmPack``\ s.
 ``SwarmPack``\ s are the particle analog to ``SparsePack``\ s for field variables.  A single
-``SwarmPack`` can contain either ``int`` or ``Real`` entries, but not both.  One can pack
+``SwarmPack`` can contain either ``int``, ``uint64_t``, or ``Real`` entries, but not combinations of them.  One can pack
 a ``SwarmPack`` via a ``std::vector<std::string>`` or the type-based variable prescription
 previously used by ``SparsePack``\ s (see :ref:`sparse_packs`).
 

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2021-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -232,6 +232,10 @@ TaskStatus TransportParticles(MeshData<Real> *md, const StagedIntegrator *integr
   auto pack_v_map = desc_v.GetMap();
   parthenon::PackIdx spi_v(pack_v_map["v"]);
 
+  // Make a SwarmPack containing ids (of type uint64_t)
+  static auto desc_id = MakeSwarmPackDescriptor<swarm_position::id>(swarm_name);
+  auto pack_id = desc_id.GetPack(md);
+
   parthenon::par_for(
       DEFAULT_LOOP_PATTERN, "TestSwarmPack", DevExecSpace(), 0,
       pack_pos.GetMaxFlatIndex(), KOKKOS_LAMBDA(const int idx) {

--- a/example/particle_leapfrog/particle_leapfrog.cpp
+++ b/example/particle_leapfrog/particle_leapfrog.cpp
@@ -257,6 +257,10 @@ TaskStatus TransportParticles(MeshData<Real> *md, const StagedIntegrator *integr
           pack_pos(b, swarm_position::x(), n) += pack_v(b, iv + 0, n) * 0.5 * dt;
           pack_pos(b, swarm_position::y(), n) += pack_v(b, iv + 1, n) * 0.5 * dt;
           pack_pos(b, swarm_position::z(), n) += pack_v(b, iv + 2, n) * 0.5 * dt;
+
+          // id
+          PARTHENON_REQUIRE(pack_id(b, swarm_position::id(), n) >= 0,
+                            "Issue with SwarmPack containing uint64 IDs!");
         }
       });
 

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -512,17 +512,20 @@ class MeshData {
 
   template <typename TYPE>
   SwarmPackCache<TYPE> &GetSwarmPackCache() {
-    if constexpr (std::is_same<TYPE, int>::value) {
-      return swarm_pack_int_cache_;
-    } else if constexpr (std::is_same<TYPE, Real>::value) {
+    if constexpr (std::is_same<TYPE, Real>::value) {
       return swarm_pack_real_cache_;
+    } else if constexpr (std::is_same<TYPE, int>::value) {
+      return swarm_pack_int_cache_;
+    } else if constexpr (std::is_same<TYPE, std::uint64_t>::value) {
+      return swarm_pack_uint64_cache_;
     }
-    PARTHENON_THROW("SwarmPacks only compatible with int and Real types");
+    PARTHENON_THROW("SwarmPacks only compatible with Real, int, or uint64_t types");
   }
 
   void ClearSwarmCaches() {
     if (swarm_pack_real_cache_.size() > 0) swarm_pack_real_cache_.clear();
     if (swarm_pack_int_cache_.size() > 0) swarm_pack_int_cache_.clear();
+    if (swarm_pack_uint64_cache_.size() > 0) swarm_pack_uint64_cache_.clear();
   }
 
  private:
@@ -537,8 +540,9 @@ class MeshData {
   MapToMeshBlockVarPack<T> varPackMap_;
   MapToMeshBlockVarFluxPack<T> varFluxPackMap_;
   SparsePackCache sparse_pack_cache_;
-  SwarmPackCache<int> swarm_pack_int_cache_;
   SwarmPackCache<Real> swarm_pack_real_cache_;
+  SwarmPackCache<int> swarm_pack_int_cache_;
+  SwarmPackCache<std::uint64_t> swarm_pack_uint64_cache_;
   // caches for boundary information
   BvarsCache_t bvars_cache_;
 };

--- a/src/interface/mesh_data.hpp
+++ b/src/interface/mesh_data.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -370,17 +370,20 @@ class MeshBlockData {
 
   template <typename TYPE>
   SwarmPackCache<TYPE> &GetSwarmPackCache() {
-    if constexpr (std::is_same<TYPE, int>::value) {
-      return swarm_pack_int_cache_;
-    } else if constexpr (std::is_same<TYPE, Real>::value) {
+    if constexpr (std::is_same<TYPE, Real>::value) {
       return swarm_pack_real_cache_;
+    } else if constexpr (std::is_same<TYPE, int>::value) {
+      return swarm_pack_int_cache_;
+    } else if constexpr (std::is_same<TYPE, std::uint64_t>::value) {
+      return swarm_pack_uint64_cache_;
     }
-    PARTHENON_THROW("SwarmPacks only compatible with int and Real types");
+    PARTHENON_THROW("SwarmPacks only compatible with Real, int, or uint64_t types");
   }
 
   void ClearSwarmCaches() {
     if (swarm_pack_real_cache_.size() > 0) swarm_pack_real_cache_.clear();
     if (swarm_pack_int_cache_.size() > 0) swarm_pack_int_cache_.clear();
+    if (swarm_pack_uint64_cache_.size() > 0) swarm_pack_uint64_cache_.clear();
   }
 
   /// Pack variables and fluxes by separate variables and fluxes names
@@ -618,8 +621,9 @@ class MeshBlockData {
   MapToVariablePack<T> coarseVarPackMap_; // cache for varpacks over coarse arrays
   MapToVariableFluxPack<T> varFluxPackMap_;
   SparsePackCache sparse_pack_cache_;
-  SwarmPackCache<int> swarm_pack_int_cache_;
   SwarmPackCache<Real> swarm_pack_real_cache_;
+  SwarmPackCache<int> swarm_pack_int_cache_;
+  SwarmPackCache<std::uint64_t> swarm_pack_uint64_cache_;
 
   // swarm data
   std::shared_ptr<SwarmContainer> swarm_data = std::make_shared<SwarmContainer>();

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/pack/swarm_pack.hpp
+++ b/src/pack/swarm_pack.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC

--- a/src/pack/swarm_pack.hpp
+++ b/src/pack/swarm_pack.hpp
@@ -50,11 +50,12 @@ class SwarmPack : public SwarmPackBase<TYPE> {
 
   explicit SwarmPack(const SwarmPackBase<TYPE> &spb) : SwarmPackBase<TYPE>(spb) {
     if constexpr (sizeof...(Ts) != 0) {
-      static_assert(std::is_same<TYPE, typename GetDataType<Ts...>::value>::value,
-                    "Type mismatch in SwarmPack! When passing type-based variables as "
-                    "template argument to SwarmPack, ensure that the first template "
-                    "parameter is a data type (e.g., Real or int) that matches the "
-                    "data type of subsequent variable types!");
+      static_assert(
+          std::is_same<TYPE, typename GetDataType<Ts...>::value>::value,
+          "Type mismatch in SwarmPack! When passing type-based variables as template "
+          "argument to SwarmPack, ensure that the first template parameter is a data "
+          "type (e.g., Real or int or uint64_t) that matches the data type of subsequent "
+          "variable types!");
     }
   }
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

PR #1253 introduced the usage of `std::uint64_t` for particle `id`s (if invoked).  This PR extends that change to `SwarmPacks`, wherein we add `std::uint64_t` compatibility.

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was made in part with generative AI.`
- [x] (@lanl.gov employees) Update copyright on changed files
