### PR TITLE
[Possibly breaking] Require all containers with the same base name in a `DataCollection` be made from the same field set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 
 
 ### Changed (changing behavior/API/variables/...)
+- [[PR 1449]](https://github.com/parthenon-hpc-lab/parthenon/pull/1449) Require all containers with the same base name in a DataCollection be made from the same field set
 - [[PR 1438]](https://github.com/parthenon-hpc-lab/parthenon/pull/1438) Performance tuning for the loop abstraction machinery and add loop abstraction OpenMP support
 - [[PR 1416][(https://github.com/parthenon-hpc-lab/parthenon/pull/1416) Remove virtual tag from destructors in sparse and swarm pack base classes
 - [[PR 1401]](https://github.com/parthenon-hpc-lab/parthenon/pull/1401) Sparse Field Component Names
@@ -68,6 +69,7 @@
 
 
 ### Incompatibilities (i.e. breaking changes)
+- [[PR 1449]](https://github.com/parthenon-hpc-lab/parthenon/pull/1449) Require all containers with the same base name in a DataCollection be made from the same field set
 - [[PR 1385]](https://github.com/parthenon-hpc-lab/parthenon/pull/1385) ParameterInput internal storage refactor removes direct access to linked list (`pfirst_block`). Use `GetBlocksWithPrefix()` or `GetBlockNames()` instead.
 - [[PR 1351]](https://github.com/parthenon-hpc-lab/parthenon/pull/1351) Bump Kokkos 5 & C++20
 - [[PR 1377]](https://github.com/parthenon-hpc-lab/parthenon/pull/1377) Extend Initialization Hierarchy

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -158,11 +158,11 @@ class DataCollection {
         return f;
     };
 
-    // Track the field list (as a canonical uid set) each container name is created from,
-    // so the DataCollection is the single source of truth for it (see GetCreationFields).
-    // Containers sharing a base name but built from different sources get distinct keys,
-    // so the per-key CreatedFrom check above cannot compare them; this does. All
-    // instances of a name must be created from the same list -- fail if not.
+    // Track the field list (as a canonical uid set) each container base name is created from,
+    // so every container with a given base name contains the same set of fields.
+    // Containers sharing a base name but built from different sources get distinct internal names,
+    // so the check above cannot compare them; this does. All
+    // instances of a name must be created from the same list.
     std::set<Uid_t> created;
     for (const auto &f : fields)
       created.insert(to_uid(f));

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -15,14 +15,17 @@
 
 #include <map>
 #include <memory>
+#include <set>
 #include <stdexcept>
 #include <string>
 #include <vector>
 
 #include "basic_types.hpp"
 #include "globals.hpp"
+#include "interface/variable.hpp"
 #include "utils/concepts_lite.hpp"
 #include "utils/error_checking.hpp"
+#include "utils/unique_id.hpp"
 
 namespace parthenon {
 class Mesh;
@@ -53,36 +56,37 @@ class DataCollection {
 
   void SetMeshPointer(Mesh *pmesh) { pmy_mesh_ = pmesh; }
 
-  template <class SRC_t, typename ID_t>
-  std::shared_ptr<T> &Add(const std::string &name, const std::shared_ptr<SRC_t> &src,
-                          const std::vector<ID_t> &fields, const bool shallow) {
-    auto key = GetKey(name, src);
-    auto it = containers_.find(key);
-    if (it != containers_.end()) {
-      if (fields.size() && !(it->second)->CreatedFrom(fields)) {
-        PARTHENON_THROW(key + " already exists in collection but fields do not match.");
-      }
-      return it->second;
-    }
-
-    auto c = std::make_shared<T>(name);
-    c->Initialize(src, fields, shallow);
-
-    containers_[key] = c;
-    return containers_[key];
-  }
-
   template <class SRC_t, typename ID_t = std::string>
   std::shared_ptr<T> &Add(const std::string &label, const std::shared_ptr<SRC_t> &src,
                           const std::vector<ID_t> &fields = {}) {
-    return Add(label, src, fields, false);
+    return AddImpl(label, src, fields, false);
+  }
+
+  template <class SRC_t, typename ID_t>
+  std::shared_ptr<T> &Add(const std::string &label, const std::shared_ptr<SRC_t> &src,
+                          const std::vector<ID_t> &fields, const bool shallow) {
+    return AddImpl(label, src, fields, shallow);
   }
 
   template <class SRC_t, typename ID_t = std::string>
   std::shared_ptr<T> &AddShallow(const std::string &label,
                                  const std::shared_ptr<SRC_t> &src,
                                  const std::vector<ID_t> &fields = {}) {
-    return Add(label, src, fields, true);
+    return AddImpl(label, src, fields, true);
+  }
+
+  template <class SRC_t, typename ID_t = Uid_t>
+  std::shared_ptr<T> &AddFromSet(const std::string &label,
+                                 const std::shared_ptr<SRC_t> &src,
+                                 const std::set<ID_t> &fields) {
+    return AddImpl(label, src, fields, false);
+  }
+
+  template <class SRC_t, typename ID_t = Uid_t>
+  std::shared_ptr<T> &AddShallowFromSet(const std::string &label,
+                                        const std::shared_ptr<SRC_t> &src,
+                                        const std::set<ID_t> &fields) {
+    return AddImpl(label, src, fields, true);
   }
 
   auto &Stages() { return containers_; }
@@ -112,6 +116,15 @@ class DataCollection {
   std::shared_ptr<T> &Get(const std::string &name = "base");
   const std::shared_ptr<T> &Get(const std::string &name = "base") const;
 
+  // The field list (as a canonical variable-uid set) that the named container was created
+  // from. Every container sharing a base name is created from the same list (see the
+  // warning in Add). If the name has never been added, returns a static empty set.
+  const std::set<Uid_t> &GetCreationFields(const std::string &name) const {
+    static const std::set<Uid_t> empty;
+    const auto nit = name_creation_fields_.find(name);
+    return nit == name_creation_fields_.end() ? empty : nit->second;
+  }
+
   void Set(const std::string &name, std::shared_ptr<T> &d) { containers_[name] = d; }
 
   // Legacy methods that are specific to MeshData
@@ -122,6 +135,54 @@ class DataCollection {
   void clear() { containers_.clear(); }
 
  private:
+  template <class SRC_t, class Fields_t>
+  std::shared_ptr<T> &AddImpl(const std::string &name, const std::shared_ptr<SRC_t> &src,
+                              const Fields_t &fields, const bool shallow) {
+    auto key = GetKey(name, src);
+    auto it = containers_.find(key);
+    if (it != containers_.end()) {
+      // Existing container. An explicit field list must match what the container was
+      // actually created from (checked against the container itself, which also catches
+      // containers built by hand or through a different DataCollection); an empty list
+      // means "all fields"/"don't check" and always passes.
+      if (fields.size() && !(it->second)->CreatedFrom(fields))
+        PARTHENON_THROW(key + " already exists in collection but fields do not match.");
+      return it->second;
+    }
+
+    using ID_t = typename Fields_t::value_type;
+    auto to_uid = [](const ID_t &f) -> Uid_t {
+      if constexpr (std::is_same_v<ID_t, std::string>)
+        return Variable<Real>::GetUniqueID(f);
+      else
+        return f;
+    };
+
+    // Track the field list (as a canonical uid set) each container name is created from,
+    // so the DataCollection is the single source of truth for it (see GetCreationFields).
+    // Containers sharing a base name but built from different sources get distinct keys,
+    // so the per-key CreatedFrom check above cannot compare them; this does. All instances
+    // of a name must be created from the same list -- fail if not.
+    std::set<Uid_t> created;
+    for (const auto &f : fields)
+      created.insert(to_uid(f));
+    auto nit = name_creation_fields_.find(name);
+    if (nit == name_creation_fields_.end()) {
+      name_creation_fields_[name] = created;
+    } else if (nit->second != created) {
+      PARTHENON_THROW(
+          "Container \"" + name +
+          "\" is being created from different field lists on different sources. All "
+          "instances sharing a name must be created from the same field list.");
+    }
+
+    std::vector<Uid_t> uids(created.begin(), created.end());
+    auto c = std::make_shared<T>(name);
+    c->Initialize(src, uids, shallow);
+    containers_[key] = c;
+    return containers_[key];
+  }
+
   std::string GetKey(const std::string &stage_label,
                      const std::shared_ptr<BlockListPartition> &in) const;
   std::string GetKey(const std::string &stage_label,
@@ -133,6 +194,7 @@ class DataCollection {
 
   Mesh *pmy_mesh_;
   std::map<std::string, std::shared_ptr<T>> containers_;
+  std::map<std::string, std::set<Uid_t>> name_creation_fields_;
 };
 
 } // namespace parthenon

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -161,8 +161,8 @@ class DataCollection {
     // Track the field list (as a canonical uid set) each container name is created from,
     // so the DataCollection is the single source of truth for it (see GetCreationFields).
     // Containers sharing a base name but built from different sources get distinct keys,
-    // so the per-key CreatedFrom check above cannot compare them; this does. All instances
-    // of a name must be created from the same list -- fail if not.
+    // so the per-key CreatedFrom check above cannot compare them; this does. All
+    // instances of a name must be created from the same list -- fail if not.
     std::set<Uid_t> created;
     for (const auto &f : fields)
       created.insert(to_uid(f));

--- a/src/interface/data_collection.hpp
+++ b/src/interface/data_collection.hpp
@@ -158,11 +158,11 @@ class DataCollection {
         return f;
     };
 
-    // Track the field list (as a canonical uid set) each container base name is created from,
-    // so every container with a given base name contains the same set of fields.
-    // Containers sharing a base name but built from different sources get distinct internal names,
-    // so the check above cannot compare them; this does. All
-    // instances of a name must be created from the same list.
+    // Track the field list (as a canonical uid set) each container base name is created
+    // from, so every container with a given base name contains the same set of fields.
+    // Containers sharing a base name but built from different sources get distinct
+    // internal names, so the check above cannot compare them; this does. All instances of
+    // a name must be created from the same list.
     std::set<Uid_t> created;
     for (const auto &f : fields)
       created.insert(to_uid(f));

--- a/src/interface/meshblock_data.hpp
+++ b/src/interface/meshblock_data.hpp
@@ -559,6 +559,11 @@ class MeshBlockData {
            std::all_of(vars.begin(), vars.end(),
                        [this](const auto &v) { return this->varUidIn_.count(v); });
   }
+  bool CreatedFrom(const std::set<Uid_t> &vars) {
+    return (vars.size() == varUidIn_.size()) &&
+           std::all_of(vars.begin(), vars.end(),
+                       [this](const auto &v) { return this->varUidIn_.count(v); });
+  }
   bool CreatedFrom(const std::vector<std::string> &vars) {
     return (vars.size() == varUidIn_.size()) &&
            std::all_of(vars.begin(), vars.end(), [this](const auto &v) {

--- a/src/interface/state_descriptor.hpp
+++ b/src/interface/state_descriptor.hpp
@@ -34,6 +34,7 @@
 #include "interface/params.hpp"
 #include "interface/sparse_pool.hpp"
 #include "interface/var_id.hpp"
+#include "interface/variable.hpp"
 #include "outputs/output_parameters.hpp"
 #include "pack/scratch_variables.hpp"
 #include "parameter_input.hpp"
@@ -313,8 +314,14 @@ class StateDescriptor {
   const auto &GetFieldVarID(const std::string &label) const {
     return labelToVidMap_.at(label);
   }
+  const auto &GetFieldVarID(const Uid_t &uid) const {
+    return labelToVidMap_.at(Variable<Real>::GetLabel(uid));
+  }
   const auto &GetFieldMetadata(const std::string &label) const {
     return metadataMap_.at(labelToVidMap_.at(label));
+  }
+  const auto &GetFieldMetadata(const Uid_t &uid) const {
+    return metadataMap_.at(labelToVidMap_.at(Variable<Real>::GetLabel(uid)));
   }
   const auto &GetFieldMetadata(const VarID &id) const { return metadataMap_.at(id); }
   const auto &AllFields() const noexcept { return metadataMap_; }

--- a/src/solvers/bicgstab_solver.hpp
+++ b/src/solvers/bicgstab_solver.hpp
@@ -146,9 +146,9 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
       return preconditioner.AddSetupTasks(tl, dependence, partition, pmesh);
     } else if (params_.precondition_type == Preconditioner::Diagonal) {
       auto partitions = pmesh->GetDefaultBlockPartitions();
-      auto &md = pmesh->mesh_data.AddFromSet(
-          container_base, partitions[partition],
-          pmesh->mesh_data.GetCreationFields(container_base));
+      auto &md =
+          pmesh->mesh_data.AddFromSet(container_base, partitions[partition],
+                                      pmesh->mesh_data.GetCreationFields(container_base));
       auto &md_diag = pmesh->mesh_data.Add(container_diag, md, sol_fields);
       return tl.AddTask(dependence, &equations_t::SetDiagonal, &eqs_, md, md_diag);
     } else {
@@ -163,9 +163,9 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
     auto partitions = pmesh->GetDefaultBlockPartitions();
     // Should contain all fields necessary for applying the matrix to a give state vector,
     // e.g. diffusion coefficients and diagonal, these will not be modified by the solvers
-    auto &md_base = pmesh->mesh_data.AddFromSet(
-        container_base, partitions[partition],
-        pmesh->mesh_data.GetCreationFields(container_base));
+    auto &md_base =
+        pmesh->mesh_data.AddFromSet(container_base, partitions[partition],
+                                    pmesh->mesh_data.GetCreationFields(container_base));
     // Container in which the solution is stored and with which the downstream user can
     // interact. This container only requires the fields in sol_fields
     auto &md_u = pmesh->mesh_data.Add(container_u, partitions[partition], sol_fields);

--- a/src/solvers/bicgstab_solver.hpp
+++ b/src/solvers/bicgstab_solver.hpp
@@ -146,7 +146,9 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
       return preconditioner.AddSetupTasks(tl, dependence, partition, pmesh);
     } else if (params_.precondition_type == Preconditioner::Diagonal) {
       auto partitions = pmesh->GetDefaultBlockPartitions();
-      auto &md = pmesh->mesh_data.Add(container_base, partitions[partition]);
+      auto &md = pmesh->mesh_data.AddFromSet(
+          container_base, partitions[partition],
+          pmesh->mesh_data.GetCreationFields(container_base));
       auto &md_diag = pmesh->mesh_data.Add(container_diag, md, sol_fields);
       return tl.AddTask(dependence, &equations_t::SetDiagonal, &eqs_, md, md_diag);
     } else {
@@ -161,7 +163,9 @@ class BiCGSTABSolver : public SolverBase, BiCGSTABSolverCounter {
     auto partitions = pmesh->GetDefaultBlockPartitions();
     // Should contain all fields necessary for applying the matrix to a give state vector,
     // e.g. diffusion coefficients and diagonal, these will not be modified by the solvers
-    auto &md_base = pmesh->mesh_data.Add(container_base, partitions[partition]);
+    auto &md_base = pmesh->mesh_data.AddFromSet(
+        container_base, partitions[partition],
+        pmesh->mesh_data.GetCreationFields(container_base));
     // Container in which the solution is stored and with which the downstream user can
     // interact. This container only requires the fields in sol_fields
     auto &md_u = pmesh->mesh_data.Add(container_u, partitions[partition], sol_fields);

--- a/src/solvers/mg_solver.hpp
+++ b/src/solvers/mg_solver.hpp
@@ -182,7 +182,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
       PARTHENON_FAIL("Does not work with non-default partitioning.");
     auto partition = partitions[default_partition_idx];
 
-    auto &md = pmesh->mesh_data.Add(container_base, partition);
+    auto &md = pmesh->mesh_data.AddFromSet(
+        container_base, partition, pmesh->mesh_data.GetCreationFields(container_base));
     auto &md_u = pmesh->mesh_data.Add(container_u, partition, sol_fields);
     auto &md_res_err = pmesh->mesh_data.Add(container_res_err, partition, sol_fields);
     auto &md_rhs = pmesh->mesh_data.Add(container_rhs, partition, sol_fields);
@@ -340,7 +341,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
                             bool input_is_zero) {
     using namespace utils;
 
-    auto &md_base = pmesh->mesh_data.Add(container_base, partition);
+    auto &md_base = pmesh->mesh_data.AddFromSet(
+        container_base, partition, pmesh->mesh_data.GetCreationFields(container_base));
     auto &md_rhs = pmesh->mesh_data.Add(container_rhs, partition, sol_fields);
     auto &md_diag = pmesh->mesh_data.Add(container_diag, partition, sol_fields);
     auto &md_ax = pmesh->mesh_data.Add(container_temp, partition, sol_fields);
@@ -418,7 +420,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
     const int level = partition->grid.multigrid_level();
     const auto [min_level, max_level] = GetMinMaxLevel(pmesh);
 
-    auto &md = pmesh->mesh_data.Add(container_base, partition);
+    auto &md = pmesh->mesh_data.AddFromSet(
+        container_base, partition, pmesh->mesh_data.GetCreationFields(container_base));
     auto &md_diag = pmesh->mesh_data.Add(container_diag, partition, sol_fields);
 
     auto task_out = dependence;
@@ -457,7 +460,8 @@ class MGSolver : public SolverBase, MGSolverCounter {
 
     bool do_FAS = params_.do_FAS;
 
-    auto &md = pmesh->mesh_data.Add(container_base, partition);
+    auto &md = pmesh->mesh_data.AddFromSet(
+        container_base, partition, pmesh->mesh_data.GetCreationFields(container_base));
     auto &md_u = pmesh->mesh_data.Add(container_u, partition, sol_fields);
     auto &md_rhs = pmesh->mesh_data.Add(container_rhs, partition, sol_fields);
     auto &md_res_err = pmesh->mesh_data.Add(container_res_err, partition, sol_fields);


### PR DESCRIPTION
## PR Summary

[Made with assistance from generative AI]

This PR updates `DataCollection` to check that every container with a given base name is created from the same field list. Previously, code like
```c++
pmesh->mesh_data.Add("my_container", partition1, {fielda, fieldb, fieldc});
pmesh->mesh_data.Add("my_container", partition2, {fielda, fieldc});
```
would run fine if there was no overlap between `partition1` and `partition2`, now it will throw an error.

I think that we should be enforcing this because boundary communication on meshdata that is built similarly to `my_container` will cause deadlocks in the task list. We ran into this issue in multigrid, where there `MeshData` with the same base name are built by both downstream code and internal to the solver on different partitions. 

To make it easier to build containers in multiple places without keeping the field lists synchronized by hand, we also add the ability to query the `DataCollection` for the list of fields used to create a partition on a given base name, allowing
```c++
auto field_list = pmesh->mesh_data.GetCreationFields("my_container"); 
auto md = pmesh->mesh_data.Add("my_container", partition, field_list);
```
`GetCreationFields` returns an empty vector if no container has been previously created with the requested base name, so the example above would include all fields. 

It is still valid to do something like
```c++
auto md1 = pmesh->mesh_data.Add("my_container", partition, {fielda, fieldb});
auto md2 = pmesh->mesh_data.Add("my_container", partition);
```
where the second call without a field list will still return the pre-existing container with the more limited field set. 


## PR Checklist

<!-- Note that some of these check boxes may not apply to all pull requests -->

- [ ] Code passes cpplint
- [ ] New features are documented.
- [ ] Adds a test for any bugs fixed. Adds tests for new features.
- [ ] Code is formatted
- [ ] Changes are summarized in CHANGELOG.md
- [ ] Change is breaking (API, behavior, ...)
  - [ ] Change is *additionally* added to CHANGELOG.md in the breaking section
  - [ ] PR is marked as breaking
  - [ ] Short summary API changes at the top of the PR (plus optionally with an automated update/fix script)
- [ ] CI has been triggered on [Darwin](https://re-git.lanl.gov/eap-oss/parthenon/-/pipelines) for performance regression tests.
- [ ] Docs build
- [ ] Any contribution that was created or modified with the assistance of generative AI is disclosed here and in code following the [guidelines](https://github.com/parthenon-hpc-lab/parthenon/blob/develop/CONTRIBUTING.md#use-of-agentic-coding)
- [ ] (@lanl.gov employees) Update copyright on changed files
