### PR TITLE
SMALL: Add `GetAsUnresolvedString()` method to ParameterInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1408]](https://github.com/parthenon-hpc-lab/parthenon/pull/1408) Add GetAsUnresolvedString() method to ParameterInput
 - [[PR 1050]](https://github.com/parthenon-hpc-lab/parthenon/pull/1050) Add support for OpenPMD/ADIOS2 output (incl slices and coarsened dumps)
 - [[PR 1271]](https://github.com/parthenon-hpc-lab/parthenon/pull/1271) Add option to set a minimum number of teams for boundary communication kernels
 - [[PR 1382]](https://github.com/parthenon-hpc-lab/parthenon/pull/1382) Support Particle AMR

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -419,8 +419,8 @@ std::string ParameterInput::GetComment(const std::string &block,
 //  from input file when available
 
 std::string ParameterInput::GetAsUnresolvedString(const std::string &block,
-                                                   const std::string &name) {
-  FinalizeParsing();  // Ensure parsing is complete (consistent with other getters)
+                                                  const std::string &name) {
+  FinalizeParsing(); // Ensure parsing is complete (consistent with other getters)
 
   const Parameter *param = FindParameter_(block, name);
   if (param == nullptr) {

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -413,6 +413,34 @@ std::string ParameterInput::GetComment(const std::string &block,
 }
 
 //----------------------------------------------------------------------------------------
+//! \fn std::string ParameterInput::GetAsUnresolvedString(const std::string & block,
+//! const std::string & name)
+//  \brief returns string representation of parameter value, preferring original string
+//  from input file when available
+
+std::string ParameterInput::GetAsUnresolvedString(const std::string &block,
+                                                   const std::string &name) {
+  FinalizeParsing();  // Ensure parsing is complete (consistent with other getters)
+
+  const Parameter *param = FindParameter_(block, name);
+  if (param == nullptr) {
+    std::stringstream msg;
+    msg << "### FATAL ERROR in function [ParameterInput::GetAsUnresolvedString]"
+        << std::endl
+        << "Parameter name '" << name << "' not found in block '" << block << "'";
+    PARTHENON_THROW(msg);
+  }
+
+  // Prefer original string for determinism (matches ParameterDump behavior)
+  if (param->original_string.has_value()) {
+    return param->original_string.value().value;
+  }
+
+  // Fallback: convert typed value to string using existing infrastructure
+  return ParamValueToString(param->value);
+}
+
+//----------------------------------------------------------------------------------------
 //! \fn int ParameterInput::GetInteger(const std::string & block, const std::string &
 //! name)
 //  \brief returns integer value of string stored in block/name

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -251,6 +251,15 @@ class ParameterInput {
   bool DoesParameterExist(const std::string &block, const std::string &name);
   bool DoesBlockExist(const std::string &block);
   std::string GetComment(const std::string &block, const std::string &name);
+  //! Get parameter value as string representation
+  //! For parameters from input files, returns the exact string from the file.
+  //! For parameters added programmatically (Set/GetOrAdd), returns a string
+  //! representation of the typed value.
+  //! @param block The block name
+  //! @param name The parameter name
+  //! @return String representation of the parameter value
+  //! @throws If parameter does not exist in the specified block
+  std::string GetAsUnresolvedString(const std::string &block, const std::string &name);
 
   // === PARAMETER ACCESS METHODS ===
   // Get*: Retrieve parameter value (throws if missing)

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -29,6 +29,7 @@
 #include "parameter_input.hpp"
 
 using parthenon::ParameterInput;
+using parthenon::Real;
 
 TEST_CASE("Test required/desired checking from inputs", "[ParameterInput]") {
   GIVEN("A ParameterInput object already populated") {
@@ -563,4 +564,53 @@ TEST_CASE("Empty vector defaults round-trip through the parameter store",
   auto values = in.GetOrAddVector<std::string>("block1", "var1", {});
   REQUIRE(values.empty());
   REQUIRE(in.GetVector<std::string>("block1", "var1").empty());
+}
+
+TEST_CASE("GetAsUnresolvedString returns string representations", "[ParameterInput]") {
+  GIVEN("Parameters from input file") {
+    ParameterInput in;
+    std::stringstream ss;
+    ss << "<test>" << std::endl
+       << "int_param = 42" << std::endl
+       << "real_param = 3.14159" << std::endl
+       << "bool_param = true" << std::endl
+       << "string_param = hello" << std::endl
+       << "vector_param = 1, 2, 3" << std::endl;
+    std::istringstream s(ss.str());
+    in.LoadFromStream(s);
+
+    WHEN("GetAsUnresolvedString is called") {
+      THEN("Returns original string from file") {
+        REQUIRE(in.GetAsUnresolvedString("test", "int_param") == "42");
+        REQUIRE(in.GetAsUnresolvedString("test", "real_param") == "3.14159");
+        REQUIRE(in.GetAsUnresolvedString("test", "bool_param") == "true");
+        REQUIRE(in.GetAsUnresolvedString("test", "string_param") == "hello");
+        REQUIRE(in.GetAsUnresolvedString("test", "vector_param") == "1, 2, 3");
+      }
+    }
+  }
+
+  GIVEN("Parameters added programmatically") {
+    ParameterInput in;
+    in.Set<int>("runtime", "int_val", 99);
+    in.Set<bool>("runtime", "bool_val", false);
+    in.Set<Real>("runtime", "real_val", 2.718);
+
+    WHEN("GetAsUnresolvedString is called") {
+      THEN("Returns converted string representation") {
+        REQUIRE(in.GetAsUnresolvedString("runtime", "int_val") == "99");
+        REQUIRE(in.GetAsUnresolvedString("runtime", "bool_val") == "false");
+        // Real conversion should use full precision
+        std::string real_str = in.GetAsUnresolvedString("runtime", "real_val");
+        REQUIRE(std::stod(real_str) == Approx(2.718));
+      }
+    }
+  }
+
+  GIVEN("Missing parameter") {
+    ParameterInput in;
+    THEN("GetAsUnresolvedString throws") {
+      REQUIRE_THROWS(in.GetAsUnresolvedString("missing", "param"));
+    }
+  }
 }


### PR DESCRIPTION
[This PR was almost entirely generated by AI]

Enables retrieving parameter values as strings without knowing their types in advance. Needed for riot-loops Python interface.

Implementation:
- Prefers original_string from input file when available
- Falls back to ParamValueToString() for programmatic parameters
- Consistent behavior with ParameterDump()
- Throws if parameter not found

<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
