### PR TITLE
Tweaks to support SYCL

### DIFF
--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -65,10 +65,12 @@ class SwarmDeviceContext {
     // Particle is on neither this block nor a neighboring block
     if (i < 0 || i > 3 || ((j < 0 || j > 3) && ndim_ > 1) ||
         ((k < 0 || k > 3) && ndim_ > 2)) {
+#ifndef KOKKOS_ENABLE_SYCL
       printf("[%i] k = %i j = %i i = %i\n", n, k, j, i);
       printf("x = %e [%e %e]\n", x, x_min_, x_max_);
       printf("y = %e [%e %e]\n", y, y_min_, y_max_);
       printf("z = %e [%e %e]\n", z, z_min_, z_max_);
+#endif
       PARTHENON_FAIL("Particle neighbor indices out of bounds; particle has somehow "
                      "moved beyond the halo of adjacent blocks which is not permitted.");
     }

--- a/src/interface/swarm_device_context.hpp
+++ b/src/interface/swarm_device_context.hpp
@@ -65,12 +65,10 @@ class SwarmDeviceContext {
     // Particle is on neither this block nor a neighboring block
     if (i < 0 || i > 3 || ((j < 0 || j > 3) && ndim_ > 1) ||
         ((k < 0 || k > 3) && ndim_ > 2)) {
-#ifndef KOKKOS_ENABLE_SYCL
-      printf("[%i] k = %i j = %i i = %i\n", n, k, j, i);
-      printf("x = %e [%e %e]\n", x, x_min_, x_max_);
-      printf("y = %e [%e %e]\n", y, y_min_, y_max_);
-      printf("z = %e [%e %e]\n", z, z_min_, z_max_);
-#endif
+      Kokkos::printf("[%i] k = %i j = %i i = %i\n", n, k, j, i);
+      Kokkos::printf("x = %e [%e %e]\n", x, x_min_, x_max_);
+      Kokkos::printf("y = %e [%e %e]\n", y, y_min_, y_max_);
+      Kokkos::printf("z = %e [%e %e]\n", z, z_min_, z_max_);
       PARTHENON_FAIL("Particle neighbor indices out of bounds; particle has somehow "
                      "moved beyond the halo of adjacent blocks which is not permitted.");
     }

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -112,9 +112,10 @@ namespace ErrorChecking {
 KOKKOS_INLINE_FUNCTION
 void require(const char *const condition, const char *const message,
              const char *const filename, int const linenumber) {
-  Kokkos::printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
-         "%s\n  Line number: %i\n",
-         condition, message, filename, linenumber);
+  Kokkos::printf(
+      "### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
+      "%s\n  Line number: %i\n",
+      condition, message, filename, linenumber);
   Kokkos::abort(message);
 }
 
@@ -151,8 +152,9 @@ inline void require_throws(const char *const condition, std::stringstream const 
 
 [[noreturn]] KOKKOS_INLINE_FUNCTION void
 fail(const char *const message, const char *const filename, int const linenumber) {
-  Kokkos::printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
-         message, filename, linenumber);
+  Kokkos::printf(
+      "### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+      message, filename, linenumber);
   Kokkos::abort(message);
   // Kokkos::abort ends control flow, but is not marked as `[[noreturn]]`, so we need this
   // loop to supress a warning that the function does not return.

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -112,11 +112,9 @@ namespace ErrorChecking {
 KOKKOS_INLINE_FUNCTION
 void require(const char *const condition, const char *const message,
              const char *const filename, int const linenumber) {
-#ifndef KOKKOS_ENABLE_SYCL
-  printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
+  Kokkos::printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
          "%s\n  Line number: %i\n",
          condition, message, filename, linenumber);
-#endif
   Kokkos::abort(message);
 }
 
@@ -153,10 +151,8 @@ inline void require_throws(const char *const condition, std::stringstream const 
 
 [[noreturn]] KOKKOS_INLINE_FUNCTION void
 fail(const char *const message, const char *const filename, int const linenumber) {
-#ifndef KOKKOS_ENABLE_SYCL
-  printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
+  Kokkos::printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
          message, filename, linenumber);
-#endif
   Kokkos::abort(message);
   // Kokkos::abort ends control flow, but is not marked as `[[noreturn]]`, so we need this
   // loop to supress a warning that the function does not return.

--- a/src/utils/error_checking.hpp
+++ b/src/utils/error_checking.hpp
@@ -112,9 +112,11 @@ namespace ErrorChecking {
 KOKKOS_INLINE_FUNCTION
 void require(const char *const condition, const char *const message,
              const char *const filename, int const linenumber) {
+#ifndef KOKKOS_ENABLE_SYCL
   printf("### PARTHENON ERROR\n  Condition:   %s\n  Message:     %s\n  File:        "
          "%s\n  Line number: %i\n",
          condition, message, filename, linenumber);
+#endif
   Kokkos::abort(message);
 }
 
@@ -151,8 +153,10 @@ inline void require_throws(const char *const condition, std::stringstream const 
 
 [[noreturn]] KOKKOS_INLINE_FUNCTION void
 fail(const char *const message, const char *const filename, int const linenumber) {
+#ifndef KOKKOS_ENABLE_SYCL
   printf("### PARTHENON ERROR\n  Message:     %s\n  File:        %s\n  Line number: %i\n",
          message, filename, linenumber);
+#endif
   Kokkos::abort(message);
   // Kokkos::abort ends control flow, but is not marked as `[[noreturn]]`, so we need this
   // loop to supress a warning that the function does not return.


### PR DESCRIPTION
Parthenon still has a couple places where failure messages use printf, which is impossible in SYCL.  I've inelegantly removed them downstream in KHARMA, where we can deal with the consequences, but I'm putting this up as a skeleton for anyone who wants to use Parthenon/SYCL and is wondering if it's hard (it's not).

If everyone's okay with the reduced functionality/more obscure behavior we could upstream this, but I'm also happy to try to add back the prints by using `cout` on SYCL, as is I believe the correct style.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
