### PR TITLE
Small: Add option to specify topological element in var views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Current develop
 
 ### Added (new features/APIs/variables/...)
+- [[PR 1443]](https://github.com/parthenon-hpc-lab/parthenon/pull/1443) Allow for specifying topological elements in var views
 - [[PR 1431]](https://github.com/parthenon-hpc-lab/parthenon/pull/1431) Add reductions to the loop abstraction
 - [[PR 1429]](https://github.com/parthenon-hpc-lab/parthenon/pull/1429) Fixes to swarm tensor xdmf
 - [[PR 1428]](https://github.com/parthenon-hpc-lab/parthenon/pull/1428) Permit larger input file sizes

--- a/src/loop_abstraction/index_space.hpp
+++ b/src/loop_abstraction/index_space.hpp
@@ -125,9 +125,9 @@ class IndexSpace {
 
   // The type the inner body's single index parameter receives (see inner() dispatch).
   // A pure function of the tags, so bodies can spell it instead of using `auto`.
-  using inner_idx_t =
-      std::conditional_t<INNER_TAG == inner_tag::logical_coords, Index3,
-                         std::conditional_t<LOOP_TAG == loop_tag::boiv, MemoryOffset, int>>;
+  using inner_idx_t = std::conditional_t<
+      INNER_TAG == inner_tag::logical_coords, Index3,
+      std::conditional_t<LOOP_TAG == loop_tag::boiv, MemoryOffset, int>>;
 
   KOKKOS_INLINE_FUNCTION int GetMemoryOffset(const int dk, const int dj,
                                              const int di) const {

--- a/src/loop_abstraction/index_space.hpp
+++ b/src/loop_abstraction/index_space.hpp
@@ -23,6 +23,7 @@
 // needed here so IndexSpace::AddPerPointScratch can call it.
 
 #include <optional>
+#include <type_traits>
 
 #include "basic_types.hpp"
 #include "interface/mesh_data.hpp"
@@ -121,6 +122,12 @@ class IndexSpace {
   // rejects for extended lambdas): both outer() and outer_reduce() bodies use it, e.g.
   // outer_reduce(rist, KOKKOS_LAMBDA(const RIST::idx_range_t &r, int b) { ... }).
   using idx_range_t = InnerIndexRange<IndexSpace, halo::none_t>;
+
+  // The type the inner body's single index parameter receives (see inner() dispatch).
+  // A pure function of the tags, so bodies can spell it instead of using `auto`.
+  using inner_index_t =
+      std::conditional_t<INNER_TAG == inner_tag::logical_coords, Index3,
+                         std::conditional_t<LOOP_TAG == loop_tag::boiv, MemoryOffset, int>>;
 
   KOKKOS_INLINE_FUNCTION int GetMemoryOffset(const int dk, const int dj,
                                              const int di) const {

--- a/src/loop_abstraction/index_space.hpp
+++ b/src/loop_abstraction/index_space.hpp
@@ -125,7 +125,7 @@ class IndexSpace {
 
   // The type the inner body's single index parameter receives (see inner() dispatch).
   // A pure function of the tags, so bodies can spell it instead of using `auto`.
-  using inner_index_t =
+  using inner_idx_t =
       std::conditional_t<INNER_TAG == inner_tag::logical_coords, Index3,
                          std::conditional_t<LOOP_TAG == loop_tag::boiv, MemoryOffset, int>>;
 

--- a/src/loop_abstraction/inner_range.hpp
+++ b/src/loop_abstraction/inner_range.hpp
@@ -96,6 +96,7 @@ class InnerIndexRange {
  public:
   using index_space_t = IndexSpaceType;
   using halo_t = Halo;
+  using inner_index_t = typename IndexSpaceType::inner_index_t;
   static_assert(impl::HaloSatisfiesContract<Halo>(),
                 "Halo offsets must include exactly one identity offset {0,0,0} "
                 "and be strictly sorted lexicographically by (dk,dj,di).");
@@ -333,6 +334,7 @@ class InnerIndexRange<IndexSpace<loop_tag::boiv, INNER_TAG, BACKEND, Reduction>,
  public:
   using index_space_t = IndexSpace<loop_tag::boiv, INNER_TAG, BACKEND, Reduction>;
   using halo_t = Halo;
+  using inner_index_t = typename index_space_t::inner_index_t;
   static_assert(impl::HaloSatisfiesContract<Halo>(),
                 "Halo offsets must include exactly one identity offset {0,0,0} "
                 "and be strictly sorted lexicographically by (dk,dj,di).");

--- a/src/loop_abstraction/inner_range.hpp
+++ b/src/loop_abstraction/inner_range.hpp
@@ -96,7 +96,7 @@ class InnerIndexRange {
  public:
   using index_space_t = IndexSpaceType;
   using halo_t = Halo;
-  using inner_index_t = typename IndexSpaceType::inner_index_t;
+  using inner_idx_t = typename IndexSpaceType::inner_idx_t;
   static_assert(impl::HaloSatisfiesContract<Halo>(),
                 "Halo offsets must include exactly one identity offset {0,0,0} "
                 "and be strictly sorted lexicographically by (dk,dj,di).");
@@ -334,7 +334,7 @@ class InnerIndexRange<IndexSpace<loop_tag::boiv, INNER_TAG, BACKEND, Reduction>,
  public:
   using index_space_t = IndexSpace<loop_tag::boiv, INNER_TAG, BACKEND, Reduction>;
   using halo_t = Halo;
-  using inner_index_t = typename index_space_t::inner_index_t;
+  using inner_idx_t = typename index_space_t::inner_idx_t;
   static_assert(impl::HaloSatisfiesContract<Halo>(),
                 "Halo offsets must include exactly one identity offset {0,0,0} "
                 "and be strictly sorted lexicographically by (dk,dj,di).");

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -283,7 +283,7 @@ struct var_view_t<LOOP_TAG, inner_tag::logical_coords, PackType> {
   KOKKOS_INLINE_FUNCTION
   var_view_t(const PackType *pack_in, int block, int var_in, TopologicalElement te)
       : pack(pack_in), b(block), vidx(var_in), te(te) {}
-  
+
   KOKKOS_INLINE_FUNCTION
   var_view_t(const PackType *pack_in, int block, int var_in)
       : pack(pack_in), b(block), vidx(var_in), te(TopologicalElement::CC) {}

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -275,6 +275,7 @@ struct var_view_t<LOOP_TAG, inner_tag::logical_coords, PackType> {
   const PackType *pack = nullptr;
   int b = 0;
   int vidx = 0;
+  TopologicalElement te;
 
   KOKKOS_DEFAULTED_FUNCTION
   var_view_t() = default;
@@ -284,17 +285,17 @@ struct var_view_t<LOOP_TAG, inner_tag::logical_coords, PackType> {
       : pack(pack_in), b(block), vidx(var_in) {}
 
   KOKKOS_FORCEINLINE_FUNCTION parthenon::Real &operator()(Index3 in) const {
-    return (*pack)(b, vidx, in.k, in.j, in.i);
+    return (*pack)(b, te, vidx, in.k, in.j, in.i);
   }
   KOKKOS_FORCEINLINE_FUNCTION parthenon::Real &operator()(int k, int j, int i) const {
-    return (*pack)(b, vidx, k, j, i);
+    return (*pack)(b, te, vidx, k, j, i);
   }
   KOKKOS_FORCEINLINE_FUNCTION parthenon::Real &operator()(int offset, Index3 in) const {
-    return (*pack)(b, vidx + offset, in.k, in.j, in.i);
+    return (*pack)(b, te, vidx + offset, in.k, in.j, in.i);
   }
   KOKKOS_FORCEINLINE_FUNCTION parthenon::Real &operator()(int offset, int k, int j,
                                                           int i) const {
-    return (*pack)(b, vidx + offset, k, j, i);
+    return (*pack)(b, te, vidx + offset, k, j, i);
   }
 };
 
@@ -303,26 +304,34 @@ struct var_view_t<LOOP_TAG, inner_tag::logical_coords, PackType> {
 template <class IndexSpaceType, class PackType, class IndexType>
 KOKKOS_INLINE_FUNCTION auto
 make_var_view(const InnerIndexRange<IndexSpaceType> &idx_range, const PackType &pack_in,
-              const IndexType &var) {
+              TopologicalElement te, const IndexType &var) {
   constexpr loop_tag LOOP_TAG = IndexSpaceType::loop_tag_v;
   constexpr inner_tag INNER_TAG = IndexSpaceType::inner_tag_v;
   const int vidx = pack_in.GetIndex(idx_range.block, var);
   if constexpr (INNER_TAG == inner_tag::logical_coords) {
-    return var_view_t<LOOP_TAG, INNER_TAG, PackType>{&pack_in, idx_range.block, vidx};
+    return var_view_t<LOOP_TAG, INNER_TAG, PackType>{&pack_in, idx_range.block, vidx, te};
   } else {
     var_view_t<LOOP_TAG, INNER_TAG, PackType> out;
     const auto &memory_indexer = idx_range.pidx_space->GetMemoryIndexer();
     out.memory_indexer = &memory_indexer;
     out.shift_ = memory_indexer.GetFlatIdx(idx_range.ks, idx_range.js, idx_range.is);
-    out.data_ = pack_in(idx_range.block, vidx).data() + out.shift_;
+    out.data_ = pack_in(idx_range.block, te, vidx).data() + out.shift_;
     const int vidx_next = ((pack_in.GetSize() > vidx + 1) &&
                            (pack_in(idx_range.block, vidx).tensor_components > 1))
                               ? vidx + 1
                               : vidx;
-    out.stride_ = pack_in(idx_range.block, vidx_next).data() + out.shift_ - out.data_;
+    out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
     return out;
   }
 }
+
+template <class IndexSpaceType, class PackType, class IndexType>
+KOKKOS_INLINE_FUNCTION auto
+make_var_view(const InnerIndexRange<IndexSpaceType> &idx_range, const PackType &pack_in,
+              const IndexType &var) {
+  return make_var_view(idx_range, pack_in, TopologicalElement::CC, var);
+}
+
 } // namespace parthenon::loop_abstraction
 
 #endif // LOOP_ABSTRACTION_PACK_VIEW_HPP_

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -281,8 +281,12 @@ struct var_view_t<LOOP_TAG, inner_tag::logical_coords, PackType> {
   var_view_t() = default;
 
   KOKKOS_INLINE_FUNCTION
+  var_view_t(const PackType *pack_in, int block, int var_in, TopologicalElement te)
+      : pack(pack_in), b(block), vidx(var_in), te(te) {}
+  
+  KOKKOS_INLINE_FUNCTION
   var_view_t(const PackType *pack_in, int block, int var_in)
-      : pack(pack_in), b(block), vidx(var_in) {}
+      : pack(pack_in), b(block), vidx(var_in), te(TopologicalElement::CC) {}
 
   KOKKOS_FORCEINLINE_FUNCTION parthenon::Real &operator()(Index3 in) const {
     return (*pack)(b, te, vidx, in.k, in.j, in.i);


### PR DESCRIPTION
## PR Summary

Before, we couldn't specify a topological element in `var_view`s. Now we can.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
