### PR TITLE
disambiguate parse, resolves #1410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1411]](https://github.com/parthenon-hpc-lab/parthenon/pull/1411) Fix bug where ParameterInput::GetOrAddVector<std::string> was ambiguous
 - [[PR 1406]](https://github.com/parthenon-hpc-lab/parthenon/pull/1406) Fix deadlock in parallel outputs after ParameterInput refactor
 - [[PR 1405]](https://github.com/parthenon-hpc-lab/parthenon/pull/1405) Fixes race condition in flux correction communication when sparse variables are disabled
 - [[PR 1339]](https://github.com/parthenon-hpc-lab/parthenon/pull/1339) Fixes doc for `numlevel` usage in non-AMR sims

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -663,8 +663,8 @@ void ParameterInput::CheckDesired(const std::string &block, const std::string &n
   if (defaulted) {
     auto *param = FindParameter_(block, name);
     std::cout << std::endl
-              << "Defaulting to <" << block << ">/" << name << " = "
-              << param->ToString() << std::endl;
+              << "Defaulting to <" << block << ">/" << name << " = " << param->ToString()
+              << std::endl;
   }
 }
 
@@ -712,7 +712,7 @@ void ParameterInput::ParameterDump(std::ostream &os) {
       auto key = std::make_pair(block.name, param_name);
       QueryRecord &record = queries_.at(key);
       std::string param_value = param.ToString();
-      if (record.IsStringVec() && (param_value.size() == 0)) {
+      if (record.IsDefaultEmptyStringVec() && (param_value.size() == 0)) {
         continue;
       }
 

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -709,15 +709,14 @@ void ParameterInput::ParameterDump(std::ostream &os) {
     // Output parameters with alignment
     for (const auto &param : block.params) {
       std::string param_name = param.name;
-  auto key = std::make_pair(block.name, param.name);
-  auto record_it = queries_.find(key);
-  std::string param_value = param.ToString();
+      auto key = std::make_pair(block.name, param.name);
+      auto record_it = queries_.find(key);
+      std::string param_value = param.ToString();
 
-  if (record_it != queries_.end() &&
-      record_it->second.IsDefaultEmptyStringVec() &&
-      param_value.empty()) {
-    continue;
-  }
+      if (record_it != queries_.end() && record_it->second.IsDefaultEmptyStringVec() &&
+          param_value.empty()) {
+        continue;
+      }
 
       std::size_t len = max_len_name - param_name.length() + 1;
       param_name.append(len, ' '); // pad name to align vertically

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -430,14 +430,7 @@ std::string ParameterInput::GetAsUnresolvedString(const std::string &block,
         << "Parameter name '" << name << "' not found in block '" << block << "'";
     PARTHENON_THROW(msg);
   }
-
-  // Prefer original string for determinism (matches ParameterDump behavior)
-  if (param->original_string.has_value()) {
-    return param->original_string.value().value;
-  }
-
-  // Fallback: convert typed value to string using existing infrastructure
-  return ParamValueToString(param->value);
+  return param->ToString();
 }
 
 //----------------------------------------------------------------------------------------
@@ -671,7 +664,7 @@ void ParameterInput::CheckDesired(const std::string &block, const std::string &n
     auto *param = FindParameter_(block, name);
     std::cout << std::endl
               << "Defaulting to <" << block << ">/" << name << " = "
-              << ParamValueToString(param->value) << std::endl;
+              << param->ToString() << std::endl;
   }
 }
 
@@ -708,9 +701,7 @@ void ParameterInput::ParameterDump(std::ostream &os) {
     std::size_t max_len_name = 0;
     std::size_t max_len_value = 0;
     for (const auto &param : block.params) {
-      std::string value_str = param.original_string.has_value()
-                                  ? param.original_string.value().value
-                                  : ParamValueToString(param.value);
+      std::string value_str = param.ToString();
       max_len_name = std::max(max_len_name, param.name.length());
       max_len_value = std::max(max_len_value, value_str.length());
     }
@@ -718,9 +709,12 @@ void ParameterInput::ParameterDump(std::ostream &os) {
     // Output parameters with alignment
     for (const auto &param : block.params) {
       std::string param_name = param.name;
-      std::string param_value = param.original_string.has_value()
-                                    ? param.original_string.value().value
-                                    : ParamValueToString(param.value);
+      auto key = std::make_pair(block.name, param_name);
+      QueryRecord &record = queries_.at(key);
+      std::string param_value = param.ToString();
+      if (record.IsStringVec() && (param_value.size() == 0)) {
+        continue;
+      }
 
       std::size_t len = max_len_name - param_name.length() + 1;
       param_name.append(len, ' '); // pad name to align vertically
@@ -800,11 +794,14 @@ void ParameterInput::OutputParameterTable(std::ostream &os,
 }
 
 //----------------------------------------------------------------------------------------
-//! \fn std::string ParameterInput::ParamValueToString()
+//! \fn std::string Param::ToString()
 //  \brief Convert a ParamValue variant to string for linked list output
 
-std::string ParameterInput::ParamValueToString(const ParamValue &value) {
+std::string Parameter::ToString() const {
   std::stringstream ss;
+  if (original_string.has_value()) {
+    return original_string.value().value;
+  }
 
   if (std::holds_alternative<UnresolvedString>(value)) {
     ss << std::get<UnresolvedString>(value).value;

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -709,12 +709,15 @@ void ParameterInput::ParameterDump(std::ostream &os) {
     // Output parameters with alignment
     for (const auto &param : block.params) {
       std::string param_name = param.name;
-      auto key = std::make_pair(block.name, param_name);
-      QueryRecord &record = queries_.at(key);
-      std::string param_value = param.ToString();
-      if (record.IsDefaultEmptyStringVec() && (param_value.size() == 0)) {
-        continue;
-      }
+  auto key = std::make_pair(block.name, param.name);
+  auto record_it = queries_.find(key);
+  std::string param_value = param.ToString();
+
+  if (record_it != queries_.end() &&
+      record_it->second.IsDefaultEmptyStringVec() &&
+      param_value.empty()) {
+    continue;
+  }
 
       std::size_t len = max_len_name - param_name.length() + 1;
       param_name.append(len, ' '); // pad name to align vertically

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -141,6 +141,10 @@ struct QueryRecord {
     ss << val;
     return ss.str();
   }
+
+  bool IsStringVec() const {
+    return param_type == GetTypeName<std::vector<std::string>>();
+  }
 };
 
 // Wrapper type to distinguish unresolved strings (from legacy parser)
@@ -190,6 +194,8 @@ struct Parameter {
   std::optional<UnresolvedString> original_string;
   // TODO(future): Consider merging QueryRecord into Parameter as
   // std::optional<QueryRecord> to eliminate the separate queries_ map
+
+  std::string ToString() const;
 };
 
 //----------------------------------------------------------------------------------------
@@ -437,6 +443,7 @@ class ParameterInput {
     AddParameter_(block, name, def, "# Default value added at run time");
     return def;
   }
+
   template <typename T>
   std::vector<T> GetOrAddVector(
       const std::string &block, const std::string &name, const ParameterRef &def,
@@ -477,7 +484,6 @@ class ParameterInput {
 
   // === HELPER METHODS (parser-agnostic) ===
   // Convert ParamValue to string for output
-  std::string ParamValueToString(const ParamValue &value);
   template <typename T>
   T ConvertParamValue(const ParamValue &value, const std::string &block,
                       const std::string &name);

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -145,6 +145,14 @@ struct QueryRecord {
   bool IsStringVec() const {
     return param_type == GetTypeName<std::vector<std::string>>();
   }
+  bool IsDefaultEmptyStringVec() const {
+    if (IsStringVec() && default_value.has_value()) {
+      using value_t = std::vector<std::string>;
+      return std::any_cast<value_t>(default_value).size() == 0;
+    } else {
+      return false;
+    }
+  }
 };
 
 // Wrapper type to distinguish unresolved strings (from legacy parser)

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -37,12 +37,16 @@ bool HasMPITests(const T &config) {
   // Used to check if a given test in the suite matches the requsted
   // test specification
   const auto &test_spec = config.testSpec();
+  const bool has_filters = test_spec.hasFilters();
 
   const auto &all_test_cases = Catch::getAllTestCasesSorted(config);
   for (auto const &test_case : all_test_cases) {
-    auto &tags = test_case.getTestCaseInfo().tags;
-    if (test_spec.matches(test_case) &&
-        std::find(tags.begin(), tags.end(), "MPI") != tags.end()) {
+    const auto &info = test_case.getTestCaseInfo();
+    const auto &tags = info.tags;
+    // if the spec is empty, i.e., all tests are requested, we have to special case.
+   const bool selected = has_filters ? test_spec.matches(test_case) : !info.isHidden();
+    const bool is_mpi = std::find(tags.begin(), tags.end(), "MPI") != tags.end();
+    if (selected && is_mpi) {
       return true;
     }
   }
@@ -75,12 +79,15 @@ int main(int argc, char *argv[]) {
 #ifdef CATCH2_MPI_PARALLEL
   bool running_mpi_tests = HasMPITests(config);
   if (running_mpi_tests) {
-    int already_initialized;
+    int already_initialized = 0;
     MPI_Initialized(&already_initialized);
-    if (!already_initialized && (MPI_SUCCESS != MPI_Init(&argc, &argv))) {
-      std::cerr << "### FATAL ERROR in ParthenonInit" << std::endl
-                << "MPI Initialization failed." << std::endl;
-      return -1;
+    if (!already_initialized) {
+      int status = MPI_Init(&argc, &argv);
+      if (status != MPI_SUCCESS) {
+        std::cerr << "### FATAL ERROR in ParthenonInit" << std::endl
+                  << "MPI Initialization failed." << std::endl;
+        return -1;
+      }
     }
     MPI_Comm_rank(MPI_COMM_WORLD, &parthenon::Globals::my_rank);
     MPI_Comm_size(MPI_COMM_WORLD, &parthenon::Globals::nranks);

--- a/tst/catch2_define.cpp
+++ b/tst/catch2_define.cpp
@@ -44,7 +44,7 @@ bool HasMPITests(const T &config) {
     const auto &info = test_case.getTestCaseInfo();
     const auto &tags = info.tags;
     // if the spec is empty, i.e., all tests are requested, we have to special case.
-   const bool selected = has_filters ? test_spec.matches(test_case) : !info.isHidden();
+    const bool selected = has_filters ? test_spec.matches(test_case) : !info.isHidden();
     const bool is_mpi = std::find(tags.begin(), tags.end(), "MPI") != tags.end();
     if (selected && is_mpi) {
       return true;

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -577,14 +577,14 @@ TEST_CASE("Empty vector defaults round-trip through the parameter store",
   REQUIRE(values.empty());
   REQUIRE(in2.GetVector<std::string>("block1", "var1").empty());
 }
-  TEST_CASE("ParameterDump includes unqueried parameters", "[ParameterInput]") {
-    ParameterInput in;
-    in.AddParsedParameter("block", "unused", 42);
+TEST_CASE("ParameterDump includes unqueried parameters", "[ParameterInput]") {
+  ParameterInput in;
+  in.AddParsedParameter("block", "unused", 42);
 
-    std::stringstream dump;
-    REQUIRE_NOTHROW(in.ParameterDump(dump));
-    REQUIRE(dump.str().find("unused") != std::string::npos);
-  }
+  std::stringstream dump;
+  REQUIRE_NOTHROW(in.ParameterDump(dump));
+  REQUIRE(dump.str().find("unused") != std::string::npos);
+}
 
 TEST_CASE("GetAsUnresolvedString returns string representations", "[ParameterInput]") {
   GIVEN("Parameters from input file") {

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -577,6 +577,14 @@ TEST_CASE("Empty vector defaults round-trip through the parameter store",
   REQUIRE(values.empty());
   REQUIRE(in2.GetVector<std::string>("block1", "var1").empty());
 }
+  TEST_CASE("ParameterDump includes unqueried parameters", "[ParameterInput]") {
+    ParameterInput in;
+    in.AddParsedParameter("block", "unused", 42);
+
+    std::stringstream dump;
+    REQUIRE_NOTHROW(in.ParameterDump(dump));
+    REQUIRE(dump.str().find("unused") != std::string::npos);
+  }
 
 TEST_CASE("GetAsUnresolvedString returns string representations", "[ParameterInput]") {
   GIVEN("Parameters from input file") {

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -564,6 +564,18 @@ TEST_CASE("Empty vector defaults round-trip through the parameter store",
   auto values = in.GetOrAddVector<std::string>("block1", "var1", {});
   REQUIRE(values.empty());
   REQUIRE(in.GetVector<std::string>("block1", "var1").empty());
+
+  auto dummy = in.GetOrAddInteger("block2", "var2", 3);
+  std::stringstream ss;
+  in.ParameterDump(ss);
+  std::string paramdump = ss.str();
+
+  ParameterInput in2;
+  std::istringstream s(paramdump);
+  in2.LoadFromStream(s);
+  values = in2.GetOrAddVector<std::string>("block1", "var1", {});
+  REQUIRE(values.empty());
+  REQUIRE(in.GetVector<std::string>("block1", "var1").empty());
 }
 
 TEST_CASE("GetAsUnresolvedString returns string representations", "[ParameterInput]") {

--- a/tst/unit/test_parameter_input.cpp
+++ b/tst/unit/test_parameter_input.cpp
@@ -575,7 +575,7 @@ TEST_CASE("Empty vector defaults round-trip through the parameter store",
   in2.LoadFromStream(s);
   values = in2.GetOrAddVector<std::string>("block1", "var1", {});
   REQUIRE(values.empty());
-  REQUIRE(in.GetVector<std::string>("block1", "var1").empty());
+  REQUIRE(in2.GetVector<std::string>("block1", "var1").empty());
 }
 
 TEST_CASE("GetAsUnresolvedString returns string representations", "[ParameterInput]") {


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

This MR resolves #1410. It's a hack though. To summarize, the issue is that GetOrAddVector<std::string> can produce a different answer if run from a restart file vs an input deck if it was defaulted. The easiest thing to do was just not output empty lists of vectors to the string stashed in restarts if they were pulled in as GetOrAddVector<std::string>. So that's what I did. 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
