### PR TITLE
SMALL: Permit larger input file sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1428]](https://github.com/parthenon-hpc-lab/parthenon/pull/1428) Permit larger input file sizes
 - [[PR 1413]](https://github.com/parthenon-hpc-lab/parthenon/pull/1413) Add support for per-package meshdata objects containing subsets of variables 
 - [[PR 1403]](https://github.com/parthenon-hpc-lab/parthenon/pull/1403) Add interface for Fourier transforms on uniform meshes via heFFTe
 - [[PR 1408]](https://github.com/parthenon-hpc-lab/parthenon/pull/1408) Add GetAsUnresolvedString() method to ParameterInput

--- a/src/parameter_input.cpp
+++ b/src/parameter_input.cpp
@@ -194,6 +194,7 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
       "Can't add new parameters to the linked list after the map is resolved.");
   std::stringstream par, msg;
   constexpr int kBufSize = 4096;
+  constexpr IOWrapperSizeT kMaxInputHeaderSize = 10 * 1024 * 1024; // 10 MiB
   char buf[kBufSize];
   IOWrapperSizeT header = 0, ret, loc;
 
@@ -215,9 +216,9 @@ void ParameterInput::LoadFromFile(IOWrapper &input) {
       header = loc + 10;             // store the header length
       break;
     }
-    if (header > kBufSize * 10) {
+    if (header > kMaxInputHeaderSize) {
       msg << "### FATAL ERROR in function [ParameterInput::LoadFromFile]"
-          << "<par_end> is not found in the first 40KBytes." << std::endl
+          << "<par_end> is not found in the first 10MiB." << std::endl
           << "Probably the file is broken or a wrong file is specified" << std::endl;
       PARTHENON_FAIL(msg);
     }


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
With our Python-generated input files downstream, I have actually been able to hit the current 40kbyte limit that Parthenon currently imposes.  There are certainly workarounds downstream, but I wonder if anyone would have issue with simply being a bit more lenient on input file sizes.  I have switched to a 10MiB limit in this PR.  


<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [x] (@lanl.gov employees) Update copyright on changed files
