### PR TITLE
Fix BiCGSTAB returning NaN when a solve converges in its first half step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
-- [[PR ????]](https://github.com/parthenon-hpc-lab/parthenon/pull/????) Fix BiCGSTAB returning NaN when a solve converges in its first half step
+- [[PR 1430]](https://github.com/parthenon-hpc-lab/parthenon/pull/1430) Fix BiCGSTAB returning NaN when a solve converges in its first half step
 - [[PR 1412]](https://github.com/parthenon-hpc-lab/parthenon/pull/1412) Fix single precision compilation with `Real=float`
 - [[PR 1411]](https://github.com/parthenon-hpc-lab/parthenon/pull/1411) Fix bug where ParameterInput::GetOrAddVector<std::string> was ambiguous
 - [[PR 1406]](https://github.com/parthenon-hpc-lab/parthenon/pull/1406) Fix deadlock in parallel outputs after ParameterInput refactor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR ????]](https://github.com/parthenon-hpc-lab/parthenon/pull/????) Fix BiCGSTAB returning NaN when a solve converges in its first half step
 - [[PR 1412]](https://github.com/parthenon-hpc-lab/parthenon/pull/1412) Fix single precision compilation with `Real=float`
 - [[PR 1411]](https://github.com/parthenon-hpc-lab/parthenon/pull/1411) Fix bug where ParameterInput::GetOrAddVector<std::string> was ambiguous
 - [[PR 1406]](https://github.com/parthenon-hpc-lab/parthenon/pull/1406) Fix deadlock in parallel outputs after ParameterInput refactor

--- a/src/solvers/bicgstab_solver.hpp
+++ b/src/solvers/bicgstab_solver.hpp
@@ -29,6 +29,7 @@
 #include "solvers/solver_utils.hpp"
 #include "tasks/tasks.hpp"
 #include "utils/reductions.hpp"
+#include "utils/robust.hpp"
 #include "utils/type_list.hpp"
 
 namespace parthenon {
@@ -346,7 +347,7 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
         get_tt_ts, "x <- h + omega u",
         [](BiCGSTABSolver *solver, std::shared_ptr<MeshData<Real>> &md_h,
            std::shared_ptr<MeshData<Real>> &md_u, std::shared_ptr<MeshData<Real>> &md_x) {
-          Real omega = solver->tt_ts.val[1] / solver->tt_ts.val[0];
+          Real omega = robust::ratio(solver->tt_ts.val[1], solver->tt_ts.val[0]);
           return AddFieldsAndStore<FieldTL>(md_h, md_u, md_x, 1.0, omega);
         },
         this, md_h, md_u, md_x);
@@ -356,7 +357,7 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
         get_tt_ts, "r <- s - omega t",
         [](BiCGSTABSolver *solver, std::shared_ptr<MeshData<Real>> &md_s,
            std::shared_ptr<MeshData<Real>> &md_t, std::shared_ptr<MeshData<Real>> &md_r) {
-          Real omega = solver->tt_ts.val[1] / solver->tt_ts.val[0];
+          Real omega = robust::ratio(solver->tt_ts.val[1], solver->tt_ts.val[0]);
           return AddFieldsAndStore<FieldTL>(md_s, md_t, md_r, 1.0, -omega);
         },
         this, md_s, md_t, md_r);
@@ -385,11 +386,10 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
         [](BiCGSTABSolver *solver, std::shared_ptr<MeshData<Real>> &md_p,
            std::shared_ptr<MeshData<Real>> &md_v, std::shared_ptr<MeshData<Real>> &md_r) {
           Real alpha = solver->rhat0r_old / solver->rhat0v.val;
-          Real omega = solver->tt_ts.val[1] / solver->tt_ts.val[0];
+          Real omega = robust::ratio(solver->tt_ts.val[1], solver->tt_ts.val[0]);
           Real beta = solver->res_rhat0r.val[1] / solver->rhat0r_old * alpha / omega;
           AddFieldsAndStore<FieldTL>(md_p, md_v, md_p, 1.0, -omega);
           return AddFieldsAndStore<FieldTL>(md_r, md_p, md_p, 1.0, beta);
-          return TaskStatus::complete;
         },
         this, md_p, md_v, md_r);
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Came across this when the driver truncates the last time step to be very nearly zero. When this happens the operator used in the solver becomes diagonal and converges after the bicg step leading to a nan in computing omega as 0/0.

This reproduces in the diffusion example with
```
<parthenon/time>
dt_force = 4.0e-6
tlim     = 2.0e-5      # 5 steps reach 1.9999999999999998e-05, so step 6 is
                                # truncated to dt = 3.3881317890172014e-21
<diffusion>
solver = BiCGSTAB
t0     = 1.0
<diffusion/solver_params>
precondition = false
```

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
