### PR TITLE
Ownership for self-bordering blocks

### DIFF
--- a/src/mesh/forest/block_ownership.cpp
+++ b/src/mesh/forest/block_ownership.cpp
@@ -41,6 +41,7 @@ namespace parthenon {
 block_ownership_t
 DetermineOwnership(const LogicalLocation &main_block,
                    const std::vector<forest::NeighborLocation> &allowed_neighbors,
+                   const std::array<bool, 3> self_border_block,
                    const std::unordered_set<LogicalLocation> &newly_refined) {
   block_ownership_t main_owns;
 
@@ -63,6 +64,19 @@ DetermineOwnership(const LogicalLocation &main_block,
     return a.morton() < b.morton();
   };
 
+  // Does this block border itself over this face, and are we on the left side?
+  // Then Morton number would say we own the face/edge/corner, but we don't
+  // (the right side does).
+  auto self_border_left = [self_border_block](int ox1, int ox2, int ox3) {
+    // Can take care of each direction independently, corners follow
+    if ((self_border_block[0] && ox1 < 0) || (self_border_block[1] && ox2 < 0) ||
+        (self_border_block[2] && ox3 < 0)) {
+      return true;
+    } else {
+      return false;
+    }
+  };
+
   for (int ox1 : {-1, 0, 1}) {
     for (int ox2 : {-1, 0, 1}) {
       for (int ox3 : {-1, 0, 1}) {
@@ -70,6 +84,10 @@ DetermineOwnership(const LogicalLocation &main_block,
         for (const auto &n : allowed_neighbors) {
           if (ownership_less_than(main_block, n.global_loc) &&
               main_block.IsNeighborOfTE(n.origin_loc, {ox1, ox2, ox3})) {
+            main_owns(ox1, ox2, ox3) = false;
+            break;
+          } else if (main_block.level() == 0 && main_block == n.global_loc &&
+                     self_border_left(ox1, ox2, ox3)) {
             main_owns(ox1, ox2, ox3) = false;
             break;
           }

--- a/src/mesh/forest/block_ownership.hpp
+++ b/src/mesh/forest/block_ownership.hpp
@@ -44,6 +44,7 @@ namespace parthenon {
 block_ownership_t
 DetermineOwnership(const LogicalLocation &main_block,
                    const std::vector<forest::NeighborLocation> &allowed_neighbors,
+                   const std::array<bool, 3> self_border_block = {false, false, false},
                    const std::unordered_set<LogicalLocation> &newly_refined = {});
 
 // Given a topological element, ownership array of the sending block, and offset indices

--- a/src/mesh/mesh-gmg.cpp
+++ b/src/mesh/mesh-gmg.cpp
@@ -62,6 +62,21 @@ void SetMeshBlockNeighbors(Mesh *pmesh, GridIdentifier grid_id, BlockList_t &blo
                     {ndim > 2 ? -1 : 0, ndim > 2 ? 1 : 0});
   BufferID buffer_id(ndim, multilevel);
 
+  // If we're periodic with just 1 block in any direction,
+  // we must treat ownership specially
+  auto block_size = pmesh->GetDefaultBlockSize();
+  std::array<bool, 3> self_border_block{
+      !pmesh->mesh_size.symmetry(X1DIR) &&
+          pmesh->mesh_size.nx(X1DIR) / block_size.nx(X1DIR) == 1 &&
+          pmesh->mesh_bcs[BoundaryFace::inner_x1] == BoundaryFlag::periodic,
+      !pmesh->mesh_size.symmetry(X2DIR) &&
+          pmesh->mesh_size.nx(X2DIR) / block_size.nx(X2DIR) == 1 &&
+          pmesh->mesh_bcs[BoundaryFace::inner_x2] == BoundaryFlag::periodic,
+      !pmesh->mesh_size.symmetry(X3DIR) &&
+          pmesh->mesh_size.nx(X3DIR) / block_size.nx(X3DIR) == 1 &&
+          pmesh->mesh_bcs[BoundaryFace::inner_x3] == BoundaryFlag::periodic,
+  };
+
   for (auto &pmb : block_list) {
     std::vector<NeighborBlock> all_neighbors;
     const auto &loc = pmb->loc;
@@ -90,8 +105,8 @@ void SetMeshBlockNeighbors(Mesh *pmesh, GridIdentifier grid_id, BlockList_t &blo
       auto &nb = all_neighbors.back();
       auto neighbor_neighbors = forest.FindNeighbors(nloc.global_loc, grid_id);
 
-      nb.ownership =
-          DetermineOwnership(nloc.global_loc, neighbor_neighbors, newly_refined);
+      nb.ownership = DetermineOwnership(nloc.global_loc, neighbor_neighbors,
+                                        self_border_block, newly_refined);
       nb.ownership.initialized = true;
 
       // Set logical coordinate transformation from this block to the neighbor


### PR DESCRIPTION
## PR Summary
This fixes an issue in very small periodic forests with very particular synchronization needs, in particular where a block borders itself.  We track when a block borders itself on the left, and flag that the block does not own those left edges, so they are always synchronized from the right.

Generally this bug actually shouldn't be an issue, at least for codes which maintain binary similarity for themselves between operations performed on the right and left faces of a single periodic block.  However, KHARMA doesn't, and further relies on having a single consistent EMF at those faces in order to preserve magnetic field divergence. The result is a divergence which climbs unless this patch is applied.

I'm not sure this is the best way to do it, but it's gotten the job done downstream.  In particular, I have no idea how it interacts with multiple forests, which I think is theoretically possible (that is, having a forest/base block border itself in a periodic direction, in a simulation with multiple forests not all of which share that configuration) but I'm not sure how to construct such a geometry, let alone whether it will happen for any practical setup.

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
