### PR TITLE
Add precision label to compiler CI jobs

### DIFF
--- a/.github/workflows/check-compilers.yml
+++ b/.github/workflows/check-compilers.yml
@@ -25,14 +25,22 @@ jobs:
         cmake_build_type: ['Release', 'DbgNoSym']
         device: ['cuda', 'host']
         parallel: ['serial', 'mpi']
-        # For one build, test single precision compilation.
-        # We pick one that we already run the regression tests for in double.
+        # Single-element axis, so it labels every job's precision without growing
+        # the matrix.
+        precision: ['double']
+        # A couple of single-precision compile checks (build only), appended as new
+        # jobs since precision=single is not in the base matrix.
         include:
           - cxx: g++
             cmake_build_type: Release
             device: cuda
             parallel: mpi
-            single_prec: "-DPARTHENON_SINGLE_PRECISION=ON"
+            precision: single
+          - cxx: g++
+            cmake_build_type: DbgNoSym
+            device: host
+            parallel: serial
+            precision: single
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/parthenon-hpc-lab/cuda12.8-mpi-hdf5-opmd
@@ -48,7 +56,7 @@ jobs:
             -DCMAKE_CXX_COMPILER=${{ matrix.cxx }} \
             -DCMAKE_BUILD_TYPE=${{ matrix.cmake_build_type }} \
             -DMACHINE_CFG=${PWD}/cmake/machinecfg/GitHubActions.cmake \
-            ${{ matrix.single_prec }} \
+            ${{ matrix.precision == 'single' && '-DPARTHENON_SINGLE_PRECISION=ON' || '' }} \
             -DMACHINE_VARIANT=${{ matrix.device }}_${{ matrix.parallel }}
       - name: Build
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 - [[PR 1360]](https://github.com/parthenon-hpc-lab/parthenon/pull/1360) Fix boundary cache clearing in different MeshData partitions
 
 ### Infrastructure (changes irrelevant to downstream codes)
+- [[PR 1436]](https://github.com/parthenon-hpc-lab/parthenon/pull/1436) Add explicit single-precision compile CI jobs and label build precision in job names
 - [[PR 1414]](https://github.com/parthenon-hpc-lab/parthenon/pull/1414) Bump ROCM CI Container to rocm 7.2.4
 - [[PR 1397]](https://github.com/parthenon-hpc-lab/parthenon/pull/1397) Add Code of Conduct
 - [[PR 1385]](https://github.com/parthenon-hpc-lab/parthenon/pull/1385) Refactor ParameterInput: Separate parsing from storage to enable multiple input formats

--- a/tst/unit/test_loop_abstraction.cpp
+++ b/tst/unit/test_loop_abstraction.cpp
@@ -42,7 +42,7 @@ namespace {
 // loop_abstraction now lives under parthenon; keep the short name for the test body.
 namespace loop_abstraction = parthenon::loop_abstraction;
 
-using Real = double;
+using parthenon::Real;
 using loop_abstraction::default_loop_backend_v;
 using loop_abstraction::Index3;
 using loop_abstraction::IndexSpace;

--- a/tst/unit/test_loop_abstraction.cpp
+++ b/tst/unit/test_loop_abstraction.cpp
@@ -42,7 +42,6 @@ namespace {
 // loop_abstraction now lives under parthenon; keep the short name for the test body.
 namespace loop_abstraction = parthenon::loop_abstraction;
 
-using parthenon::Real;
 using loop_abstraction::default_loop_backend_v;
 using loop_abstraction::Index3;
 using loop_abstraction::IndexSpace;
@@ -57,6 +56,7 @@ using parthenon::IndexDomain;
 using parthenon::MeshBlock;
 using parthenon::MeshData;
 using parthenon::Metadata;
+using parthenon::Real;
 using parthenon::StateDescriptor;
 using parthenon::TopologicalElement;
 using parthenon::TopologicalType;


### PR DESCRIPTION
## PR Summary

[Written with the assistance of generative AI] 

Clearly label CI compiler checks that exercise single precision, add a cpu single precision test, and fix a single precision bug in the loop abstraction tests.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [x] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [x] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
