### PR TITLE
Fix bugs: `CellMemAligned` and `Independent` buffer overrun, var_view bad access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 
 ### Fixed (not changing behavior/API/variables/...)
+- [[PR 1448]](https://github.com/parthenon-hpc-lab/parthenon/pull/1448) Fix bugs: CellMemAligned and Independent buffer overrun, var_view bad access
 - [[PR 1435]](https://github.com/parthenon-hpc-lab/parthenon/pull/1435) Fix loop abstraction scratch sizing for multi-axis (corner) halos
 - [[PR 1434]](https://github.com/parthenon-hpc-lab/parthenon/pull/1434) Repair nodal field output in XDMF.
 - [[PR 1430]](https://github.com/parthenon-hpc-lab/parthenon/pull/1430) Fix BiCGSTAB returning NaN when a solve converges in its first half step

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -189,7 +189,8 @@ CalcIndices(const NeighborBlock &nb, MeshBlock *pmb,
     exterior_offset /= 2;
   }
 
-  const bool missing_last_face = (!v->IsSet(Metadata::Cell)) && v->IsSet(Metadata::CellMemAligned);
+  const bool missing_last_face =
+      (!v->IsSet(Metadata::Cell)) && v->IsSet(Metadata::CellMemAligned);
   std::array<int, 3> s, e;
   for (int dir = 0; dir < 3; ++dir) {
     if (block_offset[dir] == 0) {
@@ -228,8 +229,8 @@ CalcIndices(const NeighborBlock &nb, MeshBlock *pmb,
       }
       // Prolongate into ghosts of interior receiver since we have the data available,
       // having this is important for AMR MG
-      // For cell mem-aligned fields, we cannot safely prolongate in the ghosts on the 
-      // upper sides so we only prolongate into the interior. MG does not support 
+      // For cell mem-aligned fields, we cannot safely prolongate in the ghosts on the
+      // upper sides so we only prolongate into the interior. MG does not support
       // non-cell fields currently, so there is no mismatch.
       if (prores && not_symmetry[dir] && IndexRangeType::InteriorRecv == ir_type) {
         s[dir] -= Globals::nghost / 2;

--- a/src/bvals/comms/bnd_info.cpp
+++ b/src/bvals/comms/bnd_info.cpp
@@ -189,6 +189,7 @@ CalcIndices(const NeighborBlock &nb, MeshBlock *pmb,
     exterior_offset /= 2;
   }
 
+  const bool missing_last_face = (!v->IsSet(Metadata::Cell)) && v->IsSet(Metadata::CellMemAligned);
   std::array<int, 3> s, e;
   for (int dir = 0; dir < 3; ++dir) {
     if (block_offset[dir] == 0) {
@@ -227,9 +228,12 @@ CalcIndices(const NeighborBlock &nb, MeshBlock *pmb,
       }
       // Prolongate into ghosts of interior receiver since we have the data available,
       // having this is important for AMR MG
+      // For cell mem-aligned fields, we cannot safely prolongate in the ghosts on the 
+      // upper sides so we only prolongate into the interior. MG does not support 
+      // non-cell fields currently, so there is no mismatch.
       if (prores && not_symmetry[dir] && IndexRangeType::InteriorRecv == ir_type) {
         s[dir] -= Globals::nghost / 2;
-        e[dir] += Globals::nghost / 2;
+        if (!missing_last_face) e[dir] += Globals::nghost / 2;
       }
     } else if (block_offset[dir] > 0) {
       // Fluxes are only communicated on shared elements

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -322,21 +322,23 @@ make_var_view(const InnerIndexRange<IndexSpaceType> &idx_range, const PackType &
     out.data_ = pack_in(idx_range.block, te, vidx).data() + out.shift_;
     // This stride should only make sense for a single field where the memory is allocated
     // contiguously, any time that multiple fields are packed into a single variable type
-    // the stride will not be sensible since the the pointer arithmetic will involve two 
-    // chunks of memory that were allocated at separate times. To keep things light, we 
+    // the stride will not be sensible since the the pointer arithmetic will involve two
+    // chunks of memory that were allocated at separate times. To keep things light, we
     // only provide a partial check **user beware**
     if constexpr (std::is_integral_v<IndexType>) {
       const int vidx_next = ((pack_in.GetUpperBound(idx_range.block) >= vidx + 1) &&
                              (pack_in(idx_range.block, te, vidx).tensor_components > 1))
                                 ? vidx + 1
                                 : vidx;
-      out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
+      out.stride_ =
+          pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
     } else {
       const int vidx_next = ((pack_in.GetUpperBound(idx_range.block, var) >= vidx + 1) &&
                              (pack_in(idx_range.block, te, vidx).tensor_components > 1))
                                 ? vidx + 1
                                 : vidx;
-      out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
+      out.stride_ =
+          pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
     }
     return out;
   }

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -320,11 +320,24 @@ make_var_view(const InnerIndexRange<IndexSpaceType> &idx_range, const PackType &
     out.memory_indexer = &memory_indexer;
     out.shift_ = memory_indexer.GetFlatIdx(idx_range.ks, idx_range.js, idx_range.is);
     out.data_ = pack_in(idx_range.block, te, vidx).data() + out.shift_;
-    const int vidx_next = ((pack_in.GetSize() > vidx + 1) &&
-                           (pack_in(idx_range.block, te, vidx).tensor_components > 1))
-                              ? vidx + 1
-                              : vidx;
-    out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
+    // This stride should only make sense for a single field where the memory is allocated
+    // contiguously, any time that multiple fields are packed into a single variable type
+    // the stride will not be sensible since the the pointer arithmetic will involve two 
+    // chunks of memory that were allocated at separate times. To keep things light, we 
+    // only provide a partial check
+    if constexpr (std::is_integral_v<IndexType>) {
+      const int vidx_next = ((pack_in.GetUpperBound(idx_range.block) >= vidx + 1) &&
+                             (pack_in(idx_range.block, te, vidx).tensor_components > 1))
+                                ? vidx + 1
+                                : vidx;
+      out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
+    } else {
+      const int vidx_next = ((pack_in.GetUpperBound(idx_range.block, var) >= vidx + 1) &&
+                             (pack_in(idx_range.block, te, vidx).tensor_components > 1))
+                                ? vidx + 1
+                                : vidx;
+      out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;
+    }
     return out;
   }
 }

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -321,7 +321,7 @@ make_var_view(const InnerIndexRange<IndexSpaceType> &idx_range, const PackType &
     out.shift_ = memory_indexer.GetFlatIdx(idx_range.ks, idx_range.js, idx_range.is);
     out.data_ = pack_in(idx_range.block, te, vidx).data() + out.shift_;
     const int vidx_next = ((pack_in.GetSize() > vidx + 1) &&
-                           (pack_in(idx_range.block, vidx).tensor_components > 1))
+                           (pack_in(idx_range.block, te, vidx).tensor_components > 1))
                               ? vidx + 1
                               : vidx;
     out.stride_ = pack_in(idx_range.block, te, vidx_next).data() + out.shift_ - out.data_;

--- a/src/loop_abstraction/pack_view.hpp
+++ b/src/loop_abstraction/pack_view.hpp
@@ -324,7 +324,7 @@ make_var_view(const InnerIndexRange<IndexSpaceType> &idx_range, const PackType &
     // contiguously, any time that multiple fields are packed into a single variable type
     // the stride will not be sensible since the the pointer arithmetic will involve two 
     // chunks of memory that were allocated at separate times. To keep things light, we 
-    // only provide a partial check
+    // only provide a partial check **user beware**
     if constexpr (std::is_integral_v<IndexType>) {
       const int vidx_next = ((pack_in.GetUpperBound(idx_range.block) >= vidx + 1) &&
                              (pack_in(idx_range.block, te, vidx).tensor_components > 1))


### PR DESCRIPTION
## PR Summary

This PR fixes two bugs (with help from @chadmeyer):

1. Prolongation during remesh in non-cell centered fields that have both `Metadata::CellMemAligned` and `Metadata::Independent` ended up with index ranges that reached outside of the allocated memory for a field. This restricts the index range to prevent this. **After looking at fixing this bug, I think that there is a general bug for variables with `Metadata::Independent` for fill ghost (see issue #1447) that I do not fix here.**
2. Fix the array bound check for building `var_views` to prevent UB

## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [x] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
