### PR TITLE
[Trivial] remove virtual from packs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 1416][(https://github.com/parthenon-hpc-lab/parthenon/pull/1416) Remove virtual tag from destructors in sparse and swarm pack base classes
 - [[PR 1401]](https://github.com/parthenon-hpc-lab/parthenon/pull/1401) Sparse Field Component Names
 - [[PR 1331]](https://github.com/parthenon-hpc-lab/parthenon/pull/1331) Use `size_t` for sizes
 - [[PR 1355]](https://github.com/parthenon-hpc-lab/parthenon/pull/1355) Allow disabling format and lint targets

--- a/src/pack/sparse_pack/sparse_pack_base.hpp
+++ b/src/pack/sparse_pack/sparse_pack_base.hpp
@@ -29,7 +29,7 @@ namespace parthenon {
 class SparsePackBase {
  public:
   SparsePackBase() = default;
-  virtual ~SparsePackBase() = default;
+  ~SparsePackBase() = default;
 
  protected:
   friend class SparsePackCache;

--- a/src/pack/swarm_pack/swarm_pack_base.hpp
+++ b/src/pack/swarm_pack/swarm_pack_base.hpp
@@ -37,7 +37,7 @@ template <typename TYPE>
 class SwarmPackBase {
  public:
   SwarmPackBase() = default;
-  virtual ~SwarmPackBase() = default;
+  ~SwarmPackBase() = default;
 
  protected:
   friend class SwarmPackCache<TYPE>;


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

I just noticed that SparsePackBase and SwarmPackBase both have a virtual destructor, which is unused. This adds a vtable to each class that depends on the base class. Is there a reason for this, @pdmullen @lroberts36 ? I think no right? 

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
