### PR TITLE
fix bug with trailing ","s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - [[PR 1355]](https://github.com/parthenon-hpc-lab/parthenon/pull/1355) Allow disabling format and lint targets
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1390]](https://github.com/parthenon-hpc-lab/parthenon/pull/1390) Fix bug where trailing comma in list in input deck treated as wildcard in some cases.
 - [[PR 1365]](https://github.com/parthenon-hpc-lab/parthenon/pull/1365) Fix boundary condition being called with coarse=true but no coarse neighbors.
 - [[PR 1345]](https://github.com/parthenon-hpc-lab/parthenon/pull/1345) Coalesce dot product reductions and speed up kernel
 - [[PR 1360]](https://github.com/parthenon-hpc-lab/parthenon/pull/1360) Fix boundary cache clearing in different MeshData partitions

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -419,7 +419,10 @@ class ParameterInput {
       variables.push_back(string_utils::trim(token));
       s.erase(0, pos + delimiter.length());
     }
-    variables.push_back(string_utils::trim(s));
+    token = string_utils::trim(s);
+    if (!token.empty()) {
+      variables.push_back(token);
+    }
     return variables;
   }
   template <typename T>

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -14,6 +14,8 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
+
+// This file was created in part with the generative AI
 
 #ifndef PARAMETER_INPUT_HPP_
 #define PARAMETER_INPUT_HPP_

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -126,6 +126,22 @@ TEST_CASE("Test required/desired checking from inputs", "[ParameterInput]") {
       }
     }
   }
+
+  GIVEN("An input deck with a trailing comma in a vector-valued parameter") {
+    ParameterInput in;
+    std::stringstream ss;
+    ss << "<block1>" << std::endl << "var1 = 1, 2, 3," << std::endl;
+
+    std::istringstream s(ss.str());
+    in.LoadFromStream(s);
+
+    WHEN("The vector is read back") {
+      THEN("The trailing comma does not introduce an empty final element") {
+        auto var1 = in.GetVector<int>("block1", "var1");
+        REQUIRE(var1 == std::vector<int>{1, 2, 3});
+      }
+    }
+  }
 }
 
 TEST_CASE("Parameter inputs can be hashed and hashing provides useful sanity checks",
@@ -198,4 +214,12 @@ TEST_CASE("Test deleting parameters from ParameterInput", "[ParameterInput]") {
       THEN("And others still do") { REQUIRE(in.DoesParameterExist("block1", "var2")); }
     }
   }
+}
+
+TEST_CASE("Empty vector defaults round-trip through the parameter store",
+          "[ParameterInput]") {
+  ParameterInput in;
+  auto values = in.GetOrAddVector<std::string>("block1", "var1", {});
+  REQUIRE(values.empty());
+  REQUIRE(in.GetVector<std::string>("block1", "var1").empty());
 }

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2014 James M. Stone <jmstone@princeton.edu> and other code contributors
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -14,6 +14,8 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
+
+// This file was created in part with the generative AI
 
 #include <iostream>
 #include <istream>


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR resolves #1389 where trailing commas in lists introduced an "empty" list element. Our parsing for variable names was causing this to be a wildcard in variable lists in the output block. This MR used generative AI to build the tests.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI must have a comment disclosing this such as `// This file was made in part with generative AI.`
- [x] (@lanl.gov employees) Update copyright on changed files
