### PR TITLE
Fix loop abstraction `bvoi` scratch bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1435]](https://github.com/parthenon-hpc-lab/parthenon/pull/1435) Fix loop abstraction scratch sizing for multi-axis (corner) halos
 - [[PR 1430]](https://github.com/parthenon-hpc-lab/parthenon/pull/1430) Fix BiCGSTAB returning NaN when a solve converges in its first half step
 - [[PR 1412]](https://github.com/parthenon-hpc-lab/parthenon/pull/1412) Fix single precision compilation with `Real=float`
 - [[PR 1411]](https://github.com/parthenon-hpc-lab/parthenon/pull/1411) Fix bug where ParameterInput::GetOrAddVector<std::string> was ambiguous

--- a/doc/loop_abstraction/loop_abstraction.tex
+++ b/doc/loop_abstraction/loop_abstraction.tex
@@ -106,8 +106,8 @@ The loop abstraction exists to close that gap. A kernel declares \emph{what}
 index space it covers and \emph{how} its variables are laid out; a small set of
 compile-time tags then selects the concrete loop structure. The intent is that a
 single kernel body can be compiled into either a CPU-friendly hierarchical form
-that stores and reuses intermediate results, or a GPU-friendly flat form that
-recomputes them, with no change to the physics code.
+that computes intermediate results once and stores them, or a GPU-friendly flat
+form that recomputes them on demand, with no change to the physics code.
 
 This document is organized around that claim. Section~\ref{sec:motivation}
 develops a single motivating kernel and writes it out by hand twice, once for each
@@ -148,22 +148,25 @@ Consider the flux computation in a directionally-split Godunov scheme, for the
 $x_1$ sweep. For each cell we need the flux $F_{i-1/2}$ on its lower $x_1$ face.
 The standard recipe is:
 \begin{enumerate}
-\item \textbf{Reconstruct} the left and right interface states at each face
-  $i-1/2$ from a stencil of cell-centered values --- e.g.\ for a three-point
-  reconstruction, $q_{i-1}, q_i, q_{i+1}$ contribute to the states at face
-  $i-1/2$. Call the resulting one-sided states $q^{+}_{i-1/2}$ (extrapolated from
-  the left) and $q^{-}_{i-1/2}$ (extrapolated from the right).
-\item \textbf{Solve a Riemann problem} at each face from the two one-sided states:
-  $F_{i-1/2} = \mathcal{R}\!\left(q^{+}_{i-1/2}, q^{-}_{i-1/2}\right)$.
+\item \textbf{Reconstruct}, for each cell $i$, the two one-sided interface states on
+  its faces. A reconstruction reads a stencil of cell-centered values around cell
+  $i$ --- e.g.\ $q_{i-1}, q_i, q_{i+1}$ for a three-point scheme --- forms a single
+  slope, and applies it toward each face, giving the state $q^{+}_i$ extrapolated to
+  the cell's upper face ($i+1/2$) and $q^{-}_i$ to its lower face ($i-1/2$). Both
+  states come from the \emph{same} stencil read and slope, so a cell naturally
+  produces them together.
+\item \textbf{Solve a Riemann problem} at each face from the two states that meet
+  there --- the upper-face state of the cell below and the lower-face state of the
+  cell above: $F_{i-1/2} = \mathcal{R}\!\left(q^{+}_{i-1}, q^{-}_i\right)$.
 \end{enumerate}
 
-The key structural observation is that \emph{a reconstructed state is used
-twice}. The state $q^{\pm}_{i-1/2}$ produced at face $i-1/2$ feeds the Riemann
-solve at that face; but the reconstruction machinery that produces the states at
-face $i-1/2$ also produces (or shares most of its work with) the states at the
-neighboring face $i+1/2$. Whether it is worth \emph{storing} a reconstructed state
-so the neighbor can reuse it, or simply \emph{recomputing} it, is precisely the
-decision that differs between CPU and GPU. The next two subsections write the
+The key structural observation is that \emph{a cell's two states are computed from
+one shared slope}, and that slope is then needed at \emph{both} of the cell's faces:
+the Riemann solve above cell $i$ reads its $q^{+}_i$, and the one below reads its
+$q^{-}_i$. Whether it is worth reconstructing each cell once and \emph{storing} both
+states so the two flanking Riemann solves can read them, or simply
+\emph{recomputing} a cell's slope separately at each face that needs it, is precisely
+the decision that differs between CPU and GPU. The next two subsections write the
 kernel out both ways.
 
 Throughout, $q$ is a cell-centered field, and we compute the $x_1$ flux
@@ -178,20 +181,21 @@ On a CPU the dominant concerns are (i) keeping the innermost loop long,
 unit-stride, and vectorizable, and (ii) not repeating expensive arithmetic. Both
 push toward a \emph{hierarchical} structure: an outer loop that walks planes or
 pencils of the block, and an inner loop that sweeps contiguously along $x_1$.
-Reconstruction is done \emph{once per face} and stored in a scratch buffer; the
-flux loop then reads two neighboring scratch entries per face.
+Reconstruction is done \emph{once per cell} and both of that cell's states are
+stored in scratch; the flux loop then reads the two states that meet at each face.
 
 \begin{lstlisting}
-// CPU-style: reconstruct once into scratch, reuse for the flux.
+// CPU-style: reconstruct each cell once into scratch, then solve the fluxes.
 for (int k = kb.s; k <= kb.e; ++k) {
   for (int j = jb.s; j <= jb.e; ++j) {
 
-    // scratch spans [is-1, ie]: one extra face on the low side, because the
-    // flux at face i reads the reconstructed state at face i-1 as well.
-    Real *qp = scratch_plus_row(k, j);   // q^+ at each face in this row
-    Real *qm = scratch_minus_row(k, j);  // q^-
+    // scratch spans [is-1, ie]: one extra cell on the low side, because the
+    // flux at face i reads the upper-face state q^+ of the cell at i-1.
+    Real *qp = scratch_plus_row(k, j);   // q^+ (upper-face state) of each cell
+    Real *qm = scratch_minus_row(k, j);  // q^- (lower-face state) of each cell
 
-    // Producer: reconstruct every face in the (extended) row exactly once.
+    // Producer: reconstruct every cell in the (extended) row exactly once. One
+    // stencil read and slope per cell yields both of its one-sided states.
     const Real *q_row = &q(k, j, 0);
     #pragma omp simd
     for (int i = is - 1; i <= ie; ++i) {
@@ -199,11 +203,12 @@ for (int k = kb.s; k <= kb.e; ++k) {
       qm[i] = reconstruct_minus(q_row[i-1], q_row[i], q_row[i+1]);
     }
 
-    // Consumer: one Riemann solve per face, reading neighboring scratch.
+    // Consumer: one Riemann solve per face, from the two cells' states that meet
+    // there -- the upper-face state of cell i-1 and the lower-face state of cell i.
     Real *F_row = &F(k, j, 0);
     #pragma omp simd
     for (int i = is; i <= ie; ++i) {
-      F_row[i] = riemann(qp[i-1], qm[i]);   // <-- reuse of qp at face i-1
+      F_row[i] = riemann(qp[i-1], qm[i]);
     }
   }
 }
@@ -213,12 +218,16 @@ Three features matter and will reappear as abstraction concepts:
 \begin{itemize}
 \item \textbf{Two loops over nearly the same range.} The producer runs over
   $[i_s-1, i_e]$ and the consumer over $[i_s, i_e]$. The producer's range is the
-  consumer's range \emph{plus one extra face on the low side}, because
+  consumer's range \emph{plus one extra cell on the low side}, because
   \code{riemann(qp[i-1], qm[i])} reads a produced value at $i-1$. That ``one
-  extra face'' is exactly what a \emph{halo} will name (Section~\ref{sec:halos}).
-\item \textbf{Scratch reuse.} Each reconstructed state is computed once and read
-  by (up to) two Riemann solves. The scratch buffer is sized to the extended
-  producer range.
+  extra cell'' is exactly what a \emph{halo} will name (Section~\ref{sec:halos}).
+\item \textbf{Compute-once, read-twice \emph{work}.} Each cell's reconstruction is
+  done once and stored, but its \emph{slope} feeds the fluxes on both of the cell's
+  faces (the flux above reads $q^+$, the flux below reads $q^-$). Storing spends the
+  stencil read and slope once per cell; the flat form below repeats them at each
+  face. Each stored state itself is read exactly once --- it is the per-cell
+  \emph{work}, not any one value, that is shared. The scratch buffer is sized to the
+  extended producer range.
 \item \textbf{Contiguous inner loops.} Both inner loops are unit-stride in $i$
   and marked for SIMD; \code{q_row}, \code{qp}, \code{qm} are raw pointers so the
   compiler sees \code{a[i]}-style access. The row shown here is one $i$-pencil, but
@@ -248,18 +257,19 @@ directly through the pack.
 // GPU-style: one thread per face, recompute reconstruction, no scratch.
 par_for(is, ie, jb.s, jb.e, kb.s, kb.e,
   KOKKOS_LAMBDA(const int k, const int j, const int i) {
-    // This face needs q^+ from face i-1 and q^- from face i.
+    // Face i needs cell i-1's upper-face state and cell i's lower-face state.
     const Real qp_im1 = reconstruct_plus (q(k,j,i-2), q(k,j,i-1), q(k,j,i));
     const Real qm_i   = reconstruct_minus(q(k,j,i-1), q(k,j,i), q(k,j,i+1));
     F(k, j, i) = riemann(qp_im1, qm_i);
   });
 \end{lstlisting}
 
-Here \code{reconstruct_plus} at face $i-1$ is computed independently by the thread
-that owns face $i-1$ as well --- the value is produced twice, once per consuming
-face. That redundant arithmetic is deliberate: it buys a flat, barrier-free,
-single-level parallel loop with direct field access and no shared-memory
-bookkeeping.
+Here cell $i-1$'s slope is formed twice: this thread forms it to get
+$q^{+}_{i-1}$, and the thread owning face $i-1$ forms it again to get
+$q^{-}_{i-1}$. Every cell's reconstruction is thus done by both of the threads on
+its faces, roughly doubling the reconstruction arithmetic. That redundancy is
+deliberate: it buys a flat, barrier-free, single-level parallel loop with direct
+field access and no shared-memory bookkeeping.
 
 % ---------------------------------------------------------------
 \subsection{What differs, and what does not}
@@ -268,8 +278,8 @@ bookkeeping.
 
 Comparing the two, the \emph{physics} --- \code{reconstruct_plus},
 \code{reconstruct_minus}, \code{riemann}, and the fact that the flux at a face
-reads $q^+$ from the face below and $q^-$ from the face itself --- is
-byte-for-byte identical. What differs is entirely structural:
+reads the upper-face state of the cell below and the lower-face state of the cell
+above --- is byte-for-byte identical. What differs is entirely structural:
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}
@@ -279,7 +289,8 @@ byte-for-byte identical. What differs is entirely structural:
 \midrule
 Parallelism   & hierarchical (team over planes, & flat (one thread per face) \\
               & SIMD along $i$)                 &  \\
-Intermediate  & stored in scratch, reused       & recomputed per consuming face \\
+Intermediate  & reconstructed once per cell,    & recomputed at each face \\
+              & stored in scratch               & (both faces redo the cell) \\
 Access        & raw pointers, \code{a[i]}       & direct pack access \\
 Barrier       & producer/consumer split         & none \\
 \bottomrule
@@ -310,35 +321,40 @@ touching the body.
 \begin{lstlisting}
 namespace la = parthenon::loop_abstraction;
 
-// recon_halo names the extra produced faces the flux loop will read: the flux at
-// face i reads the reconstructed q^+ at face i-1, i.e. one cell in -i.
+// recon_halo names the extra reconstructed cell the flux loop will read: the flux
+// at face i reads the upper-face state q^+ of cell i-1, i.e. one cell in -i.
 using recon_halo = la::halo::minus_i_t;
 
-// F1-face index space over the interior, backend chosen by the tags.
+// F1-face index space over the interior, backend chosen by the tags. Iterating over
+// F1 faces makes the index range include the topmost x1 face, so no flux is missed;
+// each array still reads the index by its own centering (cell-centered for the
+// reconstructed states, face for the flux).
 using idx_space_t = la::IndexSpace<LOOP_TAG, INNER_TAG>;
 idx_space_t idx_space(
     ninner, IndexDomain::interior, /*halo=*/0, pack.GetNBlocks(),
     md, TopologicalElement::F1);
-idx_space.AddPerPointScratch<Real, recon_halo>(2);   // q^+ and q^- per face
+idx_space.AddPerPointScratch<Real, recon_halo>(2);   // q^+ and q^- per cell
 
 const auto dx1 = idx_space.GetDelta(X1DIR);           // logical +1 step in x1
 
 la::outer(idx_space, KOKKOS_LAMBDA(const idx_space_t::idx_range_t &r, int b) {
-  // Extend this slice by recon_halo: the producer below now covers the flux
-  // range plus the one extra face in -i.
+  // Extend this slice by recon_halo: the producer below now covers the base
+  // cells plus the one extra cell in -i.
   const auto rp = la::AddHalo<recon_halo>(r);
   auto qp = la::GetPerPointScratch<Real>(rp);
   auto qm = la::GetPerPointScratch<Real>(rp);
   auto pv = la::make_pack_view(rp, pack);
 
-  // Producer: reconstruct over the halo-extended range.
+  // Producer: reconstruct each cell over the halo-extended range -- one stencil
+  // read and slope per cell yields both of its one-sided states.
   la::inner(rp, [&](auto f) {
     qp(f) = reconstruct_plus (pv(q(), f - dx1), pv(q(), f), pv(q(), f + dx1));
     qm(f) = reconstruct_minus(pv(q(), f - dx1), pv(q(), f), pv(q(), f + dx1));
   });
   r.TeamBarrier();  // producer must finish before the consumer reads (no-op where serial)
 
-  // Consumer: one Riemann solve per face over the base range.
+  // Consumer: one Riemann solve per face over the base range, from the two cells'
+  // states that meet there -- cell i-1's upper-face q^+ and cell i's lower-face q^-.
   auto fv = la::make_flux_pack_view(r, pack, X1DIR);
   la::inner(r, [&](auto f) {
     fv(q(), f) = riemann(qp(f - dx1), qm(f));
@@ -353,14 +369,14 @@ Now the instantiations:
   block; \code{inner} sweeps a contiguous span; \code{GetPerPointScratch} resolves
   to team scratch (Kokkos) or a host bump-arena buffer (raw), sized to the
   halo-extended producer range; the \code{TeamBarrier} separates producer and
-  consumer. The reconstructed states are stored once and reused. Choosing
-  \code{bvoi} instead keeps the whole block live per slice --- more scratch,
-  often faster (Section~\ref{sec:looptags}).
+  consumer. Each cell is reconstructed once into scratch and its two states are
+  read by the flanking flux solves. Choosing \code{bvoi} instead keeps the whole
+  block live per slice --- more scratch, often faster (Section~\ref{sec:looptags}).
 \item \code{IndexSpace<loop_tag::boiv, ...>} recovers the GPU form. \code{outer}
   is a flat grid over all $(\text{block},k,j,i)$, scratch is a tiny per-thread
   stack buffer, and the \code{TeamBarrier} is a no-op. The producer and consumer
-  run back-to-back on the same thread, so the reconstructed states are effectively
-  recomputed per face --- exactly Section~\ref{sec:gpu}. Note that here the word
+  run back-to-back on the same thread, so each cell's reconstruction is redone by
+  both of the threads on its faces --- exactly Section~\ref{sec:gpu}. Note that here the word
   \code{inner} is something of a lie: for the base (non-halo) range the
   ``\code{inner} loop'' is a single logical cell --- a one-iteration loop, i.e.\
   not really a loop at all --- and even for the halo-extended range it runs only
@@ -880,7 +896,7 @@ example, to check raw-vs-Kokkos parity on a host build where both can run.
 
 Many kernels read a cell's neighbors, whether or not scratch or halos are
 involved: a diffusion operator reads $q(f\pm\hat{\imath})$, a gradient reads
-neighbors in every direction, the flux consumer reads a produced state one face
+neighbors in every direction, the flux consumer reads a produced state one cell
 over. To do this the body needs a way to spell ``one cell over in $x_1$'' that is
 correct for whatever index form the current inner tag hands it. \code{GetDelta}
 provides exactly that, and it is a general facility --- nothing about it is tied to
@@ -932,7 +948,7 @@ halo offset agree about which directions are real.
 
 Scratch is the per-cell temporary storage a producer inner loop writes and a
 consumer inner loop reads --- the reconstructed $q^\pm$ of the flux kernel. It is
-the mechanism that makes the store-and-reuse CPU form possible, and it is sized
+the mechanism that makes the store-once CPU form possible, and it is sized
 and allocated differently for each loop path so that the same kernel text works on
 all of them.
 
@@ -1111,13 +1127,13 @@ indexed.
 % =====================================================================
 
 Recall the pattern that motivated the abstraction (Section~\ref{sec:cpu}): a
-\emph{producer} inner loop reconstructs a value at every cell and writes it into
+\emph{producer} inner loop reconstructs each cell's states and writes them into
 scratch, and a later \emph{consumer} inner loop reads that scratch back, but at
-\emph{offset} positions --- the flux at face $f$ reads the reconstructed state at
-$f$ \emph{and} at $f - \hat{\imath}$. This offset read is the whole source of the
-problem a halo solves. If both loops ran over the same set of cells $\Sset$, the
+\emph{offset} positions --- the flux at face $f$ reads the stored states of cell
+$f$ \emph{and} of cell $f - \hat{\imath}$. This offset read is the whole source of
+the problem a halo solves. If both loops ran over the same set of cells $\Sset$, the
 consumer's read at $f - \hat{\imath}$ would fall on a scratch cell the producer
-never wrote for the boundary faces of $\Sset$. The producer must therefore fill
+never wrote for the boundary cells of $\Sset$. The producer must therefore fill
 scratch not just on $\Sset$ but on $\Sset$ \emph{plus the shifted copies the
 consumer will reach into}. A halo is how the kernel declares exactly which shifted
 copies those are.
@@ -1148,9 +1164,9 @@ applying it to $\Sset$ gives the range
 \]
 In the flux kernel the consumer reads \code{qp(f - dx1)}, one cell in $-i$, so the
 type is \code{halo::minus_i_t} (offsets $\{\mathbf{0}, -\hat{\imath}\}$) and the
-range it produces is $\Sset \cup \{p - \hat{\imath} : p \in \Sset\}$ --- the flux
-faces plus one extra face below the bottom of the slice. That extra face is
-precisely the scratch cell the boundary consumer would otherwise read uninitialized.
+range it produces is $\Sset \cup \{p - \hat{\imath} : p \in \Sset\}$ --- the base
+cells plus one extra cell below the bottom of the slice. That extra cell is
+precisely the scratch entry the boundary consumer would otherwise read uninitialized.
 
 Figure~\ref{fig:halo} draws this: the type is a fixed offset stencil (the insets),
 and the range is the union of the inner range with its shifted copy (the crosses).
@@ -1181,18 +1197,18 @@ most common point of confusion. Two stencils are in play, and they are unrelated
 in size:
 \begin{itemize}
 \item The \emph{reconstruction stencil} is the set of \emph{input field} cells read
-  to compute \emph{one} reconstructed value. For a three-point reconstruction it is
-  \code{q(f-dx1)}, \code{q(f)}, \code{q(f+dx1)}; a higher-order scheme reads a wider
-  set. It lives entirely inside the producer body (the arguments to
+  to compute \emph{one} cell's reconstructed states. For a three-point reconstruction
+  it is \code{q(f-dx1)}, \code{q(f)}, \code{q(f+dx1)}; a higher-order scheme reads a
+  wider set. It lives entirely inside the producer body (the arguments to
   \code{reconstruct_plus}) and the abstraction never sees it.
 \item The \emph{halo} is the set of offsets at which the \emph{consumer} reads the
   \emph{produced scratch}. In the flux kernel that is just $\{\mathbf{0},
-  -\hat{\imath}\}$ --- the consumer reads the reconstructed state at its own face
-  and one face below --- regardless of how wide the reconstruction stencil was.
+  -\hat{\imath}\}$ --- a face reads the stored states of its own cell and of the
+  cell one step in $-i$ --- regardless of how wide the reconstruction stencil was.
 \end{itemize}
 So a wide reconstruction stencil with a one-cell halo is the common, expected case:
-reconstruction may read five input cells to produce each scratch value, but the
-flux loop still only reaches one produced face away. The halo describes the
+reconstruction may read five input cells to produce each cell's scratch states, but
+the flux loop still only reaches one produced cell away. The halo describes the
 producer/consumer \emph{coupling} through scratch, and is what determines the
 producer's iteration range; the reconstruction stencil describes the producer's own
 inputs and does not.
@@ -1312,11 +1328,12 @@ than recomputed by re-walking the spans.
 the two backends realize the identical halo semantics differently
 (Section~\ref{sec:scratch}). In a hierarchical (\code{bvoi}/\code{bovi}) loop the
 base set $\Sset$ is many cells, the halo range is the merged union above, and
-scratch is a team/host buffer over the enclosing memory span --- reconstructed
-values are computed once and reused across neighboring consumers. In the pointwise
-\code{boiv} loop $\Sset$ is a single cell, so a one-offset halo range is just
-$\{p, p+h\}$ and scratch collapses to a tiny per-thread stack array (a few
-cells); neighboring reconstructions are simply recomputed in adjacent iterations.
+scratch is a team/host buffer over the enclosing memory span --- each cell is
+reconstructed once and its stored states serve the flux solves on both of its
+faces. In the pointwise \code{boiv} loop $\Sset$ is a single cell, so a one-offset
+halo range is just $\{p, p+h\}$ and scratch collapses to a tiny per-thread stack
+array (a few cells); a cell's reconstruction is simply redone in each adjacent
+iteration that needs it.
 
 % =====================================================================
 \section{Pack, variable, and flux views}

--- a/doc/loop_abstraction/loop_abstraction.tex
+++ b/doc/loop_abstraction/loop_abstraction.tex
@@ -148,23 +148,24 @@ Consider the flux computation in a directionally-split Godunov scheme, for the
 $x_1$ sweep. For each cell we need the flux $F_{i-1/2}$ on its lower $x_1$ face.
 The standard recipe is:
 \begin{enumerate}
-\item \textbf{Reconstruct}, for each cell $i$, the two one-sided interface states on
-  its faces. A reconstruction reads a stencil of cell-centered values around cell
-  $i$ --- e.g.\ $q_{i-1}, q_i, q_{i+1}$ for a three-point scheme --- forms a single
-  slope, and applies it toward each face, giving the state $q^{+}_i$ extrapolated to
-  the cell's upper face ($i+1/2$) and $q^{-}_i$ to its lower face ($i-1/2$). Both
-  states come from the \emph{same} stencil read and slope, so a cell naturally
-  produces them together.
+\item \textbf{Reconstruct}, for each cell $i$, the two one-sided states on its two
+  faces. A reconstruction reads a stencil of cell-centered values around cell $i$ ---
+  e.g.\ $q_{i-1}, q_i, q_{i+1}$ for a three-point scheme --- forms a single slope, and
+  applies it toward each face, giving the state $q^{+}_i$ on the cell's higher-$i$
+  face ($i+1/2$) and $q^{-}_i$ on its lower-$i$ face ($i-1/2$). (Throughout, a
+  superscript $\pm$ labels which of \emph{a cell's own two faces} a state sits on ---
+  not the two sides of a single face.) Both states come from the \emph{same} stencil
+  read and slope, so a cell naturally produces them together.
 \item \textbf{Solve a Riemann problem} at each face from the two states that meet
-  there --- the upper-face state of the cell below and the lower-face state of the
-  cell above: $F_{i-1/2} = \mathcal{R}\!\left(q^{+}_{i-1}, q^{-}_i\right)$.
+  there --- the $q^{+}$ of the cell to its left and the $q^{-}$ of the cell to its
+  right: $F_{i-1/2} = \mathcal{R}\!\left(q^{+}_{i-1}, q^{-}_i\right)$.
 \end{enumerate}
 
 The key structural observation is that \emph{a cell's two states are computed from
 one shared slope}, and that slope is then needed at \emph{both} of the cell's faces:
-the Riemann solve above cell $i$ reads its $q^{+}_i$, and the one below reads its
-$q^{-}_i$. Whether it is worth reconstructing each cell once and \emph{storing} both
-states so the two flanking Riemann solves can read them, or simply
+the Riemann solve on cell $i$'s right face reads its $q^{+}_i$, and the one on its
+left face reads its $q^{-}_i$. Whether it is worth reconstructing each cell once and
+\emph{storing} both states so the two flanking Riemann solves can read them, or simply
 \emph{recomputing} a cell's slope separately at each face that needs it, is precisely
 the decision that differs between CPU and GPU. The next two subsections write the
 kernel out both ways.
@@ -190,9 +191,9 @@ for (int k = kb.s; k <= kb.e; ++k) {
   for (int j = jb.s; j <= jb.e; ++j) {
 
     // scratch spans [is-1, ie]: one extra cell on the low side, because the
-    // flux at face i reads the upper-face state q^+ of the cell at i-1.
-    Real *qp = scratch_plus_row(k, j);   // q^+ (upper-face state) of each cell
-    Real *qm = scratch_minus_row(k, j);  // q^- (lower-face state) of each cell
+    // flux at face i reads q^+ of the cell to its left (i-1).
+    Real *qp = scratch_plus_row(k, j);   // q^+ (higher-i-face state) of each cell
+    Real *qm = scratch_minus_row(k, j);  // q^- (lower-i-face state) of each cell
 
     // Producer: reconstruct every cell in the (extended) row exactly once. One
     // call forms the cell's slope and writes both one-sided states through the
@@ -204,7 +205,7 @@ for (int k = kb.s; k <= kb.e; ++k) {
     }
 
     // Consumer: one Riemann solve per face, from the two cells' states that meet
-    // there -- the upper-face state of cell i-1 and the lower-face state of cell i.
+    // there -- q^+ of the left cell (i-1) and q^- of the right cell (i).
     Real *F_row = &F(k, j, 0);
     #pragma omp simd
     for (int i = is; i <= ie; ++i) {
@@ -223,7 +224,7 @@ Three features matter and will reappear as abstraction concepts:
   extra cell'' is exactly what a \emph{halo} will name (Section~\ref{sec:halos}).
 \item \textbf{Compute-once, read-twice \emph{work}.} Each cell's reconstruction is
   done once and stored, but its \emph{slope} feeds the fluxes on both of the cell's
-  faces (the flux above reads $q^+$, the flux below reads $q^-$). Storing spends the
+  faces (the right face reads $q^+$, the left face reads $q^-$). Storing spends the
   stencil read and slope once per cell; the flat form below repeats them at each
   face. Each stored state itself is read exactly once --- it is the per-cell
   \emph{work}, not any one value, that is shared. The scratch buffer is sized to the
@@ -251,13 +252,13 @@ scheduler the most freedom to hide latency. Storing reconstructed states in
 shared memory would force a team structure and a barrier between the producer and
 consumer phases; it is usually cheaper to give each face its own thread and let it
 \emph{recompute} whatever reconstructed states it needs, reading the input field
-directly through the pack.
+directly.
 
 \begin{lstlisting}
 // GPU-style: one thread per face, recompute reconstruction, no scratch.
 par_for(is, ie, jb.s, jb.e, kb.s, kb.e,
   KOKKOS_LAMBDA(const int k, const int j, const int i) {
-    // Face i needs cell i-1's upper-face state and cell i's lower-face state.
+    // Face i needs q^+ of the left cell (i-1) and q^- of the right cell (i).
     // Each reconstruct forms one cell's slope and writes both its states; this
     // thread uses one of the two and discards the other (recomputed work).
     Real qp_im1, qm_im1;
@@ -268,12 +269,13 @@ par_for(is, ie, jb.s, jb.e, kb.s, kb.e,
   });
 \end{lstlisting}
 
-Here cell $i-1$'s reconstruction is done twice: this thread runs it and keeps
-$q^{+}_{i-1}$ (discarding $q^{-}_{i-1}$), and the thread owning face $i-1$ runs it
-again and keeps $q^{-}_{i-1}$. Every cell is thus reconstructed by both of the
-threads on its faces, roughly doubling the reconstruction arithmetic. That
-redundancy is deliberate: it buys a flat, barrier-free, single-level parallel loop
-with direct field access and no shared-memory bookkeeping.
+Here cell $i-1$'s reconstruction is done twice: this thread (face $i$) runs it and
+keeps $q^{+}_{i-1}$, discarding $q^{-}_{i-1}$; the thread for face $i-1$ makes the
+identical \code{reconstruct(q(i-2), q(i-1), q(i), ...)} call and keeps $q^{-}_{i-1}$
+instead. Every cell is thus reconstructed by both of the threads on its faces,
+roughly doubling the reconstruction arithmetic. That redundancy is deliberate: it
+buys a flat, barrier-free, single-level parallel loop with direct field access and
+no shared-memory bookkeeping.
 
 % ---------------------------------------------------------------
 \subsection{What differs, and what does not}
@@ -281,9 +283,9 @@ with direct field access and no shared-memory bookkeeping.
 % ---------------------------------------------------------------
 
 Comparing the two, the \emph{physics} --- \code{reconstruct}, \code{riemann}, and
-the fact that the flux at a face reads the upper-face state of the cell below and
-the lower-face state of the cell above --- is byte-for-byte identical. What differs
-is entirely structural:
+the fact that the flux at a face reads $q^+$ of the cell to its left and $q^-$ of
+the cell to its right --- is byte-for-byte identical. What differs is entirely
+structural:
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}
@@ -326,7 +328,7 @@ touching the body.
 namespace la = parthenon::loop_abstraction;
 
 // recon_halo names the extra reconstructed cell the flux loop will read: the flux
-// at face i reads the upper-face state q^+ of cell i-1, i.e. one cell in -i.
+// at face i reads q^+ of the cell to its left (i-1), i.e. one cell in -i.
 using recon_halo = la::halo::minus_i_t;
 
 // F1-face index space over the interior, backend chosen by the tags. Iterating over
@@ -357,7 +359,7 @@ la::outer(idx_space, KOKKOS_LAMBDA(const idx_space_t::idx_range_t &r, int b) {
   r.TeamBarrier();  // producer must finish before the consumer reads (no-op where serial)
 
   // Consumer: one Riemann solve per face over the base range, from the two cells'
-  // states that meet there -- cell i-1's upper-face q^+ and cell i's lower-face q^-.
+  // states that meet there -- q^+ of the left cell (i-1) and q^- of the right cell (i).
   auto fv = la::make_flux_pack_view(r, pack, X1DIR);
   la::inner(r, [&](auto f) {
     fv(q(), f) = riemann(qp(f - dx1), qm(f));

--- a/doc/loop_abstraction/loop_abstraction.tex
+++ b/doc/loop_abstraction/loop_abstraction.tex
@@ -195,12 +195,12 @@ for (int k = kb.s; k <= kb.e; ++k) {
     Real *qm = scratch_minus_row(k, j);  // q^- (lower-face state) of each cell
 
     // Producer: reconstruct every cell in the (extended) row exactly once. One
-    // stencil read and slope per cell yields both of its one-sided states.
+    // call forms the cell's slope and writes both one-sided states through the
+    // trailing out-pointers.
     const Real *q_row = &q(k, j, 0);
     #pragma omp simd
     for (int i = is - 1; i <= ie; ++i) {
-      qp[i] = reconstruct_plus (q_row[i-1], q_row[i], q_row[i+1]);
-      qm[i] = reconstruct_minus(q_row[i-1], q_row[i], q_row[i+1]);
+      reconstruct(q_row[i-1], q_row[i], q_row[i+1], &qp[i], &qm[i]);
     }
 
     // Consumer: one Riemann solve per face, from the two cells' states that meet
@@ -258,28 +258,32 @@ directly through the pack.
 par_for(is, ie, jb.s, jb.e, kb.s, kb.e,
   KOKKOS_LAMBDA(const int k, const int j, const int i) {
     // Face i needs cell i-1's upper-face state and cell i's lower-face state.
-    const Real qp_im1 = reconstruct_plus (q(k,j,i-2), q(k,j,i-1), q(k,j,i));
-    const Real qm_i   = reconstruct_minus(q(k,j,i-1), q(k,j,i), q(k,j,i+1));
+    // Each reconstruct forms one cell's slope and writes both its states; this
+    // thread uses one of the two and discards the other (recomputed work).
+    Real qp_im1, qm_im1;
+    reconstruct(q(k,j,i-2), q(k,j,i-1), q(k,j,i), &qp_im1, &qm_im1);  // want qp_im1
+    Real qp_i, qm_i;
+    reconstruct(q(k,j,i-1), q(k,j,i), q(k,j,i+1), &qp_i, &qm_i);      // want qm_i
     F(k, j, i) = riemann(qp_im1, qm_i);
   });
 \end{lstlisting}
 
-Here cell $i-1$'s slope is formed twice: this thread forms it to get
-$q^{+}_{i-1}$, and the thread owning face $i-1$ forms it again to get
-$q^{-}_{i-1}$. Every cell's reconstruction is thus done by both of the threads on
-its faces, roughly doubling the reconstruction arithmetic. That redundancy is
-deliberate: it buys a flat, barrier-free, single-level parallel loop with direct
-field access and no shared-memory bookkeeping.
+Here cell $i-1$'s reconstruction is done twice: this thread runs it and keeps
+$q^{+}_{i-1}$ (discarding $q^{-}_{i-1}$), and the thread owning face $i-1$ runs it
+again and keeps $q^{-}_{i-1}$. Every cell is thus reconstructed by both of the
+threads on its faces, roughly doubling the reconstruction arithmetic. That
+redundancy is deliberate: it buys a flat, barrier-free, single-level parallel loop
+with direct field access and no shared-memory bookkeeping.
 
 % ---------------------------------------------------------------
 \subsection{What differs, and what does not}
 \label{sec:differs}
 % ---------------------------------------------------------------
 
-Comparing the two, the \emph{physics} --- \code{reconstruct_plus},
-\code{reconstruct_minus}, \code{riemann}, and the fact that the flux at a face
-reads the upper-face state of the cell below and the lower-face state of the cell
-above --- is byte-for-byte identical. What differs is entirely structural:
+Comparing the two, the \emph{physics} --- \code{reconstruct}, \code{riemann}, and
+the fact that the flux at a face reads the upper-face state of the cell below and
+the lower-face state of the cell above --- is byte-for-byte identical. What differs
+is entirely structural:
 
 \begin{center}
 \begin{tabular}{@{}lll@{}}
@@ -345,11 +349,10 @@ la::outer(idx_space, KOKKOS_LAMBDA(const idx_space_t::idx_range_t &r, int b) {
   auto qm = la::GetPerPointScratch<Real>(rp);
   auto pv = la::make_pack_view(rp, pack);
 
-  // Producer: reconstruct each cell over the halo-extended range -- one stencil
-  // read and slope per cell yields both of its one-sided states.
+  // Producer: reconstruct each cell over the halo-extended range -- one call forms
+  // the cell's slope and writes both one-sided states through the out-pointers.
   la::inner(rp, [&](auto f) {
-    qp(f) = reconstruct_plus (pv(q(), f - dx1), pv(q(), f), pv(q(), f + dx1));
-    qm(f) = reconstruct_minus(pv(q(), f - dx1), pv(q(), f), pv(q(), f + dx1));
+    reconstruct(pv(q(), f - dx1), pv(q(), f), pv(q(), f + dx1), &qp(f), &qm(f));
   });
   r.TeamBarrier();  // producer must finish before the consumer reads (no-op where serial)
 
@@ -1199,8 +1202,8 @@ in size:
 \item The \emph{reconstruction stencil} is the set of \emph{input field} cells read
   to compute \emph{one} cell's reconstructed states. For a three-point reconstruction
   it is \code{q(f-dx1)}, \code{q(f)}, \code{q(f+dx1)}; a higher-order scheme reads a
-  wider set. It lives entirely inside the producer body (the arguments to
-  \code{reconstruct_plus}) and the abstraction never sees it.
+  wider set. It lives entirely inside the producer body (the field arguments to
+  \code{reconstruct}) and the abstraction never sees it.
 \item The \emph{halo} is the set of offsets at which the \emph{consumer} reads the
   \emph{produced scratch}. In the flux kernel that is just $\{\mathbf{0},
   -\hat{\imath}\}$ --- a face reads the stored states of its own cell and of the

--- a/doc/loop_abstraction/loop_abstraction.tex
+++ b/doc/loop_abstraction/loop_abstraction.tex
@@ -434,13 +434,16 @@ la::outer(idx_space, KOKKOS_LAMBDA(const idx_space_t::idx_range_t &r, int b) {
 
 The named pieces, each the subject of a subsection below, are:
 \begin{description}
-\item[\codelbl{IndexSpace<loop\_tag, inner\_tag, backend>}] The object that fixes
-  the iteration space, the memory layout, and --- through its three compile-time
+\item[\codelbl{IndexSpace<loop\_tag, inner\_tag, backend, reduction>}] The object
+  that fixes the iteration space, the memory layout, and --- through its compile-time
   tags --- the loop structure that will be generated. It is what \code{outer} is
   called on. Its index information and coordinate conventions are covered in
-  Section~\ref{sec:indexspace}; the three tags in Sections~\ref{sec:looptags}
+  Section~\ref{sec:indexspace}; the first three tags in Sections~\ref{sec:looptags}
   (\code{loop_tag}), \ref{sec:innertags} (\code{inner_tag}), and
-  \ref{sec:backends} (\code{backend}).
+  \ref{sec:backends} (\code{backend}). The trailing \code{reduction} parameter
+  defaults to a non-reducing space and is left off in the ordinary
+  \mbox{three-parameter} form; it is only supplied for the reduction paths
+  (Section~\ref{sec:reductions}).
 \item[\codelbl{outer(idx\_space, body)}] Launches the outermost loop. The body is
   a \code{KOKKOS_LAMBDA} (it is stored and invoked on the device) taking an
   \code{InnerIndexRange} and the block index.
@@ -506,10 +509,12 @@ order.
 % =====================================================================
 
 The \code{IndexSpace} is the object a kernel iterates over, and it is where the
-compile-time structure choices are recorded. Its three template parameters ---
+compile-time structure choices are recorded. Its first three template parameters ---
 \code{loop_tag}, \code{inner_tag}, and \code{loop_backend} --- are the subjects of
-the next three sections; this section describes the index information the object
-carries and the coordinate conventions every loop body relies on.
+the next three sections (a fourth, \code{reduction}, defaults to a non-reducing space
+and is deferred to Section~\ref{sec:reductions}); this section describes the index
+information the object carries and the coordinate conventions every loop body relies
+on.
 
 \paragraph{Two indexers: logical and memory.} An \code{IndexSpace} holds two
 descriptions of a block's index space:
@@ -679,14 +684,16 @@ which is why its \code{inner} is a one-iteration ``loop''
 \label{sec:selection}
 % =====================================================================
 
-The three \code{IndexSpace} template parameters --- \code{loop_tag},
-\code{inner_tag}, and \code{loop_backend} --- are what turn one kernel body into a
-specific loop structure at compile time. None of them changes what the body
-computes; together they decide how the $(b,k,j,i)$ work is nested, how a chunk is
-walked, and which backend emits the loops. They are independent axes, so any
-combination is a valid \code{IndexSpace} (with the single exception noted under
-inner tags), and switching structure is a matter of changing a tag on the
-\code{using} alias. The three subsections below take them in turn.
+The three structure-selecting \code{IndexSpace} template parameters ---
+\code{loop_tag}, \code{inner_tag}, and \code{loop_backend} --- are what turn one
+kernel body into a specific loop structure at compile time. (The fourth parameter,
+\code{reduction}, does not affect loop structure and is covered separately in
+Section~\ref{sec:reductions}.) None of them changes what the body computes; together
+they decide how the $(b,k,j,i)$ work is nested, how a chunk is walked, and which
+backend emits the loops. They are independent axes, so any combination is a valid
+\code{IndexSpace} (with the single exception noted under inner tags), and switching
+structure is a matter of changing a tag on the \code{using} alias. The three
+subsections below take them in turn.
 
 % =====================================================================
 \subsection{Loop tags: where the variable level sits}
@@ -1025,12 +1032,12 @@ la::outer(idx_space, KOKKOS_LAMBDA(const idx_space_t::idx_range_t &r, int b) {
   total.Zero();
   r.TeamBarrier();
 
-  // Component loop OUTSIDE the inner cell loop. The component bounds come from the
-  // pack for this block (a sparse variable's extent can vary block to block).
-  const int clo = pack.GetLowerBound(b, var());
-  const int chi = pack.GetUpperBound(b, var());
-  for (int c = clo; c <= chi; ++c) {
-    la::inner(r, [&](auto idx) { total(idx) += pv(c, idx); });
+  // Component loop OUTSIDE the inner cell loop. The component count comes from the
+  // pack for this block (a sparse variable's extent can vary block to block); var(c)
+  // is the tag for the c-th component of var.
+  const int nc = pack.GetSize(b, var());
+  for (int c = 0; c < nc; ++c) {
+    la::inner(r, [&](auto idx) { total(idx) += pv(var(c), idx); });
     r.TeamBarrier();   // finish this component's contribution before the next
   }
 
@@ -1046,7 +1053,7 @@ contribution into the running per-cell total, with a barrier between iterations 
 that a cell's accumulator is complete before the next sweep touches it. A loop of
 exactly this shape --- a user-written loop over variables wrapped around the inner
 $kji$ traversal --- is the origin of the $v$ (``variable'') level name in the loop
-hierarchy (Section~\ref{sec:looptags}). Taking the component bounds from the pack
+hierarchy (Section~\ref{sec:looptags}). Taking the component count from the pack
 per block, rather than from a global constant, is what lets this work when a sparse
 variable's extent varies from block to block. The final inner loop reads back the
 finished total. This is per-cell scratch used
@@ -1281,16 +1288,25 @@ and it is also what makes the reduced-dimension range a contiguous sub-run
 (Section~\ref{sec:reduced}): dropping the leading/trailing offsets of a sorted list
 leaves a sorted list.
 
-\paragraph{Scratch spans the enclosing memory range.} The scratch buffer for a
-halo range is sized not to the compact span union but to the single enclosing
-\emph{memory}-flat span from the range's lowest to highest touched cell. This
-over-allocates slightly (it includes any gaps between disjoint spans) in exchange
-for the cheapest possible indexing: a flat-index body's index is already relative
-to the slice's memory origin, so scratch access is one subtraction,
-\code{idx - scratch_index_start}; a coordinate body maps $(k,j,i)$ through the
-memory indexer and subtracts the same cached span start. The logical coverage
-\code{size()} of the range is cached at construction rather than recomputed by
-re-walking the spans.
+\paragraph{Scratch spans a single enclosing memory range.} The scratch buffer for a
+halo range is sized not to the compact span union but to a single contiguous
+\emph{memory}-flat span, so that indexing is one subtraction: a flat-index body's
+index is already relative to the slice's memory origin, giving
+\code{idx - scratch_index_start}, and a coordinate body maps $(k,j,i)$ through the
+memory indexer and subtracts the same cached span start. Which span depends on the
+loop tag, because the two hierarchical tags visit different cells. A \code{bvoi}
+inner loop enumerates contiguous flat spans and converts each flat index back to
+$(k,j,i)$, so it sweeps the whole rectangular halo-extended \emph{box} --- including
+the multi-axis corner cells that lie in no single shifted copy (the low corner of a
+7-point stencil with an extra $-2\hat{\imath}$ offset, say) --- and its scratch must therefore be
+sized to that box, the memory-flat interval from the box's low corner to its high
+corner, regardless of inner tag. (Sizing \code{bvoi} scratch to the shifted-copy
+union instead under-allocates and produces a negative scratch index at those
+corners.) A \code{bovi} inner loop visits only the union of shifted copies, so its
+scratch is sized to the enclosing memory-flat interval of that union --- a tighter
+span than the box, still slightly over-allocated where disjoint spans leave gaps.
+The logical coverage \code{size()} of the range is cached at construction rather
+than recomputed by re-walking the spans.
 
 \paragraph{The same range, two backend realizations.} These mechanics are what let
 the two backends realize the identical halo semantics differently

--- a/doc/sphinx/src/loop_abstraction.rst
+++ b/doc/sphinx/src/loop_abstraction.rst
@@ -26,11 +26,12 @@ Overview
 
 Two objects and two free functions form the core of the API:
 
-- ``IndexSpace<loop_tag, inner_tag, backend>`` describes the logical
-  ``(block, k, j, i)`` iteration space and the memory layout of a block. The three
-  template parameters fix the loop shape, the inner traversal, and the backend at
-  compile time. The backend has a default that is raw for loops with simd markings 
-  on host and kokkos based loops on device.
+- ``IndexSpace<loop_tag, inner_tag, backend, reduction>`` describes the logical
+  ``(block, k, j, i)`` iteration space and the memory layout of a block. The template
+  parameters fix the loop shape, the inner traversal, the backend, and (for the
+  reduction paths) the reducer at compile time. The backend has a default that is raw
+  for loops with simd markings on host and kokkos based loops on device; ``reduction``
+  defaults to a non-reducing space, so most call sites use the three-parameter form.
 - ``InnerIndexRange`` is one slice of an ``IndexSpace`` (a block plus the current
   chunk of ``kji`` space). It is the object handed to inner loop bodies and knows how
   to translate between flat, memory, and logical ``(k, j, i)`` indices.
@@ -161,6 +162,7 @@ Per-point scratch is registered on the ``IndexSpace`` at setup and requested ins
 the outer body:
 
 .. code:: cpp
+
    using recon_halo = la::halo::minus_i_t;
    idx_space.AddPerPointScratch<Real>();          // one Real per point
    idx_space.AddPerPointScratch<Real, 2, 3>();    // a 2x3 block per point
@@ -246,6 +248,7 @@ flux calculation kernel in the loop abstraction might look like (see below for p
 in the example):
 
 .. code:: cpp
+
    const auto desc = MakePackDescriptor<var>(md, {}, {parthenon::PDOpt::WithFluxes});
    auto pack = desc.GetPack(md);
    // Declare an index space over F1 faces 
@@ -316,6 +319,7 @@ pulls out pointers to the variables. This can promote vectorization and be a sig
 performance benefit. 
 
 .. code:: cpp
+
   auto desc = parthenon::MakePackDescriptor<v1, vf>(md);
   auto pack = desc.GetPack(md);
 

--- a/src/loop_abstraction/LOOP_ABSTRACTION_CONTRACTS.md
+++ b/src/loop_abstraction/LOOP_ABSTRACTION_CONTRACTS.md
@@ -250,12 +250,10 @@ These are known, deliberately-deferred extensions rather than open design questi
 
 Halo ranges are implemented (see `halo.hpp`, `inner_range.hpp`, `scratch.hpp`). Much of
 this section is written in the original proposal tense; the concepts and semantic rules
-below still hold. The worked producer/consumer examples use the real API, but a few
-conceptual code sketches do not describe the actual types: the `template <Index3...
-Offsets> struct halo_t` in "Offset-set representation" (real halos are the
-`halo::*_t` structs in `halo.hpp`) and the `span_union`/`flat_span` types in "Range
-construction" (regions are stored as `flat_start[]`/`flat_end[]` arrays and merged in
-`BuildRegions`).
+below still hold. The worked producer/consumer examples and "Range construction" describe
+the real API, but the `template <Index3... Offsets> struct halo_t` sketch in "Offset-set
+representation" is conceptual only -- real halos are the `halo::*_t` structs in
+`halo.hpp`.
 
 ## Concept
 
@@ -409,40 +407,50 @@ This keeps the halo operation geometric and avoids conflating logical coordinate
 
 ## Range construction
 
-For a one-offset halo, the halo range is the union of at most two flat spans in the halo-aware indexer:
+For a one-offset halo, the halo range is the union of at most two flat spans in the
+halo-aware indexer:
 
 ```text
 span 0: S flattened in D_h
 span 1: shift(S, h) flattened in D_h
 ```
 
-If the spans overlap or touch, they can be merged into one span. If they are disjoint, the range is represented as two spans.
+If the spans overlap or touch, they can be merged into one span. If they are disjoint,
+the range is represented as two spans.
 
-For a multi-offset halo, the same idea generalizes:
+For a multi-offset halo, the same idea generalizes -- one span per offset:
 
 ```text
-span 0: S
+span 0: shift(S, h0)
 span 1: shift(S, h1)
 span 2: shift(S, h2)
 ...
 ```
 
-After flattening these spans in the halo-aware logical domain, sort and merge them into a compact span union.
+where one of the offsets is the identity, so its span is `S` itself. After flattening
+these spans in the halo-aware logical domain, merge the ones that overlap or touch into a
+compact span union.
 
-Since the number of halo offsets is expected to be small, this can be represented with a small fixed-capacity span list.
+In the code this is `BuildRegions` (`inner_range.hpp`), and the merge is a single linear
+pass rather than a runtime sort. It relies on the halo offsets being **strictly sorted at
+compile time**: `HaloSatisfiesContract` enforces the ordering, and `HaloReducedRange`
+hands back a contiguous sub-run that is still sorted in a reduced-dimension run. Sorted
+offsets mean the spans arrive in non-decreasing flat-start order, so each candidate span
+only has to be compared against the last emitted one -- no runtime sort and no dynamic
+storage before every inner loop, which is what keeps it device-friendly.
+
+Since the number of halo offsets is small and known at compile time, the merged spans are
+stored in parallel fixed-capacity arrays sized by the offset count, plus a count of how
+many spans are live:
 
 ```cpp
-struct flat_span {
-  int start;
-  int stop; // inclusive
-};
-
-template <int MaxSpans>
-struct span_union {
-  int nspans;
-  flat_span spans[MaxSpans];
-};
+std::array<int, Halo::npoints> flat_start;  // inclusive
+std::array<int, Halo::npoints> flat_end;    // inclusive
+int nregions;
 ```
+
+The enclosing memory-flat interval of these spans is also tracked, for scratch sizing
+(see Scratch indexing).
 
 ## Scratch indexing
 

--- a/src/loop_abstraction/LOOP_ABSTRACTION_CONTRACTS.md
+++ b/src/loop_abstraction/LOOP_ABSTRACTION_CONTRACTS.md
@@ -9,7 +9,7 @@ One needs to be careful about making changes to the loop abstraction headers wit
 
 ## Core Types
 
-`IndexSpace<loop_tag, inner_tag, backend>`
+`IndexSpace<loop_tag, inner_tag, backend, reduction>`
 - Defines a space of (block, k, j, i) points to iterate over.
   - What we call the `v` index is an intermediate level that a user of the loop hierarchy can write loops in, do block-level work, etc.
   - The level of the v loops in the hierarchy of the (b, k, j, i) space is determined by the loop tags.
@@ -17,6 +17,9 @@ One needs to be careful about making changes to the loop abstraction headers wit
 - Carries `nblocks`, `ninner`, and the logical/memory indexers.
 - Selects the outer-loop shape at compile time.
 - Selects the loop backend at compile time via `backend_v`.
+- The trailing `reduction` parameter defaults to `no_reduce_t` (an ordinary,
+  non-reducing space); a Kokkos reducer is baked in for the reduction paths (see the
+  Reductions section). Most call sites omit it and use the three-parameter form.
 - Is the object that is passed into `outer(...)`.
 
 `InnerIndexRange<IndexSpaceType>`
@@ -24,7 +27,9 @@ One needs to be careful about making changes to the loop abstraction headers wit
 - Describes one slice of an index space.
 - Carries the block index and the current slice state.
 - Is the object passed into `inner(...)`.
-- Exposes `GetKJI(int idx)` so tests and pack-view helpers can recover `(k, j, i)` from the current inner index contract.
+- Exposes `GetKJI(...)` so tests and pack-view helpers can recover `(k, j, i)` from the
+  current inner index. It is overloaded on the index form the body received: a flat
+  `int`, a `MemoryOffset`, or an `Index3`.
 
 ## Loop Tags
 
@@ -241,7 +246,16 @@ These are known, deliberately-deferred extensions rather than open design questi
 - **Partially runtime-sized scratch.** Today per-point scratch is sized entirely by the template `Dims...`. For every loop tag except `boiv`, the size could instead be chosen at run time: keep the template argument as an upper bound (a capacity) but accept a runtime actual size, ignored for the `boiv` stack-scratch path. This is blocked on understanding the GPU tradeoffs of the fixed stack scratch vs. a more flexible runtime scratch -- register pressure is expected to be the deciding factor -- so it should not be implemented before that study.
 
 
-# Halo ranges for inner loops Implementation Ideas
+# Halo ranges for inner loops
+
+Halo ranges are implemented (see `halo.hpp`, `inner_range.hpp`, `scratch.hpp`). Much of
+this section is written in the original proposal tense; the concepts and semantic rules
+below still hold. The worked producer/consumer examples use the real API, but a few
+conceptual code sketches do not describe the actual types: the `template <Index3...
+Offsets> struct halo_t` in "Offset-set representation" (real halos are the
+`halo::*_t` structs in `halo.hpp`) and the `span_union`/`flat_span` types in "Range
+construction" (regions are stored as `flat_start[]`/`flat_end[]` arrays and merged in
+`BuildRegions`).
 
 ## Concept
 
@@ -275,25 +289,36 @@ The intended use case is a producer/consumer pattern inside an `outer` loop.
 For example, one inner loop computes reconstructed states into scratch, and a later inner loop computes fluxes from those reconstructed states:
 
 ```cpp
-constexpr auto recon_halo = halo::minus_i;
+using ist = IndexSpace<loop_tag::bvoi, inner_tag::logical_coords>;
+ist idx_space(/* ... */);
+using halo_t = halo::minus_i_t;
 
-auto scratch_p = idx_range.GetScratch<Real, recon_halo>();
-auto scratch_m = idx_range.GetScratch<Real, recon_halo>();
+// Register the scratch on the IndexSpace up front (once per buffer), sizing it for the
+// halo. GetDelta is a host call whose result is captured into the kernel.
+idx_space.AddPerPointScratch<Real, halo_t>();  // scratch_p
+idx_space.AddPerPointScratch<Real, halo_t>();  // scratch_m
+const auto dx1 = idx_space.GetDelta(X1DIR);
 
-inner(idx_range.AddHalo<recon_halo>(), KOKKOS_LAMBDA(auto kji) {
-  scratch_p(kji) = reconstruct_plus(kji);
-  scratch_m(kji) = reconstruct_minus(kji);
-});
+// Name the range type (not `auto`): KOKKOS_LAMBDA is an extended __host__ __device__
+// lambda and nvcc forbids `auto` params. `ist` is the IndexSpace type.
+outer(idx_space, KOKKOS_LAMBDA(const ist::idx_range_t &idx_range, int b) {
+  const auto halo_range = AddHalo<halo_t>(idx_range);
+  auto scratch_p = GetPerPointScratch<Real>(halo_range);
+  auto scratch_m = GetPerPointScratch<Real>(halo_range);
 
-inner(idx_range, KOKKOS_LAMBDA(auto kji) {
-  auto dx1 = idx_range.GetOffset<X1DIR>();
+  inner(halo_range, [&](auto kji) {
+    scratch_p(kji) = reconstruct_plus(kji);
+    scratch_m(kji) = reconstruct_minus(kji);
+  });
+  idx_range.TeamBarrier();
 
-  flux(kji) = riemann(scratch_p(kji - dx1),
-                      scratch_m(kji));
+  inner(idx_range, [&](auto kji) {
+    flux(kji) = riemann(scratch_p(kji - dx1), scratch_m(kji));
+  });
 });
 ```
 
-The flux loop runs over `idx_range`, but it consumes a reconstructed value at `kji - dx1`. Therefore, the reconstruction loop must produce values over `idx_range` plus that neighboring logical point set. The halo expresses this dependency.
+The flux loop runs over `idx_range`, but it consumes a reconstructed value at `kji - dx1`. Therefore, the reconstruction loop must produce values over `idx_range` plus that neighboring logical point set. The halo expresses this dependency. The `TeamBarrier()` between producer and consumer is required whenever a later inner loop reads scratch a different thread wrote.
 
 ## Halo is not reconstruction stencil width
 
@@ -351,8 +376,8 @@ not just the shifted set.
 Common aliases can make this readable:
 
 ```cpp
-constexpr auto recon_halo = halo::minus_i;
-constexpr auto transverse_halo = halo::plus_j;
+using recon_halo = halo::minus_i_t;
+using transverse_halo = halo::plus_j_t;
 ```
 
 For the expected use cases, the number of offsets is small: usually one, sometimes two or six, and perhaps up to around twelve in more general cases.
@@ -423,13 +448,32 @@ struct span_union {
 
 Scratch should use the same halo-aware flat index space as the halo range.
 
-Hierarchical scratch currently allocates the whole memory-flat span covered by
-the halo-extended range. This uses more storage than the compact union of touched
-points, but lets flat-index scratch access use a simple base subtraction:
+Hierarchical scratch is indexed by a single base subtraction in the memory-flat indexer,
+so it allocates a contiguous memory-flat span. Which span depends on the loop tag,
+because the two tags visit different sets of cells:
+
+- **`bvoi`** enumerates contiguous flat spans and converts each flat index back to
+  `(k, j, i)`, so it sweeps the *entire rectangular* halo-extended box -- including the
+  multi-axis corner cells (e.g. the low corner of a 7-point + `-2i` stencil) that lie in
+  no single shifted copy of the base range. Regardless of inner tag, its scratch is sized
+  over the full box: the memory-flat interval from the box's low corner to its high
+  corner. (Sizing from the shifted-copy union instead under-allocates and produces a
+  negative scratch index at those corners -- a real bug that segfaulted for non-square
+  blocks.)
+- **`bovi`** visits only the union of shifted copies (contiguous flat spans in the memory
+  indexer), so its scratch is sized over the enclosing memory-flat interval of that union
+  -- a tighter span than the box.
+
+Both are computed in `InnerIndexRange::InitFromEndpoints`. Either way the result is one
+contiguous span `[span_start, span_stop]`, so flat-index scratch access is a base
+subtraction:
 
 ```text
 [span_start, span_stop] -> [0, span_stop - span_start]
 ```
+
+(The `boiv` tag is different again: its scratch is a compact per-cell stack buffer sized
+by the halo's bounding box, not a memory-flat span -- see the point-wise backend below.)
 
 For flat-index bodies, the index passed to the body is already relative to the
 current inner range's memory origin, so scratch maps it as:
@@ -460,17 +504,26 @@ merged span lengths on every call.
 The user-facing semantics stay the same:
 
 ```cpp
-constexpr auto recon_halo = halo::minus_i;
+using ist = IndexSpace<loop_tag::bvoi, inner_tag::logical_coords>;
+ist idx_space(/* ... */);
+using halo_t = halo::minus_i_t;
 
-auto scratch = idx_range.GetScratch<Real, recon_halo>();
+idx_space.AddPerPointScratch<Real, halo_t>();
+const auto dx1 = idx_space.GetDelta(X1DIR);
 
-inner(idx_range.AddHalo<recon_halo>(), KOKKOS_LAMBDA(auto kji) {
-  scratch(kji) = reconstruct(kji);
-});
+// See the note above on naming the range type rather than using `auto`.
+outer(idx_space, KOKKOS_LAMBDA(const ist::idx_range_t &idx_range, int b) {
+  const auto halo_range = AddHalo<halo_t>(idx_range);
+  auto scratch = GetPerPointScratch<Real>(halo_range);
 
-inner(idx_range, KOKKOS_LAMBDA(auto kji) {
-  auto dx1 = idx_range.GetOffset<X1DIR>();
-  flux(kji) = riemann(scratch(kji - dx1), scratch(kji));
+  inner(halo_range, [&](auto kji) {
+    scratch(kji) = reconstruct(kji);
+  });
+  idx_range.TeamBarrier();
+
+  inner(idx_range, [&](auto kji) {
+    flux(kji) = riemann(scratch(kji - dx1), scratch(kji));
+  });
 });
 ```
 
@@ -504,8 +557,9 @@ The halo range covers
 S ∪ shift(S, h1) ∪ shift(S, h2) ∪ ...
 ```
 
-and scratch is allocated over the enclosing memory-flat span for those shifted
-sets. This allows reconstructed values to be reused across multiple flux
+and scratch is allocated over a contiguous enclosing memory-flat span (the full
+rectangular box for `bvoi`, the tighter union interval for `bovi` -- see Scratch
+indexing above). This allows reconstructed values to be reused across multiple flux
 calculations while reducing per-access indexing arithmetic.
 
 ## Summary

--- a/src/loop_abstraction/halo.hpp
+++ b/src/loop_abstraction/halo.hpp
@@ -187,7 +187,7 @@ constexpr bool HaloIsProjectionClosed() {
 // always the most-significant sort keys (k, then j), so the DROP-kept set -- offsets
 // with zero component in every inactive direction -- is a single contiguous run. The
 // identity {0,0,0} is always kept. Because a sub-range of a sorted array is still
-// sorted, the merge in BuildRegionsFromEndpoints stays valid when seeded from begin.
+// sorted, the merge in BuildRegions stays valid when seeded from begin.
 //
 // ndim follows the Parthenon convention: i active for ndim >= 1, j for ndim >= 2,
 // k for ndim >= 3.

--- a/src/loop_abstraction/inner_range.hpp
+++ b/src/loop_abstraction/inner_range.hpp
@@ -133,53 +133,102 @@ class InnerIndexRange {
         *pidx_space, halo_kji, block, {ks, js, is}, {ke, je, ie}, team_member);
   }
 
-  KOKKOS_INLINE_FUNCTION void BuildRegionsFromEndpoints(const Index3 start,
-                                                        const Index3 end) {
-    const auto &memory = pidx_space->GetMemoryIndexer();
+  // Result of merging the shifted copies of a [start, end] rectangle (one copy per
+  // halo offset) into contiguous flat spans, expressed in a supplied indexer's flat
+  // space. `span_start`/`span_end` are the enclosing flat interval (min flat start and
+  // max flat end over all offsets), used for scratch sizing.
+  struct RegionMerge {
+    std::array<int, Halo::npoints> flat_start{};
+    std::array<int, Halo::npoints> flat_end{};
+    int nregions = 1;
+    int cached_size = 0;
+    int span_start = 0;
+    int span_end = 0;
+  };
+
+  // Merge the halo-shifted copies of the [start, end] rectangle into contiguous flat
+  // spans, using `idxer` to flatten coordinates. This is a pure operation on (idxer,
+  // Halo, ndim, start, end): the iteration regions come from calling it with the
+  // inner-tag indexer, and the bovi scratch extent from calling it with the memory
+  // indexer.
+  KOKKOS_INLINE_FUNCTION RegionMerge BuildRegions(const parthenon::Indexer3D &idxer,
+                                                  const Index3 start,
+                                                  const Index3 end) const {
     // In a reduced-dimension run, keep only the contiguous [begin, end) run of halo
     // offsets that do not point into a degenerate direction (see HaloReducedRange).
     // The run is still sorted, so the single-pass merge below stays valid.
     const HaloRange hrange = HaloReducedRange<Halo>(pidx_space->GetNdim());
     const int hbegin = hrange.begin;
-    flat_start[0] =
-        GetFlatIdxFromKJI(start.k + Halo::dk(hbegin), start.j + Halo::dj(hbegin),
-                          start.i + Halo::di(hbegin));
-    flat_end[0] = GetFlatIdxFromKJI(end.k + Halo::dk(hbegin), end.j + Halo::dj(hbegin),
-                                    end.i + Halo::di(hbegin));
-    const int memory_base = memory.GetFlatIdx(start.k, start.j, start.i);
-    scratch_flat_start =
-        memory.GetFlatIdx(start.k + Halo::dk(hbegin), start.j + Halo::dj(hbegin),
-                          start.i + Halo::di(hbegin));
-    int scratch_flat_end = memory.GetFlatIdx(
-        end.k + Halo::dk(hbegin), end.j + Halo::dj(hbegin), end.i + Halo::di(hbegin));
-    nregions = 1;
+    RegionMerge out;
+    out.flat_start[0] =
+        idxer.GetFlatIdx(start.k + Halo::dk(hbegin), start.j + Halo::dj(hbegin),
+                         start.i + Halo::di(hbegin));
+    out.flat_end[0] = idxer.GetFlatIdx(end.k + Halo::dk(hbegin), end.j + Halo::dj(hbegin),
+                                       end.i + Halo::di(hbegin));
+    out.span_start = out.flat_start[0];
+    out.span_end = out.flat_end[0];
+    out.nregions = 1;
     // Create possibly disjoint ranges, this algorithm relies on the start and end points
     // of the ranges being sorted by flat start
     for (int n = hbegin + 1; n < hrange.end; ++n) {
-      const int fstart = GetFlatIdxFromKJI(start.k + Halo::dk(n), start.j + Halo::dj(n),
-                                           start.i + Halo::di(n));
-      const int fend = GetFlatIdxFromKJI(end.k + Halo::dk(n), end.j + Halo::dj(n),
-                                         end.i + Halo::di(n));
-      const int scratch_start = memory.GetFlatIdx(
-          start.k + Halo::dk(n), start.j + Halo::dj(n), start.i + Halo::di(n));
-      const int scratch_end = memory.GetFlatIdx(end.k + Halo::dk(n), end.j + Halo::dj(n),
-                                                end.i + Halo::di(n));
-      scratch_flat_start = std::min(scratch_flat_start, scratch_start);
-      scratch_flat_end = std::max(scratch_flat_end, scratch_end);
-      if (fstart <= flat_end[nregions - 1] + 1) {
-        if (fend > flat_end[nregions - 1]) flat_end[nregions - 1] = fend;
+      const int fstart = idxer.GetFlatIdx(start.k + Halo::dk(n), start.j + Halo::dj(n),
+                                          start.i + Halo::di(n));
+      const int fend = idxer.GetFlatIdx(end.k + Halo::dk(n), end.j + Halo::dj(n),
+                                        end.i + Halo::di(n));
+      out.span_start = std::min(out.span_start, fstart);
+      out.span_end = std::max(out.span_end, fend);
+      if (fstart <= out.flat_end[out.nregions - 1] + 1) {
+        if (fend > out.flat_end[out.nregions - 1]) out.flat_end[out.nregions - 1] = fend;
       } else {
-        flat_start[nregions] = fstart;
-        flat_end[nregions] = fend;
-        ++nregions;
+        out.flat_start[out.nregions] = fstart;
+        out.flat_end[out.nregions] = fend;
+        ++out.nregions;
       }
     }
-    cached_size = 0;
-    for (int r = 0; r < nregions; ++r) {
-      cached_size += flat_end[r] - flat_start[r] + 1;
+    out.cached_size = 0;
+    for (int r = 0; r < out.nregions; ++r) {
+      out.cached_size += out.flat_end[r] - out.flat_start[r] + 1;
     }
+    return out;
+  }
+
+  KOKKOS_INLINE_FUNCTION void BuildRegionsFromEndpoints(const Index3 start,
+                                                        const Index3 end) {
+    const auto &memory = pidx_space->GetMemoryIndexer();
+    // Iteration regions live in the inner-tag indexer's flat space (memory span for the
+    // memory tag, logical otherwise).
+    const parthenon::Indexer3D &iter_indexer =
+        (IndexSpaceType::inner_tag_v == inner_tag::memory) ? memory : logical_kji;
+    const RegionMerge iter = BuildRegions(iter_indexer, start, end);
+    flat_start = iter.flat_start;
+    flat_end = iter.flat_end;
+    nregions = iter.nregions;
+    cached_size = iter.cached_size;
+
+    if constexpr (IndexSpaceType::loop_tag_v == loop_tag::bvoi) {
+      // bvoi enumerates contiguous flat spans and converts each flat index back to
+      // (k,j,i), so it sweeps the whole rectangular (halo-extended) box -- including the
+      // multi-axis corner cells that lie in no single shifted copy -- regardless of the
+      // inner tag. Scratch must therefore cover the full box, whose extent in memory is
+      // bounded by the box's low and high corners (logical_kji is that box here). Sizing
+      // from the shifted-copy union instead would under-allocate and under-run the
+      // buffer at those corners (e.g. a 7-point + (-2i) stencil).
+      scratch_flat_start = memory.GetFlatIdx(logical_kji.template StartIdx<0>(),
+                                             logical_kji.template StartIdx<1>(),
+                                             logical_kji.template StartIdx<2>());
+      const int scratch_flat_end = memory.GetFlatIdx(logical_kji.template EndIdx<0>(),
+                                                     logical_kji.template EndIdx<1>(),
+                                                     logical_kji.template EndIdx<2>());
+      scratch_span_size = scratch_flat_end - scratch_flat_start + 1;
+    } else {
+      // bovi visits only the union of shifted copies (flat spans in the memory indexer),
+      // so the enclosing memory interval suffices.
+      const RegionMerge scr = BuildRegions(memory, start, end);
+      scratch_flat_start = scr.span_start;
+      scratch_span_size = scr.span_end - scr.span_start + 1;
+    }
+    const int memory_base = memory.GetFlatIdx(start.k, start.j, start.i);
     scratch_index_start = scratch_flat_start - memory_base;
-    scratch_span_size = scratch_flat_end - scratch_flat_start + 1;
   }
 
   KOKKOS_FORCEINLINE_FUNCTION auto GetKJIFromFlatIdx(int flat_idx) const {

--- a/src/loop_abstraction/inner_range.hpp
+++ b/src/loop_abstraction/inner_range.hpp
@@ -34,6 +34,64 @@
 
 namespace parthenon::loop_abstraction {
 
+// Result of merging the shifted copies of a [start, end] rectangle (one copy per halo
+// offset) into contiguous flat spans, expressed in some indexer's flat space.
+// `span_start`/`span_end` are the enclosing flat interval (min flat start and max flat
+// end over all offsets), used for scratch sizing.
+template <class Halo>
+struct RegionMerge {
+  std::array<int, Halo::npoints> flat_start{};
+  std::array<int, Halo::npoints> flat_end{};
+  int nregions = 1;
+  int cached_size = 0;
+  int span_start = 0;
+  int span_end = 0;
+};
+
+// Merge the Halo-shifted copies of the [start, end] rectangle into contiguous flat
+// spans, using `idxer` to flatten coordinates. A pure operation on (idxer, Halo, ndim,
+// start, end): iteration regions come from calling it with the inner-tag indexer, and
+// the bovi scratch extent from calling it with the memory indexer. `ndim` selects the
+// contiguous run of halo offsets kept in a reduced-dimension run (see HaloReducedRange);
+// the run stays sorted, so the single-pass merge below is valid.
+template <class Halo>
+KOKKOS_INLINE_FUNCTION RegionMerge<Halo>
+BuildRegions(const parthenon::Indexer3D &idxer, int ndim, Index3 start, Index3 end) {
+  const HaloRange hrange = HaloReducedRange<Halo>(ndim);
+  const int hbegin = hrange.begin;
+  RegionMerge<Halo> out;
+  out.flat_start[0] = idxer.GetFlatIdx(start.k + Halo::dk(hbegin),
+                                       start.j + Halo::dj(hbegin),
+                                       start.i + Halo::di(hbegin));
+  out.flat_end[0] = idxer.GetFlatIdx(end.k + Halo::dk(hbegin), end.j + Halo::dj(hbegin),
+                                     end.i + Halo::di(hbegin));
+  out.span_start = out.flat_start[0];
+  out.span_end = out.flat_end[0];
+  out.nregions = 1;
+  // Create possibly disjoint ranges, this algorithm relies on the start and end points
+  // of the ranges being sorted by flat start
+  for (int n = hbegin + 1; n < hrange.end; ++n) {
+    const int fstart = idxer.GetFlatIdx(start.k + Halo::dk(n), start.j + Halo::dj(n),
+                                        start.i + Halo::di(n));
+    const int fend = idxer.GetFlatIdx(end.k + Halo::dk(n), end.j + Halo::dj(n),
+                                      end.i + Halo::di(n));
+    out.span_start = std::min(out.span_start, fstart);
+    out.span_end = std::max(out.span_end, fend);
+    if (fstart <= out.flat_end[out.nregions - 1] + 1) {
+      if (fend > out.flat_end[out.nregions - 1]) out.flat_end[out.nregions - 1] = fend;
+    } else {
+      out.flat_start[out.nregions] = fstart;
+      out.flat_end[out.nregions] = fend;
+      ++out.nregions;
+    }
+  }
+  out.cached_size = 0;
+  for (int r = 0; r < out.nregions; ++r) {
+    out.cached_size += out.flat_end[r] - out.flat_start[r] + 1;
+  }
+  return out;
+}
+
 template <class IndexSpaceType, class Halo = halo::none_t>
 class InnerIndexRange {
  public:
@@ -89,7 +147,7 @@ class InnerIndexRange {
 
     chunk_logical_start = 0;
     chunk_logical_end = static_cast<int>(logical_kji.size()) - 1;
-    BuildRegionsFromEndpoints(start, end);
+    InitFromEndpoints(start, end);
   }
 
   // Constructor relevant for bovi
@@ -99,7 +157,7 @@ class InnerIndexRange {
                   Index3 end, const device_team_member_t *team_member_in = nullptr)
       : pidx_space(&idx_space), logical_kji(logical_kji_in), block(b), ks(start.k),
         js(start.j), is(start.i), team_member(team_member_in) {
-    BuildRegionsFromEndpoints(start, end);
+    InitFromEndpoints(start, end);
   }
 
   KOKKOS_INLINE_FUNCTION
@@ -113,7 +171,7 @@ class InnerIndexRange {
     ks = ks_;
     js = js_;
     is = is_;
-    BuildRegionsFromEndpoints({ks, js, is}, Index3(logical_kji(flat_end)));
+    InitFromEndpoints({ks, js, is}, Index3(logical_kji(flat_end)));
   }
 
   template <class Halo_in>
@@ -133,73 +191,16 @@ class InnerIndexRange {
         *pidx_space, halo_kji, block, {ks, js, is}, {ke, je, ie}, team_member);
   }
 
-  // Result of merging the shifted copies of a [start, end] rectangle (one copy per
-  // halo offset) into contiguous flat spans, expressed in a supplied indexer's flat
-  // space. `span_start`/`span_end` are the enclosing flat interval (min flat start and
-  // max flat end over all offsets), used for scratch sizing.
-  struct RegionMerge {
-    std::array<int, Halo::npoints> flat_start{};
-    std::array<int, Halo::npoints> flat_end{};
-    int nregions = 1;
-    int cached_size = 0;
-    int span_start = 0;
-    int span_end = 0;
-  };
-
-  // Merge the halo-shifted copies of the [start, end] rectangle into contiguous flat
-  // spans, using `idxer` to flatten coordinates. This is a pure operation on (idxer,
-  // Halo, ndim, start, end): the iteration regions come from calling it with the
-  // inner-tag indexer, and the bovi scratch extent from calling it with the memory
-  // indexer.
-  KOKKOS_INLINE_FUNCTION RegionMerge BuildRegions(const parthenon::Indexer3D &idxer,
-                                                  const Index3 start,
-                                                  const Index3 end) const {
-    // In a reduced-dimension run, keep only the contiguous [begin, end) run of halo
-    // offsets that do not point into a degenerate direction (see HaloReducedRange).
-    // The run is still sorted, so the single-pass merge below stays valid.
-    const HaloRange hrange = HaloReducedRange<Halo>(pidx_space->GetNdim());
-    const int hbegin = hrange.begin;
-    RegionMerge out;
-    out.flat_start[0] =
-        idxer.GetFlatIdx(start.k + Halo::dk(hbegin), start.j + Halo::dj(hbegin),
-                         start.i + Halo::di(hbegin));
-    out.flat_end[0] = idxer.GetFlatIdx(end.k + Halo::dk(hbegin), end.j + Halo::dj(hbegin),
-                                       end.i + Halo::di(hbegin));
-    out.span_start = out.flat_start[0];
-    out.span_end = out.flat_end[0];
-    out.nregions = 1;
-    // Create possibly disjoint ranges, this algorithm relies on the start and end points
-    // of the ranges being sorted by flat start
-    for (int n = hbegin + 1; n < hrange.end; ++n) {
-      const int fstart = idxer.GetFlatIdx(start.k + Halo::dk(n), start.j + Halo::dj(n),
-                                          start.i + Halo::di(n));
-      const int fend = idxer.GetFlatIdx(end.k + Halo::dk(n), end.j + Halo::dj(n),
-                                        end.i + Halo::di(n));
-      out.span_start = std::min(out.span_start, fstart);
-      out.span_end = std::max(out.span_end, fend);
-      if (fstart <= out.flat_end[out.nregions - 1] + 1) {
-        if (fend > out.flat_end[out.nregions - 1]) out.flat_end[out.nregions - 1] = fend;
-      } else {
-        out.flat_start[out.nregions] = fstart;
-        out.flat_end[out.nregions] = fend;
-        ++out.nregions;
-      }
-    }
-    out.cached_size = 0;
-    for (int r = 0; r < out.nregions; ++r) {
-      out.cached_size += out.flat_end[r] - out.flat_start[r] + 1;
-    }
-    return out;
-  }
-
-  KOKKOS_INLINE_FUNCTION void BuildRegionsFromEndpoints(const Index3 start,
-                                                        const Index3 end) {
+  // Initialize the iteration regions and scratch bookkeeping from the range's endpoints.
+  // Runs from every constructor after the endpoints are known; not called elsewhere.
+  KOKKOS_INLINE_FUNCTION void InitFromEndpoints(const Index3 start, const Index3 end) {
     const auto &memory = pidx_space->GetMemoryIndexer();
+    const int ndim = pidx_space->GetNdim();
     // Iteration regions live in the inner-tag indexer's flat space (memory span for the
     // memory tag, logical otherwise).
     const parthenon::Indexer3D &iter_indexer =
         (IndexSpaceType::inner_tag_v == inner_tag::memory) ? memory : logical_kji;
-    const RegionMerge iter = BuildRegions(iter_indexer, start, end);
+    const RegionMerge<Halo> iter = BuildRegions<Halo>(iter_indexer, ndim, start, end);
     flat_start = iter.flat_start;
     flat_end = iter.flat_end;
     nregions = iter.nregions;
@@ -223,7 +224,7 @@ class InnerIndexRange {
     } else {
       // bovi visits only the union of shifted copies (flat spans in the memory indexer),
       // so the enclosing memory interval suffices.
-      const RegionMerge scr = BuildRegions(memory, start, end);
+      const RegionMerge<Halo> scr = BuildRegions<Halo>(memory, ndim, start, end);
       scratch_flat_start = scr.span_start;
       scratch_span_size = scr.span_end - scr.span_start + 1;
     }

--- a/src/loop_abstraction/inner_range.hpp
+++ b/src/loop_abstraction/inner_range.hpp
@@ -60,9 +60,8 @@ BuildRegions(const parthenon::Indexer3D &idxer, int ndim, Index3 start, Index3 e
   const HaloRange hrange = HaloReducedRange<Halo>(ndim);
   const int hbegin = hrange.begin;
   RegionMerge<Halo> out;
-  out.flat_start[0] = idxer.GetFlatIdx(start.k + Halo::dk(hbegin),
-                                       start.j + Halo::dj(hbegin),
-                                       start.i + Halo::di(hbegin));
+  out.flat_start[0] = idxer.GetFlatIdx(
+      start.k + Halo::dk(hbegin), start.j + Halo::dj(hbegin), start.i + Halo::di(hbegin));
   out.flat_end[0] = idxer.GetFlatIdx(end.k + Halo::dk(hbegin), end.j + Halo::dj(hbegin),
                                      end.i + Halo::di(hbegin));
   out.span_start = out.flat_start[0];
@@ -73,8 +72,8 @@ BuildRegions(const parthenon::Indexer3D &idxer, int ndim, Index3 start, Index3 e
   for (int n = hbegin + 1; n < hrange.end; ++n) {
     const int fstart = idxer.GetFlatIdx(start.k + Halo::dk(n), start.j + Halo::dj(n),
                                         start.i + Halo::di(n));
-    const int fend = idxer.GetFlatIdx(end.k + Halo::dk(n), end.j + Halo::dj(n),
-                                      end.i + Halo::di(n));
+    const int fend =
+        idxer.GetFlatIdx(end.k + Halo::dk(n), end.j + Halo::dj(n), end.i + Halo::di(n));
     out.span_start = std::min(out.span_start, fstart);
     out.span_end = std::max(out.span_end, fend);
     if (fstart <= out.flat_end[out.nregions - 1] + 1) {

--- a/tst/unit/test_loop_abstraction.cpp
+++ b/tst/unit/test_loop_abstraction.cpp
@@ -380,6 +380,30 @@ struct plus_two_i_minus_k_halo_t {
   KOKKOS_INLINE_FUNCTION static constexpr int di(int n) { return n == 1 ? 0 : 2; }
 };
 
+// Standard 7-point stencil plus an extra -2i offset. Its bounding box has multi-axis
+// corners (e.g. (-1,-1,-2)) that lie in no single shifted copy of the block, so a
+// bvoi loop -- which sweeps the whole rectangular halo-extended box -- indexes scratch
+// cells outside the shifted-copy union. Regression for a scratch under-allocation /
+// negative-index under-run that segfaulted for non-square blocks. Offsets sorted
+// lexicographically by (dk, dj, di). Projection-closed: every offset projects onto a
+// declared offset in 2D and 1D.
+struct seven_point_minus_two_i_halo_t {
+  static constexpr int npoints = 8;
+  KOKKOS_INLINE_FUNCTION static constexpr int dk(int n) {
+    return n == 0 ? -1 : (n == 7 ? 1 : 0);
+  }
+  KOKKOS_INLINE_FUNCTION static constexpr int dj(int n) {
+    return n == 1 ? -1 : (n == 6 ? 1 : 0);
+  }
+  KOKKOS_INLINE_FUNCTION static constexpr int di(int n) {
+    // n: 0(-1,0,0) 1(0,-1,0) 2(0,0,-2) 3(0,0,-1) 4(0,0,0) 5(0,0,1) 6(0,1,0) 7(1,0,0)
+    if (n == 2) return -2;
+    if (n == 3) return -1;
+    if (n == 5) return 1;
+    return 0;
+  }
+};
+
 struct k_triplet_halo_t {
   static constexpr int npoints = 3;
   KOKKOS_INLINE_FUNCTION static constexpr int dk(int n) {
@@ -416,6 +440,8 @@ static_assert(loop_abstraction::impl::HaloSatisfiesContract<plus_j_halo_t>());
 static_assert(loop_abstraction::impl::HaloSatisfiesContract<minus_i_halo_t>());
 static_assert(loop_abstraction::impl::HaloSatisfiesContract<minus_j_halo_t>());
 static_assert(loop_abstraction::impl::HaloSatisfiesContract<plus_two_i_minus_k_halo_t>());
+static_assert(
+    loop_abstraction::impl::HaloSatisfiesContract<seven_point_minus_two_i_halo_t>());
 static_assert(loop_abstraction::impl::HaloSatisfiesContract<k_triplet_halo_t>());
 static_assert(!loop_abstraction::impl::HaloSatisfiesContract<unsorted_halo_t>());
 static_assert(
@@ -444,6 +470,8 @@ static_assert(loop_abstraction::impl::HaloIsProjectionClosed<minus_i_halo_t>());
 static_assert(loop_abstraction::impl::HaloIsProjectionClosed<k_triplet_halo_t>());
 static_assert(
     loop_abstraction::impl::HaloIsProjectionClosed<plus_two_i_minus_k_halo_t>());
+static_assert(
+    loop_abstraction::impl::HaloIsProjectionClosed<seven_point_minus_two_i_halo_t>());
 static_assert(
     !loop_abstraction::impl::HaloIsProjectionClosed<not_projection_closed_halo_t>());
 
@@ -1692,6 +1720,53 @@ TEST_CASE("loop abstraction scratch halo roundtrip",
   RunScratchHaloPatternMatrix<plus_j_halo_t, loop_tag::bovi, inner_tag::memory>();
   RunScratchHaloPatternMatrix<plus_j_halo_t, loop_tag::boiv, inner_tag::logical_flat>();
   RunScratchHaloPatternMatrix<plus_j_halo_t, loop_tag::boiv, inner_tag::logical_coords>();
+}
+
+// Run one scratch-halo case on every available backend: always the kokkos backend
+// (valid on host and device), and additionally the raw backend on a host build (where
+// raw is the default; on a device build the raw backend would drive host loops over
+// device memory).
+template <class HaloType, loop_tag LOOP_TAG, inner_tag INNER_TAG>
+void RunScratchHaloCaseBothBackends(const ProblemSpec &spec, const int ninner) {
+  RunScratchHaloCase<HaloType, LOOP_TAG, INNER_TAG, loop_backend::kokkos>(spec, ninner);
+  if constexpr (default_loop_backend_v == loop_backend::raw) {
+    RunScratchHaloCase<HaloType, LOOP_TAG, INNER_TAG, loop_backend::raw>(spec, ninner);
+  }
+}
+
+// Regression: a multi-axis "corner" halo (7-point + -2i), whose rectangular
+// halo-extended box has corners outside the union of shifted copies. A bvoi loop
+// sweeps the whole box, so scratch must be sized/indexed over the box, not the union.
+// Before the fix this under-allocated and under-ran the scratch buffer, segfaulting for
+// non-square blocks. Exercised over every valid (loop_tag, inner_tag) pair, both
+// backends, and rectangular specs (unequal nx/ny/nz) which is where it bit. boiv/memory
+// is intentionally absent (rejected at compile time, see the top-level note).
+TEST_CASE("loop abstraction corner halo scratch",
+          "[loop_abstraction][contract][scratch][halo]") {
+  using halo_t = seven_point_minus_two_i_halo_t;
+  const std::array<ProblemSpec, 3> specs{ProblemSpec{2, 8, 4, 3, 2},
+                                          ProblemSpec{1, 4, 8, 2, 2},
+                                          ProblemSpec{2, 6, 3, 5, 3}};
+  for (const auto &spec : specs) {
+    for (const int ninner : NinnerCases(spec.nx * spec.ny * spec.nz)) {
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::bvoi, inner_tag::logical_flat>(
+          spec, ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::bvoi, inner_tag::logical_coords>(
+          spec, ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::bvoi, inner_tag::memory>(spec,
+                                                                                ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::bovi, inner_tag::logical_flat>(
+          spec, ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::bovi, inner_tag::logical_coords>(
+          spec, ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::bovi, inner_tag::memory>(spec,
+                                                                                ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::boiv, inner_tag::logical_flat>(
+          spec, ninner);
+      RunScratchHaloCaseBothBackends<halo_t, loop_tag::boiv, inner_tag::logical_coords>(
+          spec, ninner);
+    }
+  }
 }
 
 TEST_CASE("loop abstraction boiv scratch halo GetDelta access",

--- a/tst/unit/test_loop_abstraction.cpp
+++ b/tst/unit/test_loop_abstraction.cpp
@@ -1744,9 +1744,8 @@ void RunScratchHaloCaseBothBackends(const ProblemSpec &spec, const int ninner) {
 TEST_CASE("loop abstraction corner halo scratch",
           "[loop_abstraction][contract][scratch][halo]") {
   using halo_t = seven_point_minus_two_i_halo_t;
-  const std::array<ProblemSpec, 3> specs{ProblemSpec{2, 8, 4, 3, 2},
-                                          ProblemSpec{1, 4, 8, 2, 2},
-                                          ProblemSpec{2, 6, 3, 5, 3}};
+  const std::array<ProblemSpec, 3> specs{
+      ProblemSpec{2, 8, 4, 3, 2}, ProblemSpec{1, 4, 8, 2, 2}, ProblemSpec{2, 6, 3, 5, 3}};
   for (const auto &spec : specs) {
     for (const int ninner : NinnerCases(spec.nx * spec.ny * spec.nz)) {
       RunScratchHaloCaseBothBackends<halo_t, loop_tag::bvoi, inner_tag::logical_flat>(


### PR DESCRIPTION
## PR Summary

[Written with the help of generative AI]

This PR fixes a bug in `bvoi` scratch memory for halo ranges that extended in multiple directions. Corner points (for instance offset by -i and -j for a standard five-point halo) were included in the iteration range for halo inner loops but did not have a representation in scratch memory. We now allocate scratch over the whole halo-enlarged rectangular index space including incidental corners and edges. 

Additionally, I use this PR as a place to clean up some of the loop abstraction documentation.

Thanks to @swjones for pointing out all of the issues fixed here.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [x] New features are documented.
- [x] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [x] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [x] (@lanl.gov employees) Update copyright on changed files
