### PR TITLE
Some XDMF fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
-- [[PR 1434]](https://github.com/parthenon-hpc-lab/parthenon/pull/1434) Repair nodal field output.
+- [[PR 1434]](https://github.com/parthenon-hpc-lab/parthenon/pull/1434) Repair nodal field output in XDMF.
 - [[PR 1430]](https://github.com/parthenon-hpc-lab/parthenon/pull/1430) Fix BiCGSTAB returning NaN when a solve converges in its first half step
 - [[PR 1412]](https://github.com/parthenon-hpc-lab/parthenon/pull/1412) Fix single precision compilation with `Real=float`
 - [[PR 1411]](https://github.com/parthenon-hpc-lab/parthenon/pull/1411) Fix bug where ParameterInput::GetOrAddVector<std::string> was ambiguous

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1434]](https://github.com/parthenon-hpc-lab/parthenon/pull/1434) Repair nodal field output.
 - [[PR 1430]](https://github.com/parthenon-hpc-lab/parthenon/pull/1430) Fix BiCGSTAB returning NaN when a solve converges in its first half step
 - [[PR 1412]](https://github.com/parthenon-hpc-lab/parthenon/pull/1412) Fix single precision compilation with `Real=float`
 - [[PR 1411]](https://github.com/parthenon-hpc-lab/parthenon/pull/1411) Fix bug where ParameterInput::GetOrAddVector<std::string> was ambiguous

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -253,31 +253,20 @@ TaskStatus FillDerived(MeshData<Real> *md) {
     la::outer(
         idx_space, KOKKOS_LAMBDA(const IST::idx_range_t &idx_range, int b) {
           const int nvar = pack.GetSize(b, Conserved::phi());
-          const Real weight = (ndim > 2) ? 0.125 : (ndim > 1) ? 0.25 : 0.5;
           for (int n = 0; n < nvar; ++n) {
             auto pvn = la::make_sparse_pack_view(idx_range, pack, n);
 
             la::inner(idx_range, [&](const auto kji) {
-              pvn(Nodal::phi(), kji) =
-                  pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - di);
+              pvn(Nodal::phi(), kji) = 0.125 * (
+                     pvn(Conserved::phi(), kji) 
+                  + pvn(Conserved::phi(), kji - di)
+                  + pvn(Conserved::phi(), kji - dj)
+                  + pvn(Conserved::phi(), kji - dk)
+                  + pvn(Conserved::phi(), kji - di - dj)
+                  + pvn(Conserved::phi(), kji - dj - dk)
+                  + pvn(Conserved::phi(), kji - dk - di)
+                  + pvn(Conserved::phi(), kji - di - dj - dk));
             });
-            idx_range.TeamBarrier();
-            if (ndim > 1) {
-              la::inner(idx_range, [&](const auto kji) {
-                pvn(Nodal::phi(), kji) +=
-                    (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - dj));
-              });
-              idx_range.TeamBarrier();
-            }
-            if (ndim > 2) {
-              la::inner(idx_range, [&](const auto kji) {
-                pvn(Nodal::phi(), kji) +=
-                    (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - dk));
-              });
-              idx_range.TeamBarrier();
-            }
-            la::inner(idx_range,
-                      [&](const auto kji) { pvn(Nodal::phi(), kji) *= weight; });
           }
         });
   }

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -257,14 +257,18 @@ TaskStatus FillDerived(MeshData<Real> *md) {
             auto pvn = la::make_sparse_pack_view(idx_range, pack, n);
 
             la::inner(idx_range, [&](const auto kji) {
+              /* clang-format off */
               pvn(Nodal::phi(), kji) =
                   0.125 *
-                  (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - di) +
-                   pvn(Conserved::phi(), kji - dj) + pvn(Conserved::phi(), kji - dk) +
+                  (pvn(Conserved::phi(), kji) +
+                   pvn(Conserved::phi(), kji - di) +
+                   pvn(Conserved::phi(), kji - dj) +
+                   pvn(Conserved::phi(), kji - dk) +
                    pvn(Conserved::phi(), kji - di - dj) +
                    pvn(Conserved::phi(), kji - dj - dk) +
                    pvn(Conserved::phi(), kji - dk - di) +
                    pvn(Conserved::phi(), kji - di - dj - dk));
+              /* clang-format on */
             });
           }
         });

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -257,15 +257,14 @@ TaskStatus FillDerived(MeshData<Real> *md) {
             auto pvn = la::make_sparse_pack_view(idx_range, pack, n);
 
             la::inner(idx_range, [&](const auto kji) {
-              pvn(Nodal::phi(), kji) = 0.125 * (
-                     pvn(Conserved::phi(), kji) 
-                  + pvn(Conserved::phi(), kji - di)
-                  + pvn(Conserved::phi(), kji - dj)
-                  + pvn(Conserved::phi(), kji - dk)
-                  + pvn(Conserved::phi(), kji - di - dj)
-                  + pvn(Conserved::phi(), kji - dj - dk)
-                  + pvn(Conserved::phi(), kji - dk - di)
-                  + pvn(Conserved::phi(), kji - di - dj - dk));
+              pvn(Nodal::phi(), kji) =
+                  0.125 *
+                  (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - di) +
+                   pvn(Conserved::phi(), kji - dj) + pvn(Conserved::phi(), kji - dk) +
+                   pvn(Conserved::phi(), kji - di - dj) +
+                   pvn(Conserved::phi(), kji - dj - dk) +
+                   pvn(Conserved::phi(), kji - dk - di) +
+                   pvn(Conserved::phi(), kji - di - dj - dk));
             });
           }
         });

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     m = Metadata(
         {Metadata::Node, Metadata::Derived, Metadata::Sparse, Metadata::CellMemAligned},
         std::vector<int>{shape_size});
-    pkg->AddSparsePool<Derived::phi_nodal>(m, Conserved::phi::name(), sparse_idxs);
+    pkg->AddSparsePool<Nodal::phi>(m, Conserved::phi::name(), sparse_idxs);
   }
 
   bool do_fine_advection = pin->GetOrAddBoolean("Advection", "do_fine_advection", true);
@@ -216,8 +216,7 @@ TaskStatus FillDerived(MeshData<Real> *md) {
       parthenon::MakePackDescriptor<Conserved::phi, Conserved::phi_fine,
                                     Conserved::phi_fine_restricted, Conserved::C,
                                     Conserved::C_cc, Conserved::D, Conserved::D_cc,
-                                    Conserved::divC, Conserved::divD, Derived::phi_nodal>(
-          md);
+                                    Conserved::divC, Conserved::divD, Nodal::phi>(md);
   auto pack = desc.GetPack(md);
 
   std::shared_ptr<StateDescriptor> pkg =
@@ -259,26 +258,26 @@ TaskStatus FillDerived(MeshData<Real> *md) {
             auto pvn = la::make_sparse_pack_view(idx_range, pack, n);
 
             la::inner(idx_range, [&](const auto kji) {
-              pvn(Derived::phi_nodal(), kji) =
+              pvn(Nodal::phi(), kji) =
                   pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - di);
             });
             idx_range.TeamBarrier();
             if (ndim > 1) {
               la::inner(idx_range, [&](const auto kji) {
-                pvn(Derived::phi_nodal(), kji) +=
+                pvn(Nodal::phi(), kji) +=
                     (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - dj));
               });
               idx_range.TeamBarrier();
             }
             if (ndim > 2) {
               la::inner(idx_range, [&](const auto kji) {
-                pvn(Derived::phi_nodal(), kji) +=
+                pvn(Nodal::phi(), kji) +=
                     (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - dk));
               });
               idx_range.TeamBarrier();
             }
             la::inner(idx_range,
-                      [&](const auto kji) { pvn(Derived::phi_nodal(), kji) *= weight; });
+                      [&](const auto kji) { pvn(Nodal::phi(), kji) *= weight; });
           }
         });
   }

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -235,7 +235,9 @@ TaskStatus FillDerived(MeshData<Real> *md) {
     const la::NInner ninner = la::chunk_shape::ij_slab;
     constexpr auto loop_tag =
         parthenon::ENABLE_GPU ? la::loop_tag::boiv : la::loop_tag::bovi;
-    using IST = la::IndexSpace<loop_tag, la::inner_tag::memory>;
+    constexpr auto inner_tag =
+        parthenon::ENABLE_GPU ? la::inner_tag::logical_flat : la::inner_tag::memory;
+    using IST = la::IndexSpace<loop_tag, inner_tag>;
 
     auto pm = md->GetParentPointer();
     const int ndim = pm->ndim;

--- a/example/fine_advection/advection_package.cpp
+++ b/example/fine_advection/advection_package.cpp
@@ -26,6 +26,7 @@
 #include "advection_package.hpp"
 #include "defs.hpp"
 #include "kokkos_abstraction.hpp"
+#include "loop_abstraction/loop_abstraction.hpp"
 #include "reconstruct/dc_inline.hpp"
 #include "utils/error_checking.hpp"
 
@@ -81,6 +82,11 @@ std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin) {
     std::vector<int> sparse_idxs(sparse_size);
     std::iota(sparse_idxs.begin(), sparse_idxs.end(), 0);
     pkg->AddSparsePool<Conserved::phi>(m, sparse_idxs);
+
+    m = Metadata(
+        {Metadata::Node, Metadata::Derived, Metadata::Sparse, Metadata::CellMemAligned},
+        std::vector<int>{shape_size});
+    pkg->AddSparsePool<Derived::phi_nodal>(m, Conserved::phi::name(), sparse_idxs);
   }
 
   bool do_fine_advection = pin->GetOrAddBoolean("Advection", "do_fine_advection", true);
@@ -207,9 +213,10 @@ Real EstimateTimestep(MeshData<Real> *md) {
 
 TaskStatus FillDerived(MeshData<Real> *md) {
   auto desc =
-      parthenon::MakePackDescriptor<Conserved::phi_fine, Conserved::phi_fine_restricted,
-                                    Conserved::C, Conserved::C_cc, Conserved::D,
-                                    Conserved::D_cc, Conserved::divC, Conserved::divD>(
+      parthenon::MakePackDescriptor<Conserved::phi, Conserved::phi_fine,
+                                    Conserved::phi_fine_restricted, Conserved::C,
+                                    Conserved::C_cc, Conserved::D, Conserved::D_cc,
+                                    Conserved::divC, Conserved::divD, Derived::phi_nodal>(
           md);
   auto pack = desc.GetPack(md);
 
@@ -221,6 +228,60 @@ TaskStatus FillDerived(MeshData<Real> *md) {
   IndexRange kb = md->GetBoundsK(IndexDomain::interior);
   const int ndim = md->GetMeshPointer()->ndim;
   const int nghost = parthenon::Globals::nghost;
+
+  auto do_regular_advection = pkg->Param<bool>("do_regular_advection");
+  if (do_regular_advection) {
+    // in general you'd add helpers for this boilerplate
+    namespace la = parthenon::loop_abstraction;
+    const la::NInner ninner = la::chunk_shape::ij_slab;
+    constexpr auto loop_tag =
+        parthenon::ENABLE_GPU ? la::loop_tag::boiv : la::loop_tag::bovi;
+    using IST = la::IndexSpace<loop_tag, la::inner_tag::memory>;
+
+    auto pm = md->GetParentPointer();
+    const int ndim = pm->ndim;
+
+    // We can use cell-centered topological elements because nodes are cell memaligned
+    // here
+    IST idx_space(ninner, IndexDomain::interior, 0, pack.GetNBlocks(), md,
+                  // logically nodes, but underlying memory is cell-shaped
+                  parthenon::TopologicalElement::NN, parthenon::TopologicalElement::CC);
+    auto di = idx_space.GetDelta(X1DIR);
+    auto dj = idx_space.GetDelta(X2DIR);
+    auto dk = idx_space.GetDelta(X3DIR);
+
+    // Average cell centered phi values to nodes, using the new loop abstraction for fun
+    la::outer(
+        idx_space, KOKKOS_LAMBDA(const IST::idx_range_t &idx_range, int b) {
+          const int nvar = pack.GetSize(b, Conserved::phi());
+          const Real weight = (ndim > 2) ? 0.125 : (ndim > 1) ? 0.25 : 0.5;
+          for (int n = 0; n < nvar; ++n) {
+            auto pvn = la::make_sparse_pack_view(idx_range, pack, n);
+
+            la::inner(idx_range, [&](const auto kji) {
+              pvn(Derived::phi_nodal(), kji) =
+                  pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - di);
+            });
+            idx_range.TeamBarrier();
+            if (ndim > 1) {
+              la::inner(idx_range, [&](const auto kji) {
+                pvn(Derived::phi_nodal(), kji) +=
+                    (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - dj));
+              });
+              idx_range.TeamBarrier();
+            }
+            if (ndim > 2) {
+              la::inner(idx_range, [&](const auto kji) {
+                pvn(Derived::phi_nodal(), kji) +=
+                    (pvn(Conserved::phi(), kji) + pvn(Conserved::phi(), kji - dk));
+              });
+              idx_range.TeamBarrier();
+            }
+            la::inner(idx_range,
+                      [&](const auto kji) { pvn(Derived::phi_nodal(), kji) *= weight; });
+          }
+        });
+  }
 
   auto do_fine_advection = pkg->Param<bool>("do_fine_advection");
   if (do_fine_advection) {

--- a/example/fine_advection/advection_package.hpp
+++ b/example/fine_advection/advection_package.hpp
@@ -22,30 +22,45 @@
 #include <utils/indexer.hpp>
 #include <utils/robust.hpp>
 
-#define VARIABLE(ns, varname)                                                            \
+#define VARIABLE(ns, varname, sparse)                                                    \
   struct varname : public parthenon::variable_names::base_t<false> {                     \
     template <class... Ts>                                                               \
     KOKKOS_INLINE_FUNCTION varname(Ts &&...args)                                         \
         : parthenon::variable_names::base_t<false>(std::forward<Ts>(args)...) {}         \
     static std::string name() { return #ns "." #varname; }                               \
+    static constexpr bool is_sparse() { return sparse; }                                 \
+  }
+#define NODE_VARIABLE(ns, varname, sparse)                                               \
+  struct varname : public parthenon::variable_names::base_w_tt_t<                        \
+                       false, parthenon::TopologicalType::Node> {                        \
+    template <class... Ts>                                                               \
+    KOKKOS_INLINE_FUNCTION varname(Ts &&...args)                                         \
+        : parthenon::variable_names::base_w_tt_t<false,                                  \
+                                                 parthenon::TopologicalType::Node>(      \
+              std::forward<Ts>(args)...) {}                                              \
+    static std::string name() { return #ns "." #varname; }                               \
+    static constexpr bool is_sparse() { return sparse; }                                 \
   }
 
 namespace advection_package {
 using namespace parthenon::package::prelude;
 
 namespace Conserved {
-VARIABLE(advection, phi);
-VARIABLE(advection, phi_fine);
-VARIABLE(advection, phi_fine_restricted);
-VARIABLE(advection, C);
-VARIABLE(advection, D);
-VARIABLE(advection, recon);
-VARIABLE(advection, recon_f);
-VARIABLE(advection, C_cc);
-VARIABLE(advection, D_cc);
-VARIABLE(advection, divC);
-VARIABLE(advection, divD);
+VARIABLE(advection, phi, true);
+VARIABLE(advection, phi_fine, false);
+VARIABLE(advection, phi_fine_restricted, false);
+VARIABLE(advection, C, false);
+VARIABLE(advection, D, false);
+VARIABLE(advection, recon, false);
+VARIABLE(advection, recon_f, false);
+VARIABLE(advection, C_cc, false);
+VARIABLE(advection, D_cc, false);
+VARIABLE(advection, divC, false);
+VARIABLE(advection, divD, false);
 } // namespace Conserved
+namespace Derived {
+NODE_VARIABLE(advection, phi_nodal, true);
+} // namespace Derived
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 AmrTag CheckRefinement(MeshBlockData<Real> *rc);

--- a/example/fine_advection/advection_package.hpp
+++ b/example/fine_advection/advection_package.hpp
@@ -58,9 +58,9 @@ VARIABLE(advection, D_cc, false);
 VARIABLE(advection, divC, false);
 VARIABLE(advection, divD, false);
 } // namespace Conserved
-namespace Derived {
-NODE_VARIABLE(advection, phi_nodal, true);
-} // namespace Derived
+namespace Nodal {
+NODE_VARIABLE(nodal, phi, true);
+} // namespace Nodal
 
 std::shared_ptr<StateDescriptor> Initialize(ParameterInput *pin);
 AmrTag CheckRefinement(MeshBlockData<Real> *rc);

--- a/example/fine_advection/parthinput.advection
+++ b/example/fine_advection/parthinput.advection
@@ -71,4 +71,4 @@ dt = 0.05
 <parthenon/output0>
 file_type = hdf5
 dt = 0.05
-variables = advection.phi, advection.phi_fine_restricted, phi_nodal
+variables = advection.phi, nodal.phi

--- a/example/fine_advection/parthinput.advection
+++ b/example/fine_advection/parthinput.advection
@@ -71,4 +71,4 @@ dt = 0.05
 <parthenon/output0>
 file_type = hdf5
 dt = 0.05
-variables = advection.scalar, advection.scalar_fine_restricted
+variables = advection.phi, advection.phi_fine_restricted, phi_nodal

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -109,7 +109,6 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
                                   [](const auto &v) { return v.is_coordinate_field; });
     const int ndim_mesh = (nx3 > 1) + (nx2 > 1) + (nx1 > 1);
     const bool is_2d = (ndim_mesh == 2);
-    const bool is_1d = (ndim_mesh == 1);
     const bool output_coords = (ndim_mesh > 1) && (coords_it != var_list.end());
     if ((coords_it != var_list.end()) && (ndim_mesh < 2) && (Globals::my_rank == 0)) {
       PARTHENON_WARN(
@@ -118,6 +117,7 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
     }
     // TODO(JMM): This warning is probably sufficiently annoying we
     // should suppress it, but this is true.
+    // const bool is_1d = (ndim_mesh == 1);
     // if (is_1d) {
     //   PARTHENON_DEBUG_WARN("1D output in XDMF can be ill-behaved. Use with caution.");
     // }
@@ -165,6 +165,8 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
       xdmf << StringPrintf("    <Grid GridType=\"Uniform\" Name=\"%d\">\n", ib);
       xdmf << StringPrintf("      <Topology TopologyType=\"%s\" Dimensions=\"%s\"/>\n",
                            mesh_type.c_str(), dimstring.c_str());
+      // JMM: Unfortunately xdmf assumes 2D+ so VX doesn't exist and
+      // we can't special case for 1D.
       xdmf << StringPrintf("      <Geometry GeometryType=\"%s\">\n",
                            output_coords ? "X_Y_Z" : (is_2d ? "VXVY" : "VXVYVZ"));
       if (output_coords) {

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -3,7 +3,7 @@
 // Copyright(C) 2023-2024 The Parthenon collaboration
 // Licensed under the 3-clause BSD License, see LICENSE file for details
 //========================================================================================
-// (C) (or copyright) 2020-2024. Triad National Security, LLC. All rights reserved.
+// (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 //
 // This program was produced under U.S. Government contract 89233218CNA000001 for Los
 // Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -14,6 +14,8 @@
 // license in this material to reproduce, prepare derivative works, distribute copies to
 // the public, perform publicly and display publicly, and to permit others to do so.
 //========================================================================================
+
+// This file was made in part with the assistance of generative AI.
 
 // options for building
 #include "config.hpp"
@@ -106,12 +108,19 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
     auto coords_it = std::find_if(var_list.begin(), var_list.end(),
                                   [](const auto &v) { return v.is_coordinate_field; });
     const int ndim_mesh = (nx3 > 1) + (nx2 > 1) + (nx1 > 1);
+    const bool is_2d = (ndim_mesh == 2);
+    const bool is_1d = (ndim_mesh == 1);
     const bool output_coords = (ndim_mesh > 1) && (coords_it != var_list.end());
     if ((coords_it != var_list.end()) && (ndim_mesh < 2) && (Globals::my_rank == 0)) {
       PARTHENON_WARN(
           "Custom coordinates not supported in XDMF for 1D meshes. Reverting to "
-          "3DRectMesh");
+          "RectMesh");
     }
+    // TODO(JMM): This warning is probably sufficiently annoying we
+    // should suppress it, but this is true.
+    // if (is_1d) {
+    //   PARTHENON_DEBUG_WARN("1D output in XDMF can be ill-behaved. Use with caution.");
+    // }
 
     // open file
     xdmf = std::ofstream(filename_aux.c_str(), std::ofstream::trunc);
@@ -145,6 +154,9 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
       } else {
         PARTHENON_FAIL("Custom coordinates not supported in XDMF for 1D meshes.");
       }
+    } else if (is_2d) {
+      mesh_type = "2DRectMesh";
+      dimstring = StringPrintf("%d %d", nx2 + 1, nx1 + 1);
     } else {
       mesh_type = "3DRectMesh";
       dimstring = StringPrintf("%d %d %d", nx3 + n3_offset, nx2 + n2_offset, nx1 + 1);
@@ -154,7 +166,7 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
       xdmf << StringPrintf("      <Topology TopologyType=\"%s\" Dimensions=\"%s\"/>\n",
                            mesh_type.c_str(), dimstring.c_str());
       xdmf << StringPrintf("      <Geometry GeometryType=\"%s\">\n",
-                           output_coords ? "X_Y_Z" : "VXVYVZ");
+                           output_coords ? "X_Y_Z" : (is_2d ? "VXVY" : "VXVYVZ"));
       if (output_coords) {
         ndim = coords_it->FillShape<hsize_t>(domain, &(dims[1])) + 1;
         for (int d = 0; d < 3; ++d) {
@@ -175,7 +187,9 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
       } else {
         BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx1, hdfFile, "x");
         BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx2, hdfFile, "y");
-        BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx3, hdfFile, "z");
+        if (!is_2d) {
+          BlockCoordRegularRef(xdmf, pm->nbtotal, ib, nx3, hdfFile, "z");
+        }
       }
       xdmf << "      </Geometry>" << std::endl;
 
@@ -193,7 +207,7 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
         const int num_components = vinfo.num_components;
         writeXdmfSlabVariableRef(xdmf, vinfo.label, vinfo.component_labels, hdfFile, ib,
                                  num_components, ndim, dims, dims[ndim - 3],
-                                 dims[ndim - 2], dims[ndim - 1], output_coords,
+                                 dims[ndim - 2], dims[ndim - 1], output_coords || is_2d,
                                  vinfo.is_vector, vinfo.where);
       }
       xdmf << "    </Grid>" << std::endl;

--- a/src/outputs/parthenon_xdmf.cpp
+++ b/src/outputs/parthenon_xdmf.cpp
@@ -191,11 +191,9 @@ void genXDMF(std::string hdfFile, Mesh *pm, SimTime *tm, IndexDomain domain, int
         }
         ndim = vinfo.FillShape<hsize_t>(domain, &(dims[1])) + 1;
         const int num_components = vinfo.num_components;
-        nx3 = dims[ndim - 3];
-        nx2 = dims[ndim - 2];
-        nx1 = dims[ndim - 1];
         writeXdmfSlabVariableRef(xdmf, vinfo.label, vinfo.component_labels, hdfFile, ib,
-                                 num_components, ndim, dims, nx3, nx2, nx1, output_coords,
+                                 num_components, ndim, dims, dims[ndim - 3],
+                                 dims[ndim - 2], dims[ndim - 1], output_coords,
                                  vinfo.is_vector, vinfo.where);
       }
       xdmf << "    </Grid>" << std::endl;

--- a/src/parameter_input.hpp
+++ b/src/parameter_input.hpp
@@ -113,7 +113,16 @@ struct QueryRecord {
       T t;
       return typeid(t).name();
     } else if constexpr (std::is_same_v<T, std::vector<typename T::value_type>>) {
-      return "std::vector<" + GetTypeName<typename T::value_type>() + ">";
+      // Build up the name with append rather than a chained operator+. GCC 15's
+      // -Wstringop-overflow constant-folds the concatenated literal (e.g.
+      // "std::vector<string>", 19 bytes) and, after aggressive inlining, wrongly
+      // assumes it targets std::string's 16-byte SSO buffer instead of the heap,
+      // emitting a false-positive overflow warning. Building the string
+      // incrementally avoids that spurious analysis.
+      std::string s = "std::vector<";
+      s += GetTypeName<typename T::value_type>();
+      s += ">";
+      return s;
     } else {
       if (Globals::my_rank == 0) {
         PARTHENON_WARN("Unknown non-arithmetic type! Attempting to use typeid, which is "

--- a/tst/regression/test_suites/restart_fine/parthinput.restart_fine
+++ b/tst/regression/test_suites/restart_fine/parthinput.restart_fine
@@ -67,3 +67,5 @@ dt = 0.05
 file_type = hdf5
 dt = 0.25
 variables = advection.C
+variables = advection.phi
+variables = nodal.phi

--- a/tst/regression/test_suites/restart_fine/parthinput.restart_fine
+++ b/tst/regression/test_suites/restart_fine/parthinput.restart_fine
@@ -66,6 +66,4 @@ dt = 0.05
 <parthenon/output2>
 file_type = hdf5
 dt = 0.25
-variables = advection.C
-variables = advection.phi
-variables = nodal.phi
+variables = advection.C, advection.phi, nodal.phi

--- a/tst/regression/test_suites/restart_fine/parthinput.restart_fine
+++ b/tst/regression/test_suites/restart_fine/parthinput.restart_fine
@@ -66,4 +66,4 @@ dt = 0.05
 <parthenon/output2>
 file_type = hdf5
 dt = 0.25
-variables = advection.C, advection.phi, nodal.phi
+variables = advection.C, advection.phi, nodal.phi, advection.phi_fine_restricted, advection.phi_fine

--- a/tst/regression/test_suites/restart_fine/restart_fine.py
+++ b/tst/regression/test_suites/restart_fine/restart_fine.py
@@ -1,9 +1,9 @@
 # ========================================================================================
 # Parthenon performance portable AMR framework
-# Copyright(C) 2020-2024 The Parthenon collaboration
+# Copyright(C) 2020-2026 The Parthenon collaboration
 # Licensed under the 3-clause BSD License, see LICENSE file for details
 # ========================================================================================
-# (C) (or copyright) 2020-2021. Triad National Security, LLC. All rights reserved.
+# (C) (or copyright) 2020-2026. Triad National Security, LLC. All rights reserved.
 #
 # This program was produced under U.S. Government contract 89233218CNA000001 for Los
 # Alamos National Laboratory (LANL), which is operated by Triad National Security, LLC
@@ -15,13 +15,185 @@
 # the public, perform publicly and display publicly, and to permit others to do so.
 # ========================================================================================
 
-# Modules
-import sys
-import utils.test_case
+# This file was modified with the assistance of generative AI.
 
+# Modules
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+import h5py
+import utils.test_case
 
 # To prevent littering up imported folders with .pyc files or __pycache_ folder
 sys.dont_write_bytecode = True
+
+
+def check_xdmf_geometry(hdf_filename, expected_num_dims):
+    """Check that an XDMF mesh description agrees with its HDF5 file."""
+    xdmf_filename = hdf_filename + ".xdmf"
+
+    try:
+        tree = ET.parse(xdmf_filename)
+        with h5py.File(hdf_filename, "r") as hdf_file:
+            info = hdf_file["Info"]
+            num_dims = int(info.attrs["NumDims"])
+            num_blocks = int(info.attrs["NumMeshBlocks"])
+            mesh_block_size = tuple(int(n) for n in info.attrs["MeshBlockSize"])
+            location_shapes = {
+                axis: hdf_file[f"Locations/{axis}"].shape
+                for axis in ("x", "y", "z")[:num_dims]
+            }
+    except (ET.ParseError, KeyError, OSError) as error:
+        print(f"ERROR: Could not read XDMF/HDF5 geometry: {error}")
+        return False
+
+    success = True
+    if num_dims != expected_num_dims:
+        print(
+            f"ERROR: Expected a {expected_num_dims}D HDF5 mesh, but {hdf_filename} "
+            f"reports NumDims={num_dims}."
+        )
+        success = False
+
+    if num_dims not in (2, 3):
+        print(f"ERROR: XDMF geometry check does not support NumDims={num_dims}.")
+        return False
+
+    collection = tree.find("./Domain/Grid")
+    if collection is None:
+        print(f"ERROR: Could not find the mesh collection in {xdmf_filename}.")
+        return False
+
+    grids = collection.findall("./Grid[@GridType='Uniform']")
+    if len(grids) != num_blocks:
+        print(
+            f"ERROR: {xdmf_filename} contains {len(grids)} mesh blocks, but "
+            f"{hdf_filename} reports {num_blocks}."
+        )
+        success = False
+
+    expected_topology_type = f"{num_dims}DRectMesh"
+    expected_topology_dims = tuple(n + 1 for n in reversed(mesh_block_size[:num_dims]))
+    expected_geometry_type = {2: "VXVY", 3: "VXVYVZ"}[num_dims]
+    axes = ("x", "y", "z")[:num_dims]
+
+    for block_index, grid in enumerate(grids):
+        topology = grid.find("Topology")
+        geometry = grid.find("Geometry")
+        block_name = grid.get("Name", str(block_index))
+
+        if topology is None or geometry is None:
+            print(f"ERROR: XDMF block {block_name} is missing topology or geometry.")
+            success = False
+            continue
+
+        topology_type = topology.get("TopologyType")
+        if topology_type != expected_topology_type:
+            print(
+                f"ERROR: XDMF block {block_name} has TopologyType={topology_type}; "
+                f"expected {expected_topology_type}."
+            )
+            success = False
+
+        try:
+            topology_dims = tuple(
+                int(n) for n in topology.get("Dimensions", "").split()
+            )
+        except ValueError:
+            topology_dims = ()
+        if topology_dims != expected_topology_dims:
+            print(
+                f"ERROR: XDMF block {block_name} has topology dimensions "
+                f"{topology_dims}; expected {expected_topology_dims} from the HDF5 "
+                f"MeshBlockSize {mesh_block_size}."
+            )
+            success = False
+
+        geometry_type = geometry.get("GeometryType")
+        if geometry_type != expected_geometry_type:
+            print(
+                f"ERROR: XDMF block {block_name} has GeometryType={geometry_type}; "
+                f"expected {expected_geometry_type}."
+            )
+            success = False
+
+        coordinate_slabs = geometry.findall("./DataItem")
+        if len(coordinate_slabs) != num_dims:
+            print(
+                f"ERROR: XDMF block {block_name} contains {len(coordinate_slabs)} "
+                f"coordinate arrays; expected {num_dims}."
+            )
+            success = False
+
+        for axis_index, (axis, slab) in enumerate(zip(axes, coordinate_slabs)):
+            expected_slab_dims = (mesh_block_size[axis_index] + 1,)
+            try:
+                slab_dims = tuple(int(n) for n in slab.get("Dimensions", "").split())
+            except ValueError:
+                slab_dims = ()
+            if slab_dims != expected_slab_dims:
+                print(
+                    f"ERROR: XDMF block {block_name} coordinate {axis} has dimensions "
+                    f"{slab_dims}; expected {expected_slab_dims}."
+                )
+                success = False
+
+            selector_items = [
+                item for item in slab.findall("DataItem") if item.get("Format") == "XML"
+            ]
+            expected_selector = (
+                block_index,
+                0,
+                1,
+                1,
+                1,
+                expected_slab_dims[0],
+            )
+            try:
+                selector = tuple(int(n) for n in selector_items[0].text.split())
+            except (AttributeError, IndexError, ValueError):
+                selector = ()
+            if len(selector_items) != 1 or selector != expected_selector:
+                print(
+                    f"ERROR: XDMF block {block_name} coordinate {axis} has hyperslab "
+                    f"selector {selector}; expected {expected_selector}."
+                )
+                success = False
+
+            hdf_items = [
+                item for item in slab.findall("DataItem") if item.get("Format") == "HDF"
+            ]
+            if len(hdf_items) != 1:
+                print(
+                    f"ERROR: XDMF block {block_name} coordinate {axis} does not have "
+                    f"exactly one HDF5 reference."
+                )
+                success = False
+                continue
+
+            hdf_item = hdf_items[0]
+            try:
+                hdf_dims = tuple(int(n) for n in hdf_item.get("Dimensions", "").split())
+            except ValueError:
+                hdf_dims = ()
+            if hdf_dims != location_shapes[axis]:
+                print(
+                    f"ERROR: XDMF block {block_name} coordinate {axis} reports HDF5 "
+                    f"dimensions {hdf_dims}; dataset Locations/{axis} has shape "
+                    f"{location_shapes[axis]}."
+                )
+                success = False
+
+            expected_reference = f"{os.path.basename(hdf_filename)}:/Locations/{axis}"
+            if (hdf_item.text or "").strip() != expected_reference:
+                print(
+                    f"ERROR: XDMF block {block_name} coordinate {axis} references "
+                    f"{(hdf_item.text or '').strip()}; expected {expected_reference}."
+                )
+                success = False
+
+    return success
 
 
 class TestCase(utils.test_case.TestCaseAbs):
@@ -115,5 +287,6 @@ class TestCase(utils.test_case.TestCaseAbs):
         # compare a few files throughout the simulations
         success &= compare_files("final", "silver")
         success &= compare_files("final", "silver_coalesced")
+        success &= check_xdmf_geometry("gold.out2.00000.phdf", expected_num_dims=2)
 
         return success

--- a/tst/regression/test_suites/restart_fine/restart_fine.py
+++ b/tst/regression/test_suites/restart_fine/restart_fine.py
@@ -227,7 +227,7 @@ class TestCase(utils.test_case.TestCaseAbs):
                 "parthenon/output1/file_type=hdf5",
                 "parthenon/output1/dt=0.25",
                 "parthenon/output1/last_time=0.25",
-                "parthenon/output1/variables=advection.C",
+                "parthenon/output1/variables=advection.C, advection.phi, nodal.phi, advection.phi_fine_restricted, advection.phi_fine",
             ]
         return parameters
 


### PR DESCRIPTION
<!--Provide a general summary of your changes in the title above, for
example "Add AMR unit test for cell centered fields.".  Please avoid
non-descriptive titles such as "Addresses issue #8576".-->

## PR Summary

Recently @jdolence noticed that including nodal fields in *any* HDF5 output broke visit for *all* fields. The reason for this was what must have been a long persistent bug, where the x1,x2,x3 values were reset per block for the variables, and this polluted the geometry logic.

There's also been a persistent issue/complaint that nodal fields (even when displayed) displayed weirdly, often on the back side of a 3D image. This was because xdmf distinguishes between 2D and 3D meshes, while parthenon does not. To resolve this, I add logic to switch between 2DRectMesh and 3DRectMesh the same way we do for custom user coordinates. This resolves the issue so that now Visit and Paraview correctly plot nodal and cell fields in 2D and 3D.

To test all of this, I add a nodal field to the output of the fine advection example, which I fill by averaging in FillDerived. I also add some Python based xml parsing to the restart_fine regression test to ensure this continues to work (as long as we continue to care about xdmf at least... It's days may be numbered.)

For fun, I fill that field with @lroberts36 's new loop abstraction. So there's now a functioning, live example of how to use it.

<!--Please provide at least 1-2 sentences describing the pull request in
detail.  Why is this change required?  What problem does it solve?-->

<!--If it fixes an open issue, please link to the issue here.-->

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [x] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [x] (@lanl.gov employees) Update copyright on changed files
