### PR TITLE
Fix deadlock in parallel outputs after ParameterInput refactor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1406]](https://github.com/parthenon-hpc-lab/parthenon/pull/1406) Fix deadlock in parallel outputs after ParameterInput refactor
 - [[PR 1405]](https://github.com/parthenon-hpc-lab/parthenon/pull/1405) Fixes race condition in flux correction communication when sparse variables are disabled
 - [[PR 1339]](https://github.com/parthenon-hpc-lab/parthenon/pull/1339) Fixes doc for `numlevel` usage in non-AMR sims
 - [[PR 1393]](https://github.com/parthenon-hpc-lab/parthenon/pull/1393) Fixes a bug where CMake does not detect HDF5 parallel IO for HDF5 2.0.0 and later.

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -680,7 +680,9 @@ void ParameterInput::ParameterDump(std::ostream &os) {
     std::size_t max_len_name = 0;
     std::size_t max_len_value = 0;
     for (const auto &param : block.params) {
-      std::string value_str = ParamValueToString(param.value);
+      std::string value_str = param.original_string.has_value()
+                                  ? param.original_string.value().value
+                                  : ParamValueToString(param.value);
       max_len_name = std::max(max_len_name, param.name.length());
       max_len_value = std::max(max_len_value, value_str.length());
     }
@@ -688,7 +690,9 @@ void ParameterInput::ParameterDump(std::ostream &os) {
     // Output parameters with alignment
     for (const auto &param : block.params) {
       std::string param_name = param.name;
-      std::string param_value = ParamValueToString(param.value);
+      std::string param_value = param.original_string.has_value()
+                                    ? param.original_string.value().value
+                                    : ParamValueToString(param.value);
 
       std::size_t len = max_len_name - param_name.length() + 1;
       param_name.append(len, ' '); // pad name to align vertically
@@ -949,6 +953,9 @@ std::optional<T> ParameterInput::GetFromStorage_(const std::string &block,
 
   // If it's an UnresolvedString, convert and cache
   if (std::holds_alternative<UnresolvedString>(param->value)) {
+    if (!param->original_string.has_value()) {
+      param->original_string = std::get<UnresolvedString>(param->value);
+    }
     T typed_val = ConvertParamValue<T>(param->value, block, name);
     param->value = typed_val; // Cache the typed value in the variant
     return typed_val;

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -16,8 +16,6 @@
 //========================================================================================
 // This file was made in part with generative AI.
 
-// This file was created in part with the generative AI
-
 #ifndef PARAMETER_INPUT_HPP_
 #define PARAMETER_INPUT_HPP_
 //! \file parameter_input.hpp
@@ -184,6 +182,12 @@ struct Parameter {
   std::string comment;
   // Value can be unresolved (string from file) or typed (from API or post-resolution)
   ParamValue value;
+  // Original string representation from input file. Preserved to ensure all ranks
+  // produce identical ParameterDump output for parallel HDF5 collective metadata writes,
+  // even when parameters are resolved to typed values on different ranks at different
+  // times. Empty for parameters created programmatically (via Set/GetOrAdd with
+  // defaults).
+  std::optional<UnresolvedString> original_string;
   // TODO(future): Consider merging QueryRecord into Parameter as
   // std::optional<QueryRecord> to eliminate the separate queries_ map
 };


### PR DESCRIPTION
This PR was made with the assistance of generative AI.

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

MPI deadlock during parallel HDF5 output after Parthenon commit `fc16e67` (`ParameterInput` refactor). Different ranks could have the same parameter in different resolution states (`UnresolvedString` vs typed), causing `ParameterDump()` to produce different strings on different ranks, which deadlocked HDF5 collective metadata writes.    

Changes:                                                                                                                                                       
  1. `parameter_input.hpp`: Added `original_string` field to `Parameter`
  2. `parameter_input.cpp`:                                                                                                                                        
    - Preserve original string in `GetFromStorage_()` before type conversion                                                                                     
    - Use original string in `ParameterDump()` when available         

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [x] (@lanl.gov employees) Update copyright on changed files
