### PR TITLE
Fixes to swarm tensor xdmf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1429]](https://github.com/parthenon-hpc-lab/parthenon/pull/1429) Fixes to swarm tensor xdmf
 - [[PR 1413]](https://github.com/parthenon-hpc-lab/parthenon/pull/1413) Add support for per-package meshdata objects containing subsets of variables 
 - [[PR 1403]](https://github.com/parthenon-hpc-lab/parthenon/pull/1403) Add interface for Fourier transforms on uniform meshes via heFFTe
 - [[PR 1408]](https://github.com/parthenon-hpc-lab/parthenon/pull/1408) Add GetAsUnresolvedString() method to ParameterInput

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -457,7 +457,7 @@ static void ParticleVariableRef(std::ofstream &xdmf, const std::string &varname,
   } else {
     const int rank = varinfo.tensor_rank;
     std::string extradims;
-    for (int i = 6; i >= 2; --i) {
+    for (int i = rank + 1; i >= 2; --i) {
       extradims += StringPrintf("%d ", varinfo.GetN(i));
     }
     for (int n6 = 0; n6 < varinfo.GetN(6); ++n6) {
@@ -466,11 +466,11 @@ static void ParticleVariableRef(std::ofstream &xdmf, const std::string &varname,
           for (int n3 = 0; n3 < varinfo.GetN(3); ++n3) {
             for (int n2 = 0; n2 < varinfo.GetN(2); ++n2) {
               std::string name = swmname + "/" + varname;
-              if (rank > 4) name += StringPrintf("_%03d", n6);
-              if (rank > 3) name += StringPrintf("_%03d", n5);
-              if (rank > 2) name += StringPrintf("_%03d", n4);
-              if (rank > 1) name += StringPrintf("_%03d", n3);
-              if (rank > 0) name += StringPrintf("_%03d", n2);
+              if (rank > 4) name += StringPrintf("_%d", n6);
+              if (rank > 3) name += StringPrintf("_%d", n5);
+              if (rank > 2) name += StringPrintf("_%d", n4);
+              if (rank > 1) name += StringPrintf("_%d", n3);
+              if (rank > 0) name += StringPrintf("_%d", n2);
               xdmf << StringPrintf(fmt, name.c_str(), "Scalar");
               if (rank > 0) {
                 std::string starts = "";
@@ -489,16 +489,16 @@ static void ParticleVariableRef(std::ofstream &xdmf, const std::string &varname,
                 xdmf << StringPrintf(
                     "        <DataItem ItemType=\"HyperSlab\" Dimensions=\"%d\">\n"
                     "          <DataItem Dimensions=\"3 %d\" Format=\"XML\">\n"
-                    "            %s1\n"
+                    "            %s0\n"
                     "            1%s\n"
                     "            %s%d\n"
-                    "          </DataItem>\n"
-                    "        </DataItem>\n",
+                    "          </DataItem>\n",
                     particle_count, rank + 1, starts.c_str(), strides.c_str(),
                     counts.c_str(), particle_count);
-                xdmf << ParticleDatasetRef("        ", swmname, varname, hdffile,
+                xdmf << ParticleDatasetRef("          ", swmname, varname, hdffile,
                                            varinfo.swtype, extradims.c_str(),
                                            particle_count);
+                xdmf << "        </DataItem>\n";
               } else {
                 xdmf << ParticleDatasetRef("        ", swmname, varname, hdffile,
                                            varinfo.swtype, "", particle_count);

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2023-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary
Visit fails to plot some non-scalar swarm variable outputs with our current XDMF.  There is a particular branch for swarm XDMF that checks for `(tensor_rank == 1) && (nvar == 3) && Metadata::Vector` (which might correspond to, e.g., a velocity), that seems to work correctly (i.e., Visit collapses this into a "magnitude field").  But for fields without `Metadata::Vector` or fields with some number of components `!= 3`, we might still want to visualize this in Visit.  

Here I make some fixes to the code path for more arbitrary tensor outputs (see diff).  Each "component" is treated as a scalar entry as before (with the exception that I move from `%03d` to just `%d` naming so that variables appear in Visit as e.g., velocity_0 instead of velocity_000).

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [x] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [x] (@lanl.gov employees) Update copyright on changed files
