### PR TITLE
Instantiate default refinement ops once, not at every Metadata call site

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 - [[PR 1360]](https://github.com/parthenon-hpc-lab/parthenon/pull/1360) Fix boundary cache clearing in different MeshData partitions
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1432]](https://github.com/parthenon-hpc-lab/parthenon/pull/1432) Instantiate default refinement ops once instead of at every Metadata call site
 - [[PR 1414]](https://github.com/parthenon-hpc-lab/parthenon/pull/1414) Bump ROCM CI Container to rocm 7.2.4
 - [[PR 1397]](https://github.com/parthenon-hpc-lab/parthenon/pull/1397) Add Code of Conduct
 - [[PR 1385]](https://github.com/parthenon-hpc-lab/parthenon/pull/1385) Refactor ParameterInput: Separate parsing from storage to enable multiple input formats

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -338,22 +338,20 @@ class Metadata {
 
   // 4 constructors, this is the general constructor called by all other constructors, so
   // we do some sanity checks here
-  Metadata(
-      const std::vector<MetadataFlag> &bits, const std::vector<MetadataFlag> &flux_bits,
-      const std::vector<int> &shape = {},
-      const std::vector<std::string> &component_labels = {},
-      const std::string &associated = "",
-      const refinement::RefinementFunctions_t ref_funcs_ =
-          refinement::DefaultRefinementFunctions(),
-      const refinement::RefinementFunctions_t flux_ref_funcs_ =
-          refinement::DefaultRefinementFunctions());
+  Metadata(const std::vector<MetadataFlag> &bits,
+           const std::vector<MetadataFlag> &flux_bits, const std::vector<int> &shape = {},
+           const std::vector<std::string> &component_labels = {},
+           const std::string &associated = "",
+           const refinement::RefinementFunctions_t ref_funcs_ =
+               refinement::DefaultRefinementFunctions(),
+           const refinement::RefinementFunctions_t flux_ref_funcs_ =
+               refinement::DefaultRefinementFunctions());
 
-  Metadata(
-      const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
-      const std::vector<std::string> &component_labels = {},
-      const std::string &associated = "",
-      const refinement::RefinementFunctions_t ref_funcs_ =
-          refinement::DefaultRefinementFunctions())
+  Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
+           const std::vector<std::string> &component_labels = {},
+           const std::string &associated = "",
+           const refinement::RefinementFunctions_t ref_funcs_ =
+               refinement::DefaultRefinementFunctions())
       : Metadata(bits, {}, shape, component_labels, associated, ref_funcs_, ref_funcs_) {}
 
   Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,

--- a/src/interface/metadata.hpp
+++ b/src/interface/metadata.hpp
@@ -1,5 +1,5 @@
 //========================================================================================
-// (C) (or copyright) 2020-2025. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -12,6 +12,8 @@
 //========================================================================================
 #ifndef INTERFACE_METADATA_HPP_
 #define INTERFACE_METADATA_HPP_
+
+// This file was made in part with generative AI.
 
 #include <algorithm>
 #include <bitset>
@@ -342,19 +344,16 @@ class Metadata {
       const std::vector<std::string> &component_labels = {},
       const std::string &associated = "",
       const refinement::RefinementFunctions_t ref_funcs_ =
-          refinement::RefinementFunctions_t::RegisterOps<
-              refinement_ops::ProlongateSharedMinMod, refinement_ops::RestrictAverage>(),
+          refinement::DefaultRefinementFunctions(),
       const refinement::RefinementFunctions_t flux_ref_funcs_ =
-          refinement::RefinementFunctions_t::RegisterOps<
-              refinement_ops::ProlongateSharedMinMod, refinement_ops::RestrictAverage>());
+          refinement::DefaultRefinementFunctions());
 
   Metadata(
       const std::vector<MetadataFlag> &bits, const std::vector<int> &shape = {},
       const std::vector<std::string> &component_labels = {},
       const std::string &associated = "",
       const refinement::RefinementFunctions_t ref_funcs_ =
-          refinement::RefinementFunctions_t::RegisterOps<
-              refinement_ops::ProlongateSharedMinMod, refinement_ops::RestrictAverage>())
+          refinement::DefaultRefinementFunctions())
       : Metadata(bits, {}, shape, component_labels, associated, ref_funcs_, ref_funcs_) {}
 
   Metadata(const std::vector<MetadataFlag> &bits, const std::vector<int> &shape,

--- a/src/prolong_restrict/prolong_restrict.cpp
+++ b/src/prolong_restrict/prolong_restrict.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020-2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2023. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
@@ -16,6 +16,8 @@
 // the public, perform publicly and display publicly, and to permit others to do
 // so.
 //========================================================================================
+
+// This file was made in part with generative AI.
 
 #include <algorithm>
 #include <tuple> // std::tuple
@@ -31,6 +33,16 @@
 
 namespace parthenon {
 namespace refinement {
+
+// Single instantiation point for the default refinement ops. Every
+// default-constructed Metadata shares this instance, so the expensive kernel
+// template chain is instantiated here once instead of in every calling TU.
+const RefinementFunctions_t &DefaultRefinementFunctions() {
+  static const RefinementFunctions_t funcs =
+      RefinementFunctions_t::RegisterOps<refinement_ops::ProlongateSharedMinMod,
+                                         refinement_ops::RestrictAverage>();
+  return funcs;
+}
 
 // TODO(JMM): Add a prolongate when prolongation is called in-one
 // TODO(JMM): Is this actually the API we want?

--- a/src/prolong_restrict/prolong_restrict.hpp
+++ b/src/prolong_restrict/prolong_restrict.hpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2020-2022 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2022. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2022-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001
 // for Los Alamos National Laboratory (LANL), which is operated by Triad
@@ -19,6 +19,8 @@
 
 #ifndef PROLONG_RESTRICT_PROLONG_RESTRICT_HPP_
 #define PROLONG_RESTRICT_PROLONG_RESTRICT_HPP_
+
+// This file was made in part with generative AI.
 
 #include <algorithm>
 #include <functional> // std::function
@@ -173,6 +175,13 @@ struct RefinementFunctionsHasher {
     return std::hash<std::string>{}(f.label());
   }
 };
+
+// Default refinement ops (ProlongateSharedMinMod + RestrictAverage). Declared
+// here but defined out-of-line in prolong_restrict.cpp so the underlying kernel
+// template chain (DoProlongationRestrictionOp -> ProlongationRestrictionLoop ->
+// par_for_*) is instantiated in exactly one TU rather than at every Metadata
+// call site that relies on the default refinement functions.
+const RefinementFunctions_t &DefaultRefinementFunctions();
 
 } // namespace refinement
 } // namespace parthenon


### PR DESCRIPTION
## PR Summary

[Written in part by generative AI] 

The Metadata constructors default their refinement-function arguments to `RefinementFunctions_t::RegisterOps<ProlongateSharedMinMod, RestrictAverage>()`. Because default arguments are evaluated at each call site, every TU that constructs a Metadata instantiates the full prolongation/restriction kernel template chain (`DoProlongationRestrictionOp` → `ProlongationRestrictionLoop` → `par_for_*`) — even though those TUs never invoke the kernels.

  This PR replaces the default-argument expression with a non-template factory `refinement::DefaultRefinementFunctions()`, declared in prolong_restrict.hpp and defined out-of-line in prolong_restrict.cpp. The kernel chain is now instantiated exactly once and shared via a function-local static.

**Behavior:** No change. `RefinementFunctions_t` equality is by string label, so the shared instance compares identically to the previous per-TU copies. Custom ops via `RegisterRefinementOps<>` are untouched.

**Impact:** Measured on CPU (Apple Clang, -ftime-trace) this removes ~16% of total downstream TU compile time. The effect should be larger for device builds, where the duplicated instantiations also emit device code (originally observed as prolongation/restriction kernels showing up in unrelated TUs' HIP register-usage reports).

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [x] (@lanl.gov employees) Update copyright on changed files
